### PR TITLE
Update v6_upgrade.md to reference new gem name

### DIFF
--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -39,7 +39,7 @@ This means you have to configure integration with frameworks yourself, but webpa
 
    ```ruby
    # Gemfile
-   gem 'webpacker', '6.0.0.rc.7'
+   gem 'shakapacker', '6.0.0.rc.7'
    ```
 
    ```bash

--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -39,7 +39,7 @@ This means you have to configure integration with frameworks yourself, but webpa
 
    ```ruby
    # Gemfile
-   gem 'shakapacker', '6.0.0.rc.7'
+   gem 'shakapacker', '6.0.0.rc.7', require: 'webpacker'
    ```
 
    ```bash


### PR DESCRIPTION
The gem has been renamed so we should reference new one in the upgrade guide.

For now, it needs also `require: 'webpacker'` in the gemfile to serve as a drop in replacement. I guess something like that might need to be documented if `webpacker` remains internally used naming