### PR TITLE
updated webpack-dev-server to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack": "^5.72.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.8.1",
+    "webpack-dev-server": "^4.9.0",
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
Bumping up the version for webpack-dev-server to 4.9.0 -- All known vulnerabilities have been eliminated in this version.