### PR TITLE
Updated Nokogiri gem to fix vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails"
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
 gem "semantic_range", require: false
+gem "nokogiri", ">= 1.13.6"
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails"
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
 gem "semantic_range", require: false
-gem "nokogiri", ">= 1.13.6"
+gem "nokogiri", "~> 1.13", ">= 1.13.6"
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ DEPENDENCIES
   bundler (>= 1.3.0)
   byebug
   minitest (~> 5.0)
-  nokogiri (>= 1.13.6)
+  nokogiri (~> 1.13, >= 1.13.6)
   rack-proxy
   rails
   rake (>= 11.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,16 +87,14 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.1)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     nio4r (2.5.8)
-    nokogiri (1.12.4)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-proxy (0.7.0)
       rack
@@ -171,6 +169,7 @@ DEPENDENCIES
   bundler (>= 1.3.0)
   byebug
   minitest (~> 5.0)
+  nokogiri (>= 1.13.6)
   rack-proxy
   rails
   rake (>= 11.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,13 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
     nio4r (2.5.8)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.2.0)
@@ -164,6 +168,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler (>= 1.3.0)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack": "^5.72.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.8.1",
+    "webpack-dev-server": "^4.9.0",
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
the current version of nokogiri has a serious vulnerability and must be upgraded. 

https://nvd.nist.gov/vuln/detail/CVE-2022-29181