### PR TITLE
append_javascript_pack_tag helper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shakapacker (6.1.1)
+    shakapacker (6.2.0)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)

--- a/README.md
+++ b/README.md
@@ -216,7 +216,18 @@ However, you may use multiple calls to stylesheet_pack_tag if, say, you require 
 <%= stylesheet_pack_tag 'print', media: 'print' %>
 ```
 
-If you need to setup the pack name args in partials, [see this discussion](https://github.com/shakacode/shakapacker/issues/39).
+You can also use `append_javascript_pack_tag` helper to bundle additional tags together when calling `javascript_pack_tag`:
+
+```erb
+<% append_javascript_pack_tag 'calendar', 'map' %>
+<%= javascript_pack_tag 'application' %>
+```
+
+In the example above, `calendar` and `map` tags will be bundled together with `application` and deduplicated once `javascript_pack_tag` is used.
+
+**Important:** `append_javascript_pack_tag` can be used anywhere in your application as long as it is executed BEFORE the `javascript_pack_tag`. If you attempt to call `append_javascript_pack_tag` helper after `javascript_pack_tag`, an error will be raised. You should aim to have only single `javascript_pack_tag` invocation in your page load.
+
+For alternative options of setting the additional packs, [see this discussion](https://github.com/shakacode/shakapacker/issues/39).
 
 If you want to link a static asset for `<img />` tag, you can use the `asset_pack_path` helper:
 ```erb

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -101,11 +101,11 @@ module Webpacker::Helper
       "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
     end
 
-    @javascript_pack_tag_loaded = true
-
     append_javascript_pack_tag(*names, defer: defer)
     non_deferred = sources_from_manifest_entrypoints(javascript_pack_tag_queue[:non_deferred], type: :javascript)
     deferred = sources_from_manifest_entrypoints(javascript_pack_tag_queue[:deferred], type: :javascript) - non_deferred
+
+    @javascript_pack_tag_loaded = true
 
     capture do
       concat javascript_include_tag(*deferred, **options.tap { |o| o[:defer] = true })
@@ -162,6 +162,11 @@ module Webpacker::Helper
   end
 
   def append_javascript_pack_tag(*names, defer: true)
+    if @javascript_pack_tag_loaded
+      raise "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " \
+      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
+    end
+
     hash_key = defer ? :deferred : :non_deferred
     javascript_pack_tag_queue[hash_key] |= names
   end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -125,6 +125,18 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag("application")
   end
 
+  def test_append_javascript_pack_tag_raises
+    error = assert_raises do
+      javascript_pack_tag("application")
+      append_javascript_pack_tag("bootstrap", defer: false)
+    end
+
+    assert_equal \
+      "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " +
+        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide",
+      error.message
+  end
+
   def test_javascript_pack_tag_splat
     assert_equal \
       %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -115,6 +115,16 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag("application", "bootstrap", defer: false)
   end
 
+  def test_javascript_pack_with_append
+    append_javascript_pack_tag("bootstrap", defer: false)
+    assert_equal \
+      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>\n) +
+        %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
+      javascript_pack_tag("application")
+  end
+
   def test_javascript_pack_tag_splat
     assert_equal \
       %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +


### PR DESCRIPTION
Another stab at improving #39 

Adds new helper to allow providing additional packs in addition that get appended to the main `javascript_pack_tag` call

`javascript_pack_tag` calls still raises when used multiple times but helper can streamline addition of packs in partials or conditionally.

Once we get list of all the tags to output, we deduplicate them and prioritise non-deferred ones - if particular bit is required by both deferred and non deferred call, the non-deferred one will be the one loaded.

Still needs testing and cleanup but just wanted to get initial version out to get thoughts and opinions

cc @justin808 