### PR TITLE
Fix compare link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Changes since last non-beta release.
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md) 
 
 [Unreleased]: https://github.com/shakacode/shakapacker/compare/v6.1.1...master
-[v6.1.1]: https://github.com/shakacode/shakapacker/compare/v6.1.1...v6.1.1
+[v6.1.1]: https://github.com/shakacode/shakapacker/compare/v6.1.0...v6.1.1
 [v6.1.0]: https://github.com/shakacode/shakapacker/compare/v6.0.2...v6.1.0
 [v6.0.2]: https://github.com/shakacode/shakapacker/compare/v6.0.1...v6.0.2
 [v6.0.1]: https://github.com/shakacode/shakapacker/compare/v6.0.0...v6.0.1


### PR DESCRIPTION
A previous version of v6.1.1 is v6.1.0.