### PR TITLE
Fix shakapacker version in Gemfile.lock to fix CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shakapacker (6.1.0)
+    shakapacker (6.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)


### PR DESCRIPTION
https://github.com/shakacode/shakapacker/commit/756318738dda09d6432d8b06418ad40abf98cd11 breaks CI 💔 
Like https://github.com/shakacode/shakapacker/runs/5090267102.

It may be better to remove `Gemfile.lock` maintenance easier.
In this PR, I just updated gem version.