### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* For versions prior to v6, see the [5.x stable branch of rails/webpacker](https://github.com/rails/webpacker/tree/5-x-stable). 
+* For versions prior to v6, see the [5.x stable branch of rails/webpacker](https://github.com/rails/webpacker/tree/5-x-stable).
 * Please see [UPGRADE GUIDE](./docs/v6_upgrade.md).
 
 ## Versions
@@ -8,19 +8,19 @@ Changes since last non-beta release.
 *Please add entries here for your pull requests that are not yet released.*
 ## [v6.0.1] - January 24, 2022
 ### Improved
-- PR #21 removed pnp-webpack-plugin as a dev dependency but did not remove it from the peer dependency list. [PR 30](https://github.com/shakacode/shakapacker/pull/19) by [t27duck](https://github.com/t27duck].
+- PR #21 removed pnp-webpack-plugin as a dev dependency but did not remove it from the peer dependency list. [PR 30](https://github.com/shakacode/shakapacker/pull/30) by [t27duck](https://github.com/t27duck).
 
 ## [v6.0.0 changes from v6.0.0.rc.6] - January 22, 2022
 
 ### Improved
-- Raise on multiple invocations of javascript_pack_tag and stylesheet_pack_tag helpers. [PR 19](https://github.com/shakacode/shakapacker/pull/19) by [tomdracz](https://github.com/tomdracz].
-- Remove automatic addition of node_modules into rails asset load path. [PR 20](https://github.com/shakacode/shakapacker/pull/20) by [tomdracz](https://github.com/tomdracz].
-- Remove pnp-webpack-plugin. [PR 21](https://github.com/shakacode/shakapacker/pull/21) by [tomdracz](https://github.com/tomdracz].
+- Raise on multiple invocations of javascript_pack_tag and stylesheet_pack_tag helpers. [PR 19](https://github.com/shakacode/shakapacker/pull/19) by [tomdracz](https://github.com/tomdracz).
+- Remove automatic addition of node_modules into rails asset load path. [PR 20](https://github.com/shakacode/shakapacker/pull/20) by [tomdracz](https://github.com/tomdracz).
+- Remove pnp-webpack-plugin. [PR 21](https://github.com/shakacode/shakapacker/pull/21) by [tomdracz](https://github.com/tomdracz).
 
 
 ### Merged from rails/webpacker
 
-- Make watched_files_digest thread safe. [rails/webpacker #3233](https://github.com/rails/webpacker/pull/3233) 
+- Make watched_files_digest thread safe. [rails/webpacker #3233](https://github.com/rails/webpacker/pull/3233)
 - Use single webpack config webpack.config.js. [rails/webpacker #3240](https://github.com/rails/webpacker/pull/3240)
 - Switch to peer dependencies. [rails/webpacker #3234](https://github.com/rails/webpacker/pull/3234)
 


### PR DESCRIPTION
Hi,

was checking the changelog for the new 6.0.1 release and I've found some minor issues

PS: Out of curiosity, about the trailing whitespaces, is it because they are being edited on GitHub? 

---

- Remove trailing whitespace
- Fix PR 30 link
- Fix link to contributors

[ci skip]