### PR TITLE
Raise on multiple invocations of javascript_pack_tag and stylesheet_pack_tag helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shakapacker (6.0.0.rc.6)
+    shakapacker (6.0.0.rc.13)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -96,6 +96,9 @@ module Webpacker::Helper
   #   <%= javascript_pack_tag 'calendar' %>
   #   <%= javascript_pack_tag 'map' %>
   def javascript_pack_tag(*names, defer: true, **options)
+    raise "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page." if @javascript_pack_tag_loaded
+    @javascript_pack_tag_loaded = true
+
     javascript_include_tag(*sources_from_manifest_entrypoints(names, type: :javascript), **options.tap { |o| o[:defer] = defer })
   end
 
@@ -141,6 +144,8 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar' %>
   #   <%= stylesheet_pack_tag 'map' %>
   def stylesheet_pack_tag(*names, **options)
+    raise "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page." if @stylesheet_pack_tag_loaded
+    @stylesheet_pack_tag_loaded = true
     return "" if Webpacker.inlining_css?
 
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -96,7 +96,11 @@ module Webpacker::Helper
   #   <%= javascript_pack_tag 'calendar' %>
   #   <%= javascript_pack_tag 'map' %>
   def javascript_pack_tag(*names, defer: true, **options)
-    raise "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page." if @javascript_pack_tag_loaded
+    if @javascript_pack_tag_loaded
+      raise "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " \
+      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
+    end
+
     @javascript_pack_tag_loaded = true
 
     javascript_include_tag(*sources_from_manifest_entrypoints(names, type: :javascript), **options.tap { |o| o[:defer] = defer })
@@ -144,8 +148,13 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar' %>
   #   <%= stylesheet_pack_tag 'map' %>
   def stylesheet_pack_tag(*names, **options)
-    raise "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page." if @stylesheet_pack_tag_loaded
+    if @stylesheet_pack_tag_loaded
+      raise "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page. " \
+      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
+    end
+
     @stylesheet_pack_tag_loaded = true
+
     return "" if Webpacker.inlining_css?
 
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -12,6 +12,9 @@ class HelperTest < ActionView::TestCase
         "https://example.com"
       end
     end.new
+
+    @javascript_pack_tag_loaded = nil
+    @stylesheet_pack_tag_loaded = nil
   end
 
   def test_asset_pack_path
@@ -129,6 +132,17 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag(:application)
   end
 
+  def test_javascript_pack_tag_multiple_invocations
+    error = assert_raises do
+      javascript_pack_tag(:application)
+      javascript_pack_tag(:bootstrap)
+    end
+
+    assert_equal \
+      "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page.",
+      error.message
+  end
+
   def application_stylesheet_chunks
     %w[/packs/1-c20632e7baf2c81200d3.chunk.css /packs/application-k344a6d59eef8632c9d1.chunk.css]
   end
@@ -155,5 +169,16 @@ class HelperTest < ActionView::TestCase
     assert_equal \
       (application_stylesheet_chunks).map { |chunk| stylesheet_link_tag(chunk, media: "all") }.join("\n"),
       stylesheet_pack_tag("application", media: "all")
+  end
+
+  def test_stylesheet_pack_tag_multiple_invocations
+    error = assert_raises do
+      stylesheet_pack_tag(:application)
+      stylesheet_pack_tag(:hello_stimulus)
+    end
+
+    assert_equal \
+      "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page.",
+      error.message
   end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -139,7 +139,8 @@ class HelperTest < ActionView::TestCase
     end
 
     assert_equal \
-      "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page.",
+      "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " +
+        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide",
       error.message
   end
 
@@ -178,7 +179,8 @@ class HelperTest < ActionView::TestCase
     end
 
     assert_equal \
-      "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page.",
+      "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page. " +
+        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide",
       error.message
   end
 end


### PR DESCRIPTION
Addresses #17

Adapted from [rails#3083](https://github.com/rails/webpacker/pull/3083) by @guillaumebriday

Multiple calls to `javascript_pack_tag` and `stylesheet_pack_tag` will now raise an error as they can result with duplicate files being loaded

