### PR TITLE
Increase default connect timeout to 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes since last non-beta release.
 - Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan)
 - Initialization check to ensure shakapacker gem and NPM package version are consistent. Opt-in behaviour enabled by setting `ensure_consistent_versioning` configuration variable. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
 - Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-extract-css-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald)
+- Increase default connect timeout for dev server connections, establishing connections more reliably for busy machines. [PR 74](https://github.com/shakacode/shakapacker/pull/74) by [stevecrozz](https://github.com/stevecrozz)
 
 ## [v6.1.1] - February 6, 2022
 

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,9 +1,9 @@
 class Webpacker::DevServer
   DEFAULT_ENV_PREFIX = "WEBPACKER_DEV_SERVER".freeze
 
-  # Configure dev server connection timeout (in seconds), default: 0.01
+  # Configure dev server connection timeout (in seconds), default: 0.1
   # Webpacker.dev_server.connect_timeout = 1
-  cattr_accessor(:connect_timeout) { 0.01 }
+  cattr_accessor(:connect_timeout) { 0.1 }
 
   attr_reader :config
 


### PR DESCRIPTION
Set the default webpack dev server connect timeout to 0.1s for calling the #running? method

Raised an issue and a PR was requested in #73 

Reproducing this issue is a little tricky as it means having a dev server that takes longer than 0.01s to accept a TCP connection. Perhaps it could be reproduced with a very busy workstation.

I have observed this happening repeatedly while troubleshooting with coworkers, but it doesn't typically happen for me, although I have also seen it. I am recommending this change because firstly, it has proved to be a more reliable value in my observations.

But also, the change from 1s to 0.01s seems to have been made without much discussion and without any stated reason:
rails/webpacker/pull/753

It is thankfully configurable now and we have done that for ourselves, but I'm interested in helping others avoid this debugging headache by choosing a more generous timeout. If I understand correctly, this will

1. have no effect for most people who are not running the dev server as `running?` will return false immediately when the connection is refused
2. It will solve an issue when a dev server takes between 0.01s and 0.1s to accept a connection and
3. It will cause a 0.09s added delay for someone who's system drops TCP packets to the specified devserver host/port (not sure how common that is)