### PR TITLE
Ensure consistent versions of package and gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes since last non-beta release.
 
 ### Added
 - Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan)
-- Initialization check to ensure shakapacker gem and NPM package version are consistent. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
+- Initialization check to ensure shakapacker gem and NPM package version are consistent. Opt-in behaviour enabled by setting `ensure_consistent_versioning` configuration variable. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.1.1] - February 6, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes since last non-beta release.
 
 ### Added
 - Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan)
+- Initialization check to ensure shakapacker gem and NPM package version are consistent. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.1.1] - February 6, 2022
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,10 @@ rails new myapp --skip-javascript
 
 _Note, Rails 6 installs the older v5 version of webpacker unless you specify `--skip-javascript`._
 
-Update your `Gemfile`:
+Add `shakapacker` gem to your `Gemfile`:
 
-```ruby
-# Gemfile
-gem 'shakapacker', '~> 6.0'
+```bash
+bundle add shakapacker --strict
 ```
 
 Then running the following to install Webpacker:

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -18,6 +18,9 @@ default: &default
   # Select loader to use, available options are 'babel' (default), 'swc' or 'esbuild'
   webpack_loader: 'babel'
 
+  # Set to true to enable check for matching versions of shakapacker gem and NPM package - will raise an error if there is a mismatch or wildcard versioning is used
+  ensure_consistent_versioning: false
+
 development:
   <<: *default
   compile: true

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -58,10 +58,10 @@ results = []
 Dir.chdir(Rails.root) do
   if Webpacker::VERSION.match?(/^[0-9]+\.[0-9]+\.[0-9]+$/)
     say "Installing shakapacker@#{Webpacker::VERSION}"
-    results << run("yarn add shakapacker@#{Webpacker::VERSION}")
+    results << run("yarn add shakapacker@#{Webpacker::VERSION} --exact")
   else
     say "Installing shakapacker@next"
-    results << run("yarn add shakapacker@next")
+    results << run("yarn add shakapacker@next --exact")
   end
 
   package_json = File.read("#{__dir__}/../../package.json")

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -23,6 +23,10 @@ class Webpacker::Configuration
     fetch(:compile)
   end
 
+  def ensure_consistent_versioning?
+    fetch(:ensure_consistent_versioning)
+  end
+
   def source_path
     root_path.join(fetch(:source_path))
   end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -9,7 +9,7 @@ class Webpacker::Engine < ::Rails::Engine
   config.webpacker = ActiveSupport::OrderedOptions.new
 
   initializer "webpacker.version_checker" do
-    if File.exist?(Webpacker::VersionChecker::NodePackageVersion.package_json_path) && Webpacker.config.ensure_consistent_versioning?
+    if File.exist?(Webpacker::VersionChecker::NodePackageVersion.package_json_path)
       Webpacker::VersionChecker.build.raise_if_gem_and_node_package_versions_differ
     end
   end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -9,7 +9,7 @@ class Webpacker::Engine < ::Rails::Engine
   config.webpacker = ActiveSupport::OrderedOptions.new
 
   initializer "webpacker.version_checker" do
-    if File.exist?(Webpacker::VersionChecker::NodePackageVersion.package_json_path)
+    if File.exist?(Webpacker::VersionChecker::NodePackageVersion.package_json_path) && Webpacker.config.ensure_consistent_versioning?
       Webpacker::VersionChecker.build.raise_if_gem_and_node_package_versions_differ
     end
   end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -2,10 +2,17 @@ require "rails/railtie"
 
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
+require "webpacker/version_checker"
 
 class Webpacker::Engine < ::Rails::Engine
   # Allows Webpacker config values to be set via Rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
+
+  initializer "webpacker.version_checker" do
+    if File.exist?(Webpacker::VersionChecker::NodePackageVersion.package_json_path)
+      Webpacker::VersionChecker.build.raise_if_gem_and_node_package_versions_differ
+    end
+  end
 
   initializer "webpacker.proxy" do |app|
     if (Webpacker.config.dev_server.present? rescue nil)

--- a/lib/webpacker/version_checker.rb
+++ b/lib/webpacker/version_checker.rb
@@ -16,11 +16,8 @@ module Webpacker
     end
 
     def raise_if_gem_and_node_package_versions_differ
-      # Skip check if package is listed from relative path, git repo or github URL
+      # Skip check if package is not in package.json or listed from relative path, git repo or github URL
       return if node_package_version.skip_processing?
-
-      # If no package found, assume user doesn't use it
-      return unless node_package_version.package_specified?
 
       node_major_minor_patch = node_package_version.major_minor_patch
       gem_major_minor_patch = gem_major_minor_patch_version
@@ -86,16 +83,12 @@ module Webpacker
           parsed_package_contents.dig("dependencies", "shakapacker").to_s
         end
 
-        def package_specified?
-          raw.present?
-        end
-
         def semver_wildcard?
           raw.match(/[~^]/).present?
         end
 
         def skip_processing?
-          relative_path? || git_url? || github_url?
+          !package_specified? || relative_path? || git_url? || github_url?
         end
 
         def major_minor_patch
@@ -110,6 +103,10 @@ module Webpacker
         end
 
         private
+
+          def package_specified?
+            raw.present?
+          end
 
           def relative_path?
             raw.match(%r{(\.\.|\Afile:///)}).present?

--- a/lib/webpacker/version_checker.rb
+++ b/lib/webpacker/version_checker.rb
@@ -25,9 +25,33 @@ module Webpacker
                        node_major_minor_patch[1] == gem_major_minor_patch[1] &&
                        node_major_minor_patch[2] == gem_major_minor_patch[2]
 
+      uses_wildcard = node_package_version.semver_wildcard?
+
+      if !Webpacker.config.ensure_consistent_versioning? && (uses_wildcard || !versions_match)
+        check_failed = if uses_wildcard
+          "Semver wildcard detected"
+        else
+          "Version mismatch detected"
+        end
+
+        warn <<-MSG.strip_heredoc
+          Webpacker::VersionChecker - #{check_failed}
+
+          You are currently not checking for consistent versions of shakapacker gem and npm package. A version mismatch or usage of semantic versioning wildcard (~ or ^) has been detected.
+
+          Version mismatch can lead to incorrect behavior and bugs. You should ensure that both the gem and npm package dependencies are locked to the same version.
+
+          You can enable the version check by setting `ensure_consistent_versioning: true` in your `webpacker.yml` file.
+
+          Checking for gem and npm package versions mismatch or wildcard will be enabled by default in the next major version of shakapacker.
+        MSG
+
+        return
+      end
+
       raise_differing_versions_warning unless versions_match
 
-      raise_node_semver_version_warning if node_package_version.semver_wildcard?
+      raise_node_semver_version_warning if uses_wildcard
     end
 
     private

--- a/lib/webpacker/version_checker.rb
+++ b/lib/webpacker/version_checker.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Webpacker
+  class VersionChecker
+    attr_reader :node_package_version
+
+    MAJOR_MINOR_PATCH_VERSION_REGEX = /(\d+)\.(\d+)\.(\d+)/.freeze
+
+    def self.build
+      new(NodePackageVersion.build)
+    end
+
+    def initialize(node_package_version)
+      @node_package_version = node_package_version
+    end
+
+    def raise_if_gem_and_node_package_versions_differ
+      # Skip check if package is listed from relative path, git repo or github URL
+      return if node_package_version.skip_processing?
+
+      # If no package found, assume user doesn't use it
+      return unless node_package_version.package_specified?
+
+      node_major_minor_patch = node_package_version.major_minor_patch
+      gem_major_minor_patch = gem_major_minor_patch_version
+      versions_match = node_major_minor_patch[0] == gem_major_minor_patch[0] &&
+                       node_major_minor_patch[1] == gem_major_minor_patch[1] &&
+                       node_major_minor_patch[2] == gem_major_minor_patch[2]
+
+      raise_differing_versions_warning unless versions_match
+
+      raise_node_semver_version_warning if node_package_version.semver_wildcard?
+    end
+
+    private
+
+      def common_error_msg
+        <<-MSG.strip_heredoc
+         Detected: #{node_package_version.raw}
+              gem: #{gem_version}
+         Ensure the installed version of the gem is the same as the version of
+         your installed node package. Do not use >= or ~> in your Gemfile for shakapacker.
+         Do not use ^ or ~ in your package.json for shakapacker.
+         Run `yarn add shakapacker --exact` in the directory containing folder node_modules.
+      MSG
+      end
+
+      def raise_differing_versions_warning
+        msg = "**ERROR** Webpacker: Webpacker gem and node package versions do not match\n#{common_error_msg}"
+        raise msg
+      end
+
+      def raise_node_semver_version_warning
+        msg = "**ERROR** Webpacker: Your node package version for shakapacker contains a "\
+              "^ or ~\n#{common_error_msg}"
+        raise msg
+      end
+
+      def gem_version
+        Webpacker::VERSION
+      end
+
+      def gem_major_minor_patch_version
+        match = gem_version.match(MAJOR_MINOR_PATCH_VERSION_REGEX)
+        [match[1], match[2], match[3]]
+      end
+
+      class NodePackageVersion
+        attr_reader :package_json
+
+        def self.build
+          new(package_json_path)
+        end
+
+        def self.package_json_path
+          Rails.root.join("package.json")
+        end
+
+        def initialize(package_json)
+          @package_json = package_json
+        end
+
+        def raw
+          parsed_package_contents = JSON.parse(package_json_contents)
+          package_info = parsed_package_contents.dig("dependencies", "shakapacker").to_s
+        end
+
+        def package_specified?
+          raw.present?
+        end
+
+        def semver_wildcard?
+          raw.match(/[~^]/).present?
+        end
+
+        def skip_processing?
+          relative_path? || git_url? || github_url?
+        end
+
+        def major_minor_patch
+          return if skip_processing?
+
+          match = raw.match(MAJOR_MINOR_PATCH_VERSION_REGEX)
+          unless match
+            raise "Cannot parse version number '#{raw}' (wildcard versions are not supported)"
+          end
+
+          [match[1], match[2], match[3]]
+        end
+
+        private
+
+          def relative_path?
+            raw.match(%r{(\.\.|\Afile:///)}).present?
+          end
+
+          def git_url?
+            raw.match(%r{^git}).present?
+          end
+
+          def github_url?
+            raw.match(%r{^([\w-]+\/[\w-]+)}).present?
+          end
+
+          def package_json_contents
+            @package_json_contents ||= File.read(package_json)
+          end
+      end
+  end
+end

--- a/lib/webpacker/version_checker.rb
+++ b/lib/webpacker/version_checker.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "webpacker/version"
 
 module Webpacker
   class VersionChecker
@@ -82,7 +83,7 @@ module Webpacker
 
         def raw
           parsed_package_contents = JSON.parse(package_json_contents)
-          package_info = parsed_package_contents.dig("dependencies", "shakapacker").to_s
+          parsed_package_contents.dig("dependencies", "shakapacker").to_s
         end
 
         def package_specified?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -75,4 +75,16 @@ class ConfigurationTest < Webpacker::Test
       assert Webpacker.config.compile?
     end
   end
+
+  def test_ensure_consistent_versioning?
+    refute @config.ensure_consistent_versioning?
+
+    with_rails_env("development") do
+      assert Webpacker.config.ensure_consistent_versioning?
+    end
+
+    with_rails_env("test") do
+      refute Webpacker.config.ensure_consistent_versioning?
+    end
+  end
 end

--- a/test/fixtures/beta_package.json
+++ b/test/fixtures/beta_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "6.0.0-beta.1"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/git_url_package.json
+++ b/test/fixtures/git_url_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "git://github.com/shakapacker/shakapacker.git"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/github_url_package.json
+++ b/test/fixtures/github_url_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "shakapacker/shakapacker#feature\/branch"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/normal_package.json
+++ b/test/fixtures/normal_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "6.0.0"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/relative_path_package.json
+++ b/test/fixtures/relative_path_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "../shakapacker"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/semver_caret_package.json
+++ b/test/fixtures/semver_caret_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "^6.0.0"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/semver_tilde_package.json
+++ b/test/fixtures/semver_tilde_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "~6.0.0"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/fixtures/without_package.json
+++ b/test/fixtures/without_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "left-pad": "1.0.2"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -36,6 +36,7 @@ default: &default
 development:
   <<: *default
   compile: true
+  ensure_consistent_versioning: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/test/version_checker_test.rb
+++ b/test/version_checker_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+require "webpacker/version"
+
+class NodePackageVersionDouble
+  attr_reader :raw, :major_minor_patch
+
+  def initialize(raw: nil, major_minor_patch: nil, semver_wildcard: false, skip_processing: false, package_specified: true)
+    @raw = raw
+    @major_minor_patch = major_minor_patch
+    @semver_wildcard = semver_wildcard
+    @skip_processing = skip_processing
+    @package_specified = package_specified
+  end
+
+  def semver_wildcard?
+    @semver_wildcard
+  end
+
+  def skip_processing?
+    @skip_processing
+  end
+
+  def package_specified?
+    @package_specified
+  end
+end
+
+class VersionCheckerTest < Minitest::Test
+  def check_version(node_package_version, stub_gem_version = Webpacker::VERSION)
+    version_checker = Webpacker::VersionChecker.new(node_package_version)
+    version_checker.stub :gem_version, stub_gem_version do
+      version_checker.raise_if_gem_and_node_package_versions_differ
+    end
+  end
+
+  def test_raise_on_different_major_version
+    node_package_version = NodePackageVersionDouble.new(raw: "6.1.0", major_minor_patch: ["6", "1", "0"])
+
+    error = assert_raises do
+      check_version(node_package_version, "7.0.0")
+    end
+
+    assert_match \
+      "**ERROR** Webpacker: Webpacker gem and node package versions do not match",
+      error.message
+  end
+
+  def test_raise_on_different_minor_version
+    node_package_version = NodePackageVersionDouble.new(raw: "6.1.0", major_minor_patch: ["6", "1", "0"])
+
+    error = assert_raises do
+      check_version(node_package_version, "6.2.0")
+    end
+
+    assert_match \
+      "**ERROR** Webpacker: Webpacker gem and node package versions do not match",
+      error.message
+  end
+
+  def test_raise_on_different_patch_version
+    node_package_version = NodePackageVersionDouble.new(raw: "6.1.1", major_minor_patch: ["6", "1", "1"])
+
+    error = assert_raises do
+      check_version(node_package_version, "6.1.2")
+    end
+
+    assert_match \
+      "**ERROR** Webpacker: Webpacker gem and node package versions do not match",
+      error.message
+  end
+
+  def test_raise_on_semver_wildcard
+    node_package_version = NodePackageVersionDouble.new(raw: "^6.0.0", major_minor_patch: ["6", "0", "0"], semver_wildcard: true)
+
+    error = assert_raises do
+      check_version(node_package_version, "6.0.0")
+    end
+
+    assert_match \
+      "**ERROR** Webpacker: Your node package version for shakapacker contains a ^ or ~",
+      error.message
+  end
+
+  def test_no_raise_on_matching_versions
+    node_package_version = NodePackageVersionDouble.new(raw: "6.0.0", major_minor_patch: ["6", "0", "0"])
+
+    assert_silent do
+      check_version(node_package_version, "6.0.0")
+    end
+  end
+
+  def test_no_raise_on_matching_versions_beta
+    node_package_version = NodePackageVersionDouble.new(raw: "6.0.0-beta.1", major_minor_patch: ["6", "0", "0"])
+
+    assert_silent do
+      check_version(node_package_version, "6.0.0.beta.1")
+    end
+  end
+
+  def test_no_raise_on_no_package
+    node_package_version = NodePackageVersionDouble.new(raw: nil, package_specified: false)
+
+    assert_silent do
+      check_version(node_package_version, "6.0.0")
+    end
+  end
+
+  def test_no_raise_on_skipped_path
+    node_package_version = NodePackageVersionDouble.new(raw: "../shakapacker", skip_processing: true)
+
+    assert_silent do
+      check_version(node_package_version, "6.0.0")
+    end
+  end
+end
+
+class NodePackageVersionTest < Minitest::Test
+end

--- a/test/version_checker_test.rb
+++ b/test/version_checker_test.rb
@@ -4,12 +4,11 @@ require "webpacker/version"
 class NodePackageVersionDouble
   attr_reader :raw, :major_minor_patch
 
-  def initialize(raw: nil, major_minor_patch: nil, semver_wildcard: false, skip_processing: false, package_specified: true)
+  def initialize(raw: nil, major_minor_patch: nil, semver_wildcard: false, skip_processing: false)
     @raw = raw
     @major_minor_patch = major_minor_patch
     @semver_wildcard = semver_wildcard
     @skip_processing = skip_processing
-    @package_specified = package_specified
   end
 
   def semver_wildcard?
@@ -18,10 +17,6 @@ class NodePackageVersionDouble
 
   def skip_processing?
     @skip_processing
-  end
-
-  def package_specified?
-    @package_specified
   end
 end
 
@@ -98,7 +93,7 @@ class VersionCheckerTest < Minitest::Test
   end
 
   def test_no_raise_on_no_package
-    node_package_version = NodePackageVersionDouble.new(raw: nil, package_specified: false)
+    node_package_version = NodePackageVersionDouble.new(raw: nil, skip_processing: true)
 
     assert_silent do
       check_version(node_package_version, "6.0.0")
@@ -115,4 +110,136 @@ class VersionCheckerTest < Minitest::Test
 end
 
 class NodePackageVersionTest < Minitest::Test
+  def node_package_version(fixture_version: "normal")
+    file_path = File.expand_path("fixtures/#{fixture_version}_package.json", __dir__)
+    Webpacker::VersionChecker::NodePackageVersion.new(file_path)
+  end
+
+  def test_normal_package_raw
+    assert_equal "6.0.0", node_package_version.raw
+  end
+
+  def test_normal_package_major_minor_patch
+    assert_equal ["6", "0", "0"], node_package_version.major_minor_patch
+  end
+
+  def test_normal_package_skip_processing
+    assert_equal false, node_package_version.skip_processing?
+  end
+
+  def test_normal_package_semver_wildcard
+    assert_equal false, node_package_version.semver_wildcard?
+  end
+
+  def test_beta_package_raw
+    assert_equal "6.0.0-beta.1", node_package_version(fixture_version: "beta").raw
+  end
+
+  def test_beta_package_major_minor_patch
+    assert_equal ["6", "0", "0"], node_package_version(fixture_version: "beta").major_minor_patch
+  end
+
+  def test_beta_package_skip_processing
+    assert_equal false, node_package_version(fixture_version: "beta").skip_processing?
+  end
+
+  def test_beta_package_semver_wildcard
+    assert_equal false, node_package_version(fixture_version: "beta").semver_wildcard?
+  end
+
+  def test_semver_caret_package_raw
+    assert_equal "^6.0.0", node_package_version(fixture_version: "semver_caret").raw
+  end
+
+  def test_semver_caret_package_major_minor_patch
+    assert_equal ["6", "0", "0"], node_package_version(fixture_version: "semver_caret").major_minor_patch
+  end
+
+  def test_semver_caret_package_skip_processing
+    assert_equal false, node_package_version(fixture_version: "semver_caret").skip_processing?
+  end
+
+  def test_semver_caret_package_semver_wildcard
+    assert_equal true, node_package_version(fixture_version: "semver_caret").semver_wildcard?
+  end
+
+  def test_semver_tilde_package_raw
+    assert_equal "~6.0.0", node_package_version(fixture_version: "semver_tilde").raw
+  end
+
+  def test_semver_tilde_package_major_minor_patch
+    assert_equal ["6", "0", "0"], node_package_version(fixture_version: "semver_tilde").major_minor_patch
+  end
+
+  def test_semver_tilde_package_skip_processing
+    assert_equal false, node_package_version(fixture_version: "semver_tilde").skip_processing?
+  end
+
+  def test_semver_tilde_package_semver_wildcard
+    assert_equal true, node_package_version(fixture_version: "semver_tilde").semver_wildcard?
+  end
+
+  def test_relative_path_package_raw
+    assert_equal "../shakapacker", node_package_version(fixture_version: "relative_path").raw
+  end
+
+  def test_relative_path_package_major_minor_patch
+    assert_nil node_package_version(fixture_version: "relative_path").major_minor_patch
+  end
+
+  def test_relative_path_package_skip_processing
+    assert_equal true, node_package_version(fixture_version: "relative_path").skip_processing?
+  end
+
+  def test_relative_path_package_semver_wildcard
+    assert_equal false, node_package_version(fixture_version: "relative_path").semver_wildcard?
+  end
+
+  def test_git_url_package_raw
+    assert_equal "git://github.com/shakapacker/shakapacker.git", node_package_version(fixture_version: "git_url").raw
+  end
+
+  def test_git_url_package_major_minor_patch
+    assert_nil node_package_version(fixture_version: "git_url").major_minor_patch
+  end
+
+  def test_git_url_package_skip_processing
+    assert_equal true, node_package_version(fixture_version: "git_url").skip_processing?
+  end
+
+  def test_git_url_package_semver_wildcard
+    assert_equal false, node_package_version(fixture_version: "git_url").semver_wildcard?
+  end
+
+  def test_github_url_package_raw
+    assert_equal "shakapacker/shakapacker#feature/branch", node_package_version(fixture_version: "github_url").raw
+  end
+
+  def test_github_url_package_major_minor_patch
+    assert_nil node_package_version(fixture_version: "github_url").major_minor_patch
+  end
+
+  def test_github_url_package_skip_processing
+    assert_equal true, node_package_version(fixture_version: "github_url").skip_processing?
+  end
+
+  def test_github_url_package_semver_wildcard
+    assert_equal false, node_package_version(fixture_version: "github_url").semver_wildcard?
+  end
+
+  def test_without_package_raw
+    assert_equal "", node_package_version(fixture_version: "without").raw
+  end
+
+  def test_without_package_major_minor_patch
+    assert_nil node_package_version(fixture_version: "without").major_minor_patch
+  end
+
+  def test_without_package_skip_processing
+    assert_equal true, node_package_version(fixture_version: "without").skip_processing?
+  end
+
+  def test_without_package_semver_wildcard
+    assert_equal false, node_package_version(fixture_version: "without").semver_wildcard?
+  end
 end


### PR DESCRIPTION
Closes #36 

- Adds version check to ensure consistency between gem and npm package versions (mostly adapter from https://github.com/shakacode/react_on_rails/blob/master/lib/react_on_rails/version_checker.rb)
- Updates instructions and generators to use bundler `--strict` and yarn `--exact` flags to lock versions.

TODO:

- [x] Add tests for the `VersionChecker` module