### PR TITLE
Remove "loose" mode from the default babel configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Breaking changes
+- Remove Loose mode from the default @babel-preset/env configuration. [PR 107](https://github.com/shakacode/shakapacker/pull/107) by [Jeremy Liberman](https://github.com/MrLeebo)
+
+  Loose mode compiles the bundle down to be compatible with ES5, but saves space by skipping over behaviors that are considered edge cases. Loose mode can affect how your code runs in a variety of ways, but in newer versions of Babel it's better to use [Compiler Assumptions](https://babeljs.io/docs/en/assumptions) to have finer-grained control over which edge cases you're choosing to ignore. 
+
+  This change may increase the file size of your bundles, and may change some behavior in your app if your code touches upon one of the edge cases where Loose mode differs from native JavaScript. There are notes in the linked PR about how to turn Loose mode back on if you need to, but consider migrating to Compiler Assumptions when you can. If you have already customized your babel config, this change probably won't affect you.
+
 ## [v6.2.1] - April 15, 2022
 ### Fixed
 - Put back config.public_manifest_path, removed in 6.2.0 in PR 78. [PR 104](https://github.com/shakacode/shakapacker/pull/104) by [justin808](https://github.com/justin808).

--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -25,7 +25,6 @@ module.exports = function config(api) {
           corejs: '3.8',
           modules: 'auto',
           bugfixes: true,
-          loose: true,
           exclude: ['transform-typeof-symbol']
         }
       ],


### PR DESCRIPTION
Fixes #106. This is a potentially breaking change for users who have coded around the loose mode behaviors already, so there should probably be a note in the release notes about how to get the original config back if you need to--essentially the workaround from #106, only in reverse:

```js
// babel.config.js
module.exports = function (api) {
  // fetch the default babel config
  const defaultConfigFunc = require("shakapacker/package/babel/preset.js");
  const resultConfig = defaultConfigFunc(api);

  // you can either re-enable "loose" mode to bring back the original behavior, or use "assumptions" 
  // to manage which edge cases you are ignoring on a more fine-grain level. Enabling all assumptions
  // is equivalent to turning "loose" mode back on.

  // to enable "loose" mode, add "loose: true" to the options of the "@babel/preset-env" preset:

  // "@babel/preset-env" is always the 1st preset
  const [[, options]] = resultConfig.presets;
  options.loose = true;

  // otherwise, activate the assumptions you need from https://babeljs.io/docs/en/assumptions
  resultConfig.assumptions = {
    arrayLikeIsIterable: true
  };

  // you can also make any other babel config changes that you need here
  return resultConfig;
};
```