### PR TITLE
Fix SWC & esbuild configuration for production in doc

### DIFF
--- a/docs/using_esbuild_loader.md
+++ b/docs/using_esbuild_loader.md
@@ -24,7 +24,7 @@ To use esbuild as your transpiler today. You need to do two things:
 1. Make sure you've installed `esbuild` and `esbuild-loader` packages.
 
 ```
-yarn add -D esbuild esbuild-loader
+yarn add esbuild esbuild-loader
 ```
 
 2. Add or change `webpacker_loader` value in your default `webpacker.yml` config to `esbuild`

--- a/docs/using_swc_loader.md
+++ b/docs/using_swc_loader.md
@@ -19,7 +19,7 @@ In order to use SWC as your compiler today. You need to do two things:
 1. Make sure you've installed `@swc/core` and `swc-loader` packages.
 
 ```
-yarn add -D @swc/core swc-loader
+yarn add @swc/core swc-loader
 ```
 
 2. Add or change `webpacker_loader` value in your default `webpacker.yml` config to `swc`


### PR DESCRIPTION
In `RAILS_ENV=production`, shakapacker sets `NODE_ENV` as `production` in some places:
- https://github.com/shakacode/shakapacker/blob/v6.1.1/lib/tasks/webpacker/yarn_install.rake#L5-L7
- https://github.com/shakacode/shakapacker/blob/v6.1.1/lib/tasks/yarn.rake#L11-L13

All node modules that are installed via `-D` option will be ignored in `NODE_ENV=production`.
However, we need SWC dependencies in production.
So, these modules should be installed as `dependencies`, not a `devDependencies`.