### PR TITLE
Remove pnp-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Note, in v6, most JS packages are peer dependencies. Thus, the installer will ad
 
 ```bash
 yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader \
-  compression-webpack-plugin pnp-webpack-plugin terser-webpack-plugin \
+  compression-webpack-plugin terser-webpack-plugin \
   webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server
 ```
 

--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -14,7 +14,7 @@ This means you have to configure integration with frameworks yourself, but webpa
 See example migration, [PR 27](https://github.com/shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh/pull/27).
           
 ### Update
-1. Peer dependencies. Run `yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader compression-webpack-plugin pnp-webpack-plugin terser-webpack-plugin webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server`
+1. Peer dependencies. Run `yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader compression-webpack-plugin terser-webpack-plugin webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server`
 2. Update your webpack config for a single config file, `config/webpack/webpack.config.js`. 
 3. Update `babel.config.js` if you need JSX support. 
 
@@ -66,7 +66,7 @@ See example migration, [PR 27](https://github.com/shakacode/react_on_rails_tutor
 
   Note, the webpacker:install will install the peer dependencies:
   ```bash
-  yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader compression-webpack-plugin pnp-webpack-plugin terser-webpack-plugin webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server
+  yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader compression-webpack-plugin terser-webpack-plugin webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server
   ```
 
 1. There is now a single default configuration file of `config/webpack/webpack.config.js`. Previously, the config file was set

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.26.0",
     "jest": "^27.2.1",
-    "pnp-webpack-plugin": "^1.7.0",
     "webpack": "^5.53.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-merge": "^5.8.0"

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -3,7 +3,6 @@
 
 const { basename, dirname, join, relative, resolve } = require('path')
 const extname = require('path-complete-extname')
-const PnpWebpackPlugin = require('pnp-webpack-plugin')
 const { sync: globSync } = require('glob')
 const WebpackAssetsManifest = require('webpack-assets-manifest')
 const webpack = require('webpack')
@@ -92,15 +91,13 @@ module.exports = {
   entry: getEntryObject(),
   resolve: {
     extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.coffee'],
-    modules: getModulePaths(),
-    plugins: [PnpWebpackPlugin]
+    modules: getModulePaths()
   },
 
   plugins: getPlugins(),
 
   resolveLoader: {
-    modules: ['node_modules'],
-    plugins: [PnpWebpackPlugin.moduleLoader(module)]
+    modules: ['node_modules']
   },
 
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,13 +3215,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pnp-webpack-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz#65741384f6d8056f36e2255a8d67ffc20866f5c9"
-  integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
-  dependencies:
-    ts-pnp "^1.1.6"
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -3729,11 +3722,6 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
-
-ts-pnp@^1.1.6:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
-  integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tsconfig-paths@^3.12.0:
   version "3.12.0"


### PR DESCRIPTION
Addresses #16 

Webpack 5 [supports Yarn PnP out of the box](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#resolving) so the `PnpWebpackPlugin` should be no longer needed and included by default.


