### PR TITLE
tweak swc config for parity with babel

### DIFF
--- a/package/swc/index.js
+++ b/package/swc/index.js
@@ -30,12 +30,12 @@ const getSwcLoaderConfig = (filenameToProcess) => {
             : 'ecmascript',
           [isTypescriptFile(filenameToProcess) ? 'tsx' : 'jsx']:
             isJsxFile(filenameToProcess)
-        }
+        },
+        loose: true
       },
       sourceMaps: true,
       env: {
-        coreJs: '3.8',
-        loose: true,
+        coreJs: 3,
         exclude: ['transform-typeof-symbol'],
         mode: 'entry'
       }


### PR DESCRIPTION
move "loose" setting in swc config from under env to under jsc

matches the babel setting of the same name:
https://swc.rs/docs/configuration/compilation#jscloose

workaround for this:
https://github.com/swc-project/swc/issues/3943

also make the "coreJs" setting an integer which seems to be what the swc config schema validator wants

fixes #77 