### PR TITLE
Address configuration incompatibility with rake

### DIFF
--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -11,13 +11,11 @@ namespace :webpacker do
   end
 end
 
-if Webpacker.config.webpacker_precompile?
-  # Run clean if the assets:clean is run
-  if Rake::Task.task_defined?("assets:clean")
-    Rake::Task["assets:clean"].enhance do
-      Rake::Task["webpacker:clean"].invoke
-    end
-  else
-    Rake::Task.define_task("assets:clean" => "webpacker:clean")
+# Run clean if the assets:clean is run
+if Rake::Task.task_defined?("assets:clean")
+  Rake::Task["assets:clean"].enhance do
+    Rake::Task["webpacker:clean"].invoke
   end
+else
+  Rake::Task.define_task("assets:clean" => "webpacker:clean")
 end

--- a/lib/tasks/webpacker/clobber.rake
+++ b/lib/tasks/webpacker/clobber.rake
@@ -8,11 +8,9 @@ namespace :webpacker do
   end
 end
 
-if Webpacker.config.webpacker_precompile?
-  # Run clobber if the assets:clobber is run
-  if Rake::Task.task_defined?("assets:clobber")
-    Rake::Task["assets:clobber"].enhance do
-      Rake::Task["webpacker:clobber"].invoke
-    end
+# Run clobber if the assets:clobber is run
+if Rake::Task.task_defined?("assets:clobber")
+  Rake::Task["assets:clobber"].enhance do
+    Rake::Task["webpacker:clobber"].invoke
   end
 end

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -25,10 +25,8 @@ namespace :webpacker do
   end
 end
 
-if Webpacker.config.webpacker_precompile?
-  if Rake::Task.task_defined?("assets:precompile")
-    enhance_assets_precompile
-  else
-    Rake::Task.define_task("assets:precompile" => ["webpacker:compile"])
-  end
+if Rake::Task.task_defined?("assets:precompile")
+  enhance_assets_precompile
+else
+  Rake::Task.define_task("assets:precompile" => ["webpacker:compile"])
 end

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -16,6 +16,7 @@ class Webpacker::Commands
   #   age=600.
   #
   def clean(count = 2, age = 3600)
+    return unless config.webpacker_precompile?
     if config.public_output_path.exist? && config.manifest_path.exist?
       packs
         .map do |paths|
@@ -40,15 +41,18 @@ class Webpacker::Commands
   end
 
   def clobber
+    return unless config.webpacker_precompile?
     config.public_output_path.rmtree if config.public_output_path.exist?
     config.cache_path.rmtree if config.cache_path.exist?
   end
 
   def bootstrap
+    return unless config.webpacker_precompile?
     manifest.refresh
   end
 
   def compile
+    return unless config.webpacker_precompile?
     compiler.compile.tap do |success|
       manifest.refresh if success
     end


### PR DESCRIPTION
Resolves #123 by moving the conditional check on `Webpacker::Configuration.webpacker_precompile?` out of the rake tasks & into the `clean`, `clobber`, & `compile` commands.

This changes means that the Rails` default `assets` rake tasks will always be enhanced & that `webpacker:verify_install` will be ran as a prereq for `webpacker:clean` & `webpacker:compile` (but not `webpacker:clobber`?).

Seems like a small detail, but I believe it qualifies as a breaking change.