### PR TITLE
Use modified time rather than digest for freshness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ import 'images/rails.png'
 
 **Note:** Please be careful when adding paths here otherwise it will make the compilation slow, consider adding specific paths instead of whole parent directory if you just need to reference one or two modules
 
-**Also note:** While importing assets living outside your `source_path` defined in webpacker.yml (like, for instance, assets under `app/assets`) from within your packs using _relative_ paths like `import '../../assets/javascripts/file.js'` will work in development, Webpacker won't recompile the bundle in production unless a file that lives in one of it's watched paths has changed (check out `Webpacker::Compiler#watched_files_digest`). That's why you'd need to add `app/assets` to the additional_paths as stated above and use `import 'javascripts/file.js'` instead.
+**Also note:** While importing assets living outside your `source_path` defined in webpacker.yml (like, for instance, assets under `app/assets`) from within your packs using _relative_ paths like `import '../../assets/javascripts/file.js'` will work in development, Webpacker won't recompile the bundle in production unless a file that lives in one of it's watched paths has changed (check out `Webpacker::Compiler#latest_modified_timestamp`). That's why you'd need to add `app/assets` to the additional_paths as stated above and use `import 'javascripts/file.js'` instead.
 
 
 ## Deployment

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -1,18 +1,18 @@
 require "test_helper"
 
 class CompilerTest < Minitest::Test
-  def remove_compilation_digest_path
-    Webpacker.compiler.send(:compilation_digest_path).tap do |path|
+  def remove_compilation_timestamp_path
+    Webpacker.compiler.send(:compilation_timestamp_path).tap do |path|
       path.delete if path.exist?
     end
   end
 
   def setup
-    remove_compilation_digest_path
+    remove_compilation_timestamp_path
   end
 
   def teardown
-    remove_compilation_digest_path
+    remove_compilation_timestamp_path
   end
 
   def test_custom_environment_variables
@@ -52,8 +52,8 @@ class CompilerTest < Minitest::Test
     end
   end
 
-  def test_compilation_digest_path
-    assert_equal Webpacker.compiler.send(:compilation_digest_path).basename.to_s, "last-compilation-digest-#{Webpacker.env}"
+  def test_compilation_timestamp_path
+    assert_equal Webpacker.compiler.send(:compilation_timestamp_path).basename.to_s, "last-compilation-timestamp-#{Webpacker.env}"
   end
 
   def test_external_env_variables

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -1,20 +1,6 @@
 require "test_helper"
 
 class CompilerTest < Minitest::Test
-  def remove_compilation_timestamp_path
-    Webpacker.compiler.send(:compilation_timestamp_path).tap do |path|
-      path.delete if path.exist?
-    end
-  end
-
-  def setup
-    remove_compilation_timestamp_path
-  end
-
-  def teardown
-    remove_compilation_timestamp_path
-  end
-
   def test_custom_environment_variables
     assert_nil Webpacker.compiler.send(:webpack_env)["FOO"]
     Webpacker.compiler.env["FOO"] = "BAR"
@@ -50,10 +36,6 @@ class CompilerTest < Minitest::Test
       Webpacker.compiler.compile
       assert Webpacker.compiler.fresh?
     end
-  end
-
-  def test_compilation_timestamp_path
-    assert_equal Webpacker.compiler.send(:compilation_timestamp_path).basename.to_s, "last-compilation-timestamp-#{Webpacker.env}"
   end
 
   def test_external_env_variables

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -9,33 +9,48 @@ class CompilerTest < Minitest::Test
     Webpacker.compiler.env = {}
   end
 
-  def test_freshness
-    assert Webpacker.compiler.stale?
-    assert !Webpacker.compiler.fresh?
+  def setup
+    @manifest_timestamp = Time.parse("2021-01-01 12:34:56 UTC")
+  end
+
+  def with_stubs(latest_timestamp:, manifest_exists: true, &proc)
+    @latest_timestamp = latest_timestamp
+
+    Webpacker.compiler.stub :latest_modified_timestamp, @latest_timestamp do
+      FileTest.stub :exist?, manifest_exists do
+        File.stub :mtime, @manifest_timestamp do
+          yield proc
+        end
+      end
+    end
+  end
+
+  def test_freshness_when_manifest_missing
+    latest_timestamp = @manifest_timestamp + 3600
+
+    with_stubs(latest_timestamp: latest_timestamp.to_i, manifest_exists: false) do
+      assert Webpacker.compiler.stale?
+    end
+  end
+
+  def test_freshness_when_manifest_older
+    latest_timestamp = @manifest_timestamp + 3600
+
+    with_stubs(latest_timestamp: latest_timestamp.to_i) do
+      assert Webpacker.compiler.stale?
+    end
+  end
+
+  def test_freshness_when_manifest_newer
+    latest_timestamp = @manifest_timestamp - 3600
+
+    with_stubs(latest_timestamp: latest_timestamp.to_i) do
+      assert Webpacker.compiler.fresh?
+    end
   end
 
   def test_compile
     assert !Webpacker.compiler.compile
-  end
-
-  def test_freshness_on_compile_success
-    status = OpenStruct.new(success?: true)
-
-    assert Webpacker.compiler.stale?
-    Open3.stub :capture3, [:sterr, :stdout, status] do
-      Webpacker.compiler.compile
-      assert Webpacker.compiler.fresh?
-    end
-  end
-
-  def test_freshness_on_compile_fail
-    status = OpenStruct.new(success?: false)
-
-    assert Webpacker.compiler.stale?
-    Open3.stub :capture3, [:sterr, :stdout, status] do
-      Webpacker.compiler.compile
-      assert Webpacker.compiler.fresh?
-    end
   end
 
   def test_external_env_variables

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -13,11 +13,11 @@ class CompilerTest < Minitest::Test
     @manifest_timestamp = Time.parse("2021-01-01 12:34:56 UTC")
   end
 
-  def with_stubs(latest_timestamp:, manifest_exists: true, &proc)
+  def with_stubs(latest_timestamp:, manifest_exists: true)
     Webpacker.compiler.stub :latest_modified_timestamp, latest_timestamp do
       FileTest.stub :exist?, manifest_exists do
         File.stub :mtime, @manifest_timestamp do
-          yield proc
+          yield
         end
       end
     end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -14,9 +14,7 @@ class CompilerTest < Minitest::Test
   end
 
   def with_stubs(latest_timestamp:, manifest_exists: true, &proc)
-    @latest_timestamp = latest_timestamp
-
-    Webpacker.compiler.stub :latest_modified_timestamp, @latest_timestamp do
+    Webpacker.compiler.stub :latest_modified_timestamp, latest_timestamp do
       FileTest.stub :exist?, manifest_exists do
         File.stub :mtime, @manifest_timestamp do
           yield proc


### PR DESCRIPTION
Rather than calculating and storing digest for the assets, we can try and just check for the latest modified file in the paths we're watching.

This PR removes the digest calculation logic and instead finds and stores modified time of the last updated file. This is still stored in the cache directory after compilation and used for freshness comparison.

Would be great to have some bigger repo to benchmark, but on fairly small sized app, the timestamp is obviously much quicker than calculating digests. Both are reasonably quick but every little helps!