### PR TITLE
Install PostCSS with CSS to avoid warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ module.exports = merge(webpackConfig, {
 To enable CSS support in your application, add following packages:
 
 ```bash
-yarn add css-loader style-loader mini-css-extract-plugin css-minimizer-webpack-plugin
+yarn add css-loader style-loader mini-css-extract-plugin css-minimizer-webpack-plugin postcss
 ```
 
 Optionally, add the `CSS` extension to webpack config for easy resolution.
@@ -479,7 +479,7 @@ then add the relevant pre-processors:
 #### Postcss
 
 ```bash
-yarn add postcss postcss-loader
+yarn add postcss-loader
 ```
 
 Optionally add these two plugins if they are required in your `postcss.config.js`:


### PR DESCRIPTION
`css-loader` depends on `postcss` and `postcss-loader` has a peer
dependency on `postcss`.

When following Webpacker instructions to install PostCSS loader,
the console shows this warning:

```
warning " > postcss-loader@4.1.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
```

On the other hand, installing `postcss` and `postcss-loader` together,
will result in a different warning:

```
warning Pattern ["postcss@^8.2.1"] is trying to unpack in the same destination "node_modules/postcss" as pattern ["postcss@^8.1.4"]. This could result in non-deterministic behavior, skipping.
```

This change explicitly installs `postcss` with CSS packages to avoid
both warnings