### PR TITLE
Add additional platforms to Gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,10 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -167,7 +171,9 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Follow up from https://github.com/shakacode/shakapacker/pull/129

Adds additional platforms so native Nokogiri platform can be pulled in if applicable