### PR TITLE
Configurable manifest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since last non-beta release.
 - Initialization check to ensure shakapacker gem and NPM package version are consistent. Opt-in behaviour enabled by setting `ensure_consistent_versioning` configuration variable. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
 - Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-extract-css-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald)
 - Increase default connect timeout for dev server connections, establishing connections more reliably for busy machines. [PR 74](https://github.com/shakacode/shakapacker/pull/74) by [stevecrozz](https://github.com/stevecrozz)
+- Make manifest_path configurable, to keep manifest.json private if desired. [PR 78](https://github.com/shakacode/shakapacker/pull/78) by [jdelStrother](https://github.com/jdelStrother)
 
 ## [v6.1.1] - February 6, 2022
 

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -8,6 +8,9 @@ default: &default
   cache_path: tmp/webpacker
   webpack_compile_output: true
 
+  # Location for manifest.json, defaults to {public_output_path}/manifest.json if unset
+  # manifest_path: public/packs/manifest.json
+
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']
   additional_paths: []

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -16,7 +16,7 @@ class Webpacker::Commands
   #   age=600.
   #
   def clean(count = 2, age = 3600)
-    if config.public_output_path.exist? && config.public_manifest_path.exist?
+    if config.public_output_path.exist? && config.manifest_path.exist?
       packs
         .map do |paths|
           paths.map { |path| [Time.now - File.mtime(path), path] }
@@ -57,7 +57,7 @@ class Webpacker::Commands
   private
     def packs
       all_files       = Dir.glob("#{config.public_output_path}/**/*")
-      manifest_config = Dir.glob("#{config.public_manifest_path}*")
+      manifest_config = Dir.glob("#{config.manifest_path}*")
 
       packs = all_files - manifest_config - current_version
       packs.reject { |file| File.directory?(file) }.group_by do |path|

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -47,7 +47,7 @@ class Webpacker::Compiler
     attr_reader :webpacker
 
     def last_compilation_digest
-      compilation_digest_path.read if compilation_digest_path.exist? && config.public_manifest_path.exist?
+      compilation_digest_path.read if compilation_digest_path.exist? && config.manifest_path.exist?
     rescue Errno::ENOENT, Errno::ENOTDIR
     end
 

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -39,16 +39,16 @@ class Webpacker::Configuration
     source_path.join(fetch(:source_entry_path))
   end
 
+  def manifest_path
+    public_output_path.join("manifest.json")
+  end
+
   def public_path
     root_path.join(fetch(:public_root_path))
   end
 
   def public_output_path
     public_path.join(fetch(:public_output_path))
-  end
-
-  def public_manifest_path
-    public_output_path.join("manifest.json")
   end
 
   def cache_manifest?

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -40,7 +40,11 @@ class Webpacker::Configuration
   end
 
   def manifest_path
-    public_output_path.join("manifest.json")
+    if data.has_key?(:manifest_path)
+      root_path.join(fetch(:manifest_path))
+    else
+      public_output_path.join("manifest.json")
+    end
   end
 
   def public_path

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -80,8 +80,8 @@ class Webpacker::Manifest
     end
 
     def load
-      if config.public_manifest_path.exist?
-        JSON.parse config.public_manifest_path.read
+      if config.manifest_path.exist?
+        JSON.parse config.manifest_path.read
       else
         {}
       end
@@ -104,7 +104,7 @@ class Webpacker::Manifest
 
     def missing_file_from_manifest_error(bundle_name)
       <<-MSG
-Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
+Webpacker can't find #{bundle_name} in #{config.manifest_path}. Possible causes:
 1. You forgot to install node packages (try `yarn install`) or are running an incompatible version of Node
 2. Your app has code with a non-standard extension (like a `.jsx` file) but the extension is not in the `extensions` config in `config/webpacker.yml`
 3. You have set compile: false (see `config/webpacker.yml`) for this environment

--- a/package/__tests__/config.js
+++ b/package/__tests__/config.js
@@ -1,6 +1,7 @@
 /* global test expect, describe */
 
 const { chdirCwd, chdirTestApp, resetEnv } = require('../utils/helpers')
+const { resolve } = require('path')
 
 chdirTestApp()
 
@@ -30,5 +31,15 @@ describe('Config', () => {
       'some.config.js',
       'app/elm'
     ])
+  })
+
+  test('should default manifestPath to the public dir', () => {
+    expect(config.manifestPath).toEqual(resolve('public/packs/manifest.json'))
+  })
+
+  test('should allow overriding manifestPath', () => {
+    process.env.WEBPACKER_CONFIG = 'config/webpacker_manifest_path.yml'
+    const config = require('../config')
+    expect(config.manifestPath).toEqual(resolve('app/packs/manifest.json'))
   })
 })

--- a/package/config.js
+++ b/package/config.js
@@ -29,4 +29,10 @@ const getPublicPath = () => {
 config.publicPath = getPublicPath()
 config.publicPathWithoutCDN = `/${config.public_output_path}/`
 
+if (config.manifest_path) {
+  config.manifestPath = resolve(config.manifest_path)
+} else {
+  config.manifestPath = resolve(config.outputPath, 'manifest.json')
+}
+
 module.exports = config

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -54,7 +54,7 @@ const getPlugins = () => {
     new WebpackAssetsManifest({
       entrypoints: true,
       writeToDisk: true,
-      output: 'manifest.json',
+      output: config.manifestPath,
       entrypointsUseAssets: true,
       publicPath: true
     })

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -41,6 +41,15 @@ class ConfigurationTest < Webpacker::Test
   def test_manifest_path
     manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
     assert_equal @config.manifest_path.to_s, manifest_path
+
+    @config = Webpacker::Configuration.new(
+      root_path: @config.root_path,
+      config_path: Pathname.new(File.expand_path("./test_app/config/webpacker_manifest_path.yml", __dir__)),
+      env: "production"
+    )
+
+    manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/app/packs", "manifest.json").to_s
+    assert_equal @config.manifest_path.to_s, manifest_path
   end
 
   def test_cache_path

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -38,9 +38,9 @@ class ConfigurationTest < Webpacker::Test
     assert_equal @config.public_output_path.to_s, public_output_path
   end
 
-  def test_public_manifest_path
-    public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
-    assert_equal @config.public_manifest_path.to_s, public_manifest_path
+  def test_manifest_path
+    manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
+    assert_equal @config.manifest_path.to_s, manifest_path
   end
 
   def test_cache_path

--- a/test/test_app/config/webpacker_manifest_path.yml
+++ b/test/test_app/config/webpacker_manifest_path.yml
@@ -1,4 +1,4 @@
-# Note: You must restart bin/webpacker-dev-server for changes to take effect
+# Note: You must restart bin/webpack-dev-server for changes to take effect
 
 default: &default
   source_path: app/packs
@@ -7,10 +7,9 @@ default: &default
   public_output_path: packs
   cache_path: tmp/webpacker
   webpack_compile_output: false
-  webpack_loader: babel
 
   # Location for manifest.json, defaults to {public_output_path}/manifest.json if unset
-  # manifest_path: public/packs/manifest.json
+  manifest_path: app/packs/manifest.json
 
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']
@@ -39,7 +38,6 @@ default: &default
 development:
   <<: *default
   compile: true
-  ensure_consistent_versioning: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
This is another run at the old https://github.com/rails/webpacker/pull/3152 PR

Unlike that PR, this version doesn't change the default behaviour at all - manifest.json will stay in public/packs, unless you set `manifest_path` in webpacker.yml.

WDYT?