### PR TITLE
Retain subdirectory structure of static assets when compiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changes since last non-beta release.
 ### Added
 - Experimental support for SWC loader. [PR 29](https://github.com/shakacode/shakapacker/pull/29) by [tomdracz](https://github.com/tomdracz).
 
+### Fixed
+- Static asset subdirectories are retained after compilation, matching Webpacker v5 behaviour. [PR 47](https://github.com/shakacode/shakapacker/pull/47) by [tomdracz](https://github.com/tomdracz).
+
 ## [v6.0.2] - January 25, 2022
 ### Improved
 - Fix incorrect command name in warning. [PR 33](https://github.com/shakacode/shakapacker/pull/33) by [tricknotes](https://github.com/tricknotes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * For versions prior to v6, see the [5.x stable branch of rails/webpacker](https://github.com/rails/webpacker/tree/5-x-stable).
-* Please see [UPGRADE GUIDE](./docs/v6_upgrade.md).
+* Please see [v6 Upgrade Guide](./docs/v6_upgrade.md) to go from version prior to v6.
 
 ## Versions
 ## [Unreleased]
@@ -7,11 +7,12 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+## [v6.1.0] - February 4, 2020
 ### Added
-- Experimental support for SWC loader. [PR 29](https://github.com/shakacode/shakapacker/pull/29) by [tomdracz](https://github.com/tomdracz).
+- Support for SWC loader. [PR 29](https://github.com/shakacode/shakapacker/pull/29) by [tomdracz](https://github.com/tomdracz).
 
 ### Fixed
-- Static asset subdirectories are retained after compilation, matching Webpacker v5 behaviour. [PR 47](https://github.com/shakacode/shakapacker/pull/47) by [tomdracz](https://github.com/tomdracz).
+- Static asset subdirectories are retained after compilation, matching Webpacker v5 behaviour. [PR 47](https://github.com/shakacode/shakapacker/pull/47) by [tomdracz](https://github.com/tomdracz). Fixes issues [rails/webpacker#2956](https://github.com/rails/webpacker/issues/2956) which broke in [rails/webpacker#2802](https://github.com/rails/webpacker/pull/2802).
 
 ## [v6.0.2] - January 25, 2022
 ### Improved
@@ -65,8 +66,11 @@ Changes since last non-beta release.
 - Splitchunks enabled by default
 - CSS extraction enabled by default, except when devServer is configured and running
 
+## v5.4.3 and prior changes from rails/webpacker
+See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md) 
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v6.0.2...master
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v6.1.0...master
+[v6.1.0]: https://github.com/shakacode/shakapacker/compare/v6.0.2...v6.1.0
 [v6.0.2]: https://github.com/shakacode/shakapacker/compare/v6.0.1...v6.0.2
 [v6.0.1]: https://github.com/shakacode/shakapacker/compare/v6.0.0...v6.0.1
 [v6.0.0 changes from v6.0.0.rc.6]: https://github.com/shakacode/shakapacker/compare/aba79635e6ff6562ec04d3c446d57ef19a5fef7d...v6.0.0

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,3 +1,6 @@
+const { dirname, join } = require('path')
+const { source_path: sourcePath } = require('../config')
+
 module.exports = {
   test: [
     /\.bmp$/,
@@ -18,6 +21,14 @@ module.exports = {
   exclude: [/\.(js|mjs|jsx|ts|tsx)$/],
   type: 'asset/resource',
   generator: {
-    filename: 'static/[name]-[hash][ext][query]'
+    filename: (pathData) => {
+      const folders = dirname(pathData.filename)
+        .replace(`${sourcePath}/`, '')
+        .split('/')
+        .slice(1)
+
+      const foldersWithStatic = join('static', ...folders)
+      return `${foldersWithStatic}/[name]-[hash][ext][query]`
+    }
   }
 }


### PR DESCRIPTION
Closes https://github.com/shakacode/shakapacker/issues/44

During Webpacker v6 development, a change was made to move away from file-loader to webpack built-in asset modules. Along the way we've lost an ability to retain the folder structure though - all static assets are output in the `static` folder regardless of their original nesting.

This creates two issues:
- you can no longer reference the asset with the folder name (i.e. `<%= image_pack_tag "homepage/logo.png" %>`  will not work as `logo.png` will be lifted from its original folder into `static`
- clashing file name will result in unpredictable results - if you have same filename `logo.png` in multiple places, you cannot reliably reference it with a pack helper as it might refer to any of those in a manifest.

Rather than trying to add any workaround by modifying the manifest generation as discussed in https://github.com/rails/webpacker/issues/2956, this PR aims to change the generated static file output to match the Webpacker v5 behaviour (minus the fact that the output path is now `static` in v6 vs `media/images` in v5)

This WILL be a breaking change if you've already updated to v6 (or any pre-release v6 webpacker versions) and changed your view helpers to remove folder from the requested filename. Folders are back so this will need to be updated again. It should remain unchanged if the static assets were not nested in any folders before.