### PR TITLE
Fix backslash in CSS urls on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Fixed
+- On Windows CSS urls no longer contain backslashes resulting in 404 errors. [PR 115](https://github.com/shakacode/shakapacker/pull/115) by [daniel-rikowski](https://github.com/daniel-rikowski).
+
 ## [v6.3.0-rc.1] - April 24, 2024
 
 Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions/6.3.0.pre.rc.1) and [NPM is 6.3.0-rc.1](https://www.npmjs.com/package/shakapacker/v/6.3.0-rc.1).

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,4 +1,4 @@
-const { dirname, join } = require('path')
+const { dirname } = require('path')
 const { source_path: sourcePath } = require('../config')
 
 module.exports = {
@@ -12,7 +12,7 @@ module.exports = {
         .split('/')
         .slice(1)
 
-      const foldersWithStatic = join('static', ...folders)
+      const foldersWithStatic = ['static', ...folders].join('/')
       return `${foldersWithStatic}/[name]-[hash][ext][query]`
     }
   }


### PR DESCRIPTION
Do not use path.join because it introduces backslashes on Windows platforms. Fixes #114 .