### PR TITLE
Put back config.public_manifest_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+## [v6.2.1] - April 15, 2022
+### Fixed
+- Put back config.public_manifest_path, removed in 6.2.0 in PR 78. [PR 104](https://github.com/shakacode/shakapacker/pull/104) by [justin808](https://github.com/justin808).
+
 ## [v6.2.0] - March 22, 2022
 
 ### Added

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -47,6 +47,10 @@ class Webpacker::Configuration
     end
   end
 
+  def public_manifest_path
+    manifest_path
+  end
+
   def public_path
     root_path.join(fetch(:public_root_path))
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -38,6 +38,11 @@ class ConfigurationTest < Webpacker::Test
     assert_equal @config.public_output_path.to_s, public_output_path
   end
 
+  def test_public_manifest_path
+    public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
+    assert_equal @config.public_manifest_path.to_s, public_manifest_path
+  end
+
   def test_manifest_path
     manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
     assert_equal @config.manifest_path.to_s, manifest_path


### PR DESCRIPTION
Fixes #103.

See test run: https://github.com/shakacode/react_on_rails/runs/6036261442?check_suite_focus=true

https://github.com/shakacode/react_on_rails/blob/master/lib/react_on_rails/webpacker_utils.rb#L53-L55

refers to 
```ruby
Webpacker.config.public_manifest_path.exist?
```

We need to put back the method (maybe with a warning that it's deprecated and remove it for version 7?)


```
  def public_manifest_path
    manifest_path
  end
``` 