### PR TITLE
javascript_pack_tag handles repetition of individual chunks. Closes #39

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -101,16 +101,18 @@ module Webpacker::Helper
       @emitted = {}
     end
     includetags = "".html_safe
+    newline = "".html_safe
     sources = sources_from_manifest_entrypoints(names, type: :javascript)
     sources.each do |source|
-      if @emitted.keys.include?(source) && @emitted[source][:defer] != defer
+      if @emitted.key?(source) && @emitted[source][:defer] != defer
         raise "Chunk #{source} already emitted with defer value "\
           "#{@emitted[source][:defer]}. Trying to emit with different "\
           "defer value is not allowed."
-      elsif !@emitted.keys.include?(source)
-        includetags += javascript_include_tag(source, options)
+      elsif !@emitted.key?(source)
+        includetags += newline + javascript_include_tag(source, options)
       end
-      @emitted[source] = {defer: defer}
+      @emitted[source] = { defer: defer }
+      newline = "\n".html_safe
     end
     return includetags
   end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -106,12 +106,13 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag("application", "bootstrap")
   end
 
-  def test_javascript_pack_with_no_defer_tag
-    assert_equal \
-      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+  SCRIPTS_APPLICATION_BOOTSTRAP = %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
         %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
         %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>\n) +
-        %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
+        %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>)
+
+  def test_javascript_pack_with_no_defer_tag
+    assert_equal SCRIPTS_APPLICATION_BOOTSTRAP,
       javascript_pack_tag("application", "bootstrap", defer: false)
   end
 
@@ -132,15 +133,10 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_javascript_pack_tag_multiple_invocations
-    error = assert_raises do
-      javascript_pack_tag(:application)
-      javascript_pack_tag(:bootstrap)
-    end
+    r = javascript_pack_tag(:application, defer: false)
+    r += "\n".html_safe + javascript_pack_tag(:bootstrap, defer: false)
 
-    assert_equal \
-      "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide",
-      error.message
+    assert_equal SCRIPTS_APPLICATION_BOOTSTRAP, r
   end
 
   def application_stylesheet_chunks


### PR DESCRIPTION
This one would close #39.

The idea is to record what chunks have been emitted and with what defer value.

When a chunk previously emitted is going to be emitted again, skip repeating it so long as the defer value is the same as the previous one, or raises an error if different.

But what about the order of chunks?

This way, the components in the loaded packs could be used anywhere, and it would be possible to repeat 
javascript_pack_tag without actually loading the chunks repeated.

I guess there are situations I'm not considering.  

I also think that before merging this, it is essential to fix #88  (we don't want to confuse what is causing that bug with this!)