### PR TITLE
Standardized Webpack rule formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Added
+- Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan)
+
 ## [v6.1.1] - February 6, 2022
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ console.log(webpackConfig.source_path)
 console.log(JSON.stringify(webpackConfig, undefined, 2))
 ```
 
+You may want to modify rules in the default configuration. For instance, if you are using a custom svg loader, you may want to remove `.svg` from the default file loader rules. You can search and filter the default rules like so:
+
+```js
+const svgRule = config.module.rules.find(rule => rule.test.test('.svg'));
+svgRule.test = svgRule.test.filter(t => !t.test('.svg'))
+```
+
 ### Babel configuration
 
 By default, you will find the Webpacker preset in your `package.json`. Note, you need to use the new NPM package name, `shakapacker`.

--- a/package/rules/__tests__/file.js
+++ b/package/rules/__tests__/file.js
@@ -1,0 +1,35 @@
+const file = require('../file')
+
+describe('file', () => {
+  test('test expected file types', () => {
+    const types = [
+      '.bmp',
+      '.gif',
+      '.jpg',
+      '.jpeg',
+      '.png',
+      '.tiff',
+      '.ico',
+      '.avif',
+      '.webp',
+      '.eot',
+      '.otf',
+      '.ttf',
+      '.woff',
+      '.woff2',
+      '.svg',
+    ]
+    types.forEach(type => expect(file.test.test(type)).toBe(true))
+  })
+
+  test('exclude expected file types', () => {
+    const types = [
+      '.js',
+      '.mjs',
+      '.jsx',
+      '.ts',
+      '.tsx',
+    ]
+    types.forEach(type => expect(file.exclude.test(type)).toBe(true))
+  })
+})

--- a/package/rules/__tests__/index.js
+++ b/package/rules/__tests__/index.js
@@ -1,0 +1,11 @@
+const rules = require('../index')
+
+describe('index', () => {
+  test('rule tests are regexes', () => {
+    rules.forEach(rule => expect(rule.test instanceof RegExp).toBe(true))
+  })
+
+  test('rule excludes are regexes', () => {
+    rules.forEach(rule => expect(rule.exclude instanceof RegExp).toBe(true))
+  })
+})

--- a/package/rules/__tests__/raw.js
+++ b/package/rules/__tests__/raw.js
@@ -1,0 +1,18 @@
+const raw = require('../raw')
+
+describe('raw', () => {
+  test('test expected file types', () => {
+    expect(raw.test.test('.html')).toBe(true)
+  })
+
+  test('exclude expected file types', () => {
+    const types = [
+      '.js',
+      '.mjs',
+      '.jsx',
+      '.ts',
+      '.tsx',
+    ]
+    types.forEach(type => expect(raw.exclude.test(type)).toBe(true))
+  })
+})

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -2,23 +2,8 @@ const { dirname, join } = require('path')
 const { source_path: sourcePath } = require('../config')
 
 module.exports = {
-  test: [
-    /\.bmp$/,
-    /\.gif$/,
-    /\.jpe?g$/,
-    /\.png$/,
-    /\.tiff$/,
-    /\.ico$/,
-    /\.avif$/,
-    /\.webp$/,
-    /\.eot$/,
-    /\.otf$/,
-    /\.ttf$/,
-    /\.woff$/,
-    /\.woff2$/,
-    /\.svg$/
-  ],
-  exclude: [/\.(js|mjs|jsx|ts|tsx)$/],
+  test: /\.(bmp|gif|jpe?g|png|tiff|ico|avif|webp|eot|otf|ttf|woff|woff2|svg)$/,
+  exclude: /\.(js|mjs|jsx|ts|tsx)$/,
   type: 'asset/resource',
   generator: {
     filename: (pathData) => {

--- a/package/rules/raw.js
+++ b/package/rules/raw.js
@@ -1,5 +1,5 @@
 module.exports = {
-  test: [/\.html$/],
-  exclude: [/\.(js|mjs|jsx|ts|tsx)$/],
+  test: /\.html$/,
+  exclude: /\.(js|mjs|jsx|ts|tsx)$/,
   type: 'asset/source'
 }


### PR DESCRIPTION
When adding a Webpack rule, it's common to remove existing rules for that file type. For example, if you're adding a custom svg loader, you may want to exclude `.svg` from existing rules like so:

```
const fileLoaderRule = config.module.rules.find(rule => rule.test.test('.svg'));
fileLoaderRule.exclude = /\.svg$/;
```

The rules in shakapacker's wepback config used a mix of arrays and regular expressions, making this kind of iteration a pain to implement. These changes refactor all rules to use regular expressions to allow for easy customization.