### PR TITLE
Permit calling stylesheet_pack_tag more than once per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since last non-beta release.
 - Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-extract-css-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald)
 - Increase default connect timeout for dev server connections, establishing connections more reliably for busy machines. [PR 74](https://github.com/shakacode/shakapacker/pull/74) by [stevecrozz](https://github.com/stevecrozz)
 - Make manifest_path configurable, to keep manifest.json private if desired. [PR 78](https://github.com/shakacode/shakapacker/pull/78) by [jdelStrother](https://github.com/jdelStrother)
+- Allow multiple invocations of stylesheet_pack_tag (eg for a regular stylesheet & a print stylesheet). [PR 82](https://github.com/shakacode/shakapacker/pull/82) by [jdelStrother](https://github.com/jdelStrother)
 
 ## [v6.1.1] - February 6, 2022
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ The result looks like this:
 <%= stylesheet_pack_tag 'map' %>
 ```
 
+However, you may use multiple calls to stylesheet_pack_tag if, say, you require multiple <style> tags for different output media:
+
+``` erb
+<%= stylesheet_pack_tag 'application', media: 'screen' %>
+<%= stylesheet_pack_tag 'print', media: 'print' %>
+```
+
 If you need to setup the pack name args in partials, [see this discussion](https://github.com/shakacode/shakapacker/issues/39).
 
 If you want to link a static asset for `<img />` tag, you can use the `asset_pack_path` helper:

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -148,13 +148,6 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar' %>
   #   <%= stylesheet_pack_tag 'map' %>
   def stylesheet_pack_tag(*names, **options)
-    if @stylesheet_pack_tag_loaded
-      raise "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page. " \
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
-    end
-
-    @stylesheet_pack_tag_loaded = true
-
     return "" if Webpacker.inlining_css?
 
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -14,7 +14,6 @@ class HelperTest < ActionView::TestCase
     end.new
 
     @javascript_pack_tag_loaded = nil
-    @stylesheet_pack_tag_loaded = nil
   end
 
   def test_asset_pack_path
@@ -149,19 +148,19 @@ class HelperTest < ActionView::TestCase
   end
 
   def hello_stimulus_stylesheet_chunks
-    %w[/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css]
+    %w[/packs/1-c20632e7baf2c81200d3.chunk.css /packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css]
   end
 
   def test_stylesheet_pack_tag
     assert_equal \
-      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq
         .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stylesheet_pack_tag("application", "hello_stimulus")
   end
 
   def test_stylesheet_pack_tag_symbol
     assert_equal \
-      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq
         .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stylesheet_pack_tag(:application, :hello_stimulus)
   end
@@ -172,15 +171,16 @@ class HelperTest < ActionView::TestCase
       stylesheet_pack_tag("application", media: "all")
   end
 
-  def test_stylesheet_pack_tag_multiple_invocations
-    error = assert_raises do
-      stylesheet_pack_tag(:application)
-      stylesheet_pack_tag(:hello_stimulus)
-    end
+  def test_stylesheet_pack_tag_multiple_invocations_are_allowed
+    app_style = stylesheet_pack_tag(:application)
+    stimulus_style = stylesheet_pack_tag(:hello_stimulus)
 
     assert_equal \
-      "To prevent duplicated chunks on the page, you should call stylesheet_pack_tag only once on the page. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide",
-      error.message
+      application_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
+      app_style
+
+    assert_equal \
+      hello_stimulus_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
+      stimulus_style
   end
 end


### PR DESCRIPTION
Previously discussed in #39 


This is necessary to allow usage like, eg:

```
<%= stylesheet_pack_tag :application %>
<%= stylesheet_pack_tag :print, media: "print" %>
```

However, it can result in duplicate style chunks on the page,
so the following should still be used where possible -

```
<%= stylesheet_pack_tag :application, :admin %>
```