### PR TITLE
Only compile if no compilation is currently already in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changes since last non-beta release.
 ### Added
 - `append_stylesheet_pack_tag` helper. It helps in configuring stylesheet pack names from the view for a route or partials. It is also required for filesystem-based automated Component Registry API on React on Rails gem. [PR 144](https://github.com/shakacode/shakapacker/pull/144) by [pulkitkkr](https://github.com/pulkitkkr).
 
+### Fixed
+- Make sure at most one compilation runs at a time (#139).
+
 _Please add entries here for your pull requests that are not yet released._
 
 ## [v6.4.1] - June 5, 2022

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -14,6 +14,11 @@ class Webpacker::Compiler
   end
 
   def compile
+    if compiling?
+      sleep 0.5
+      return compile
+    end
+
     if stale?
       run_webpack.tap do |success|
         after_compile_hook
@@ -26,6 +31,15 @@ class Webpacker::Compiler
 
   private
     attr_reader :webpacker
+
+    def compiling?
+      # Parallel testing workers assume that the compilation is performed by the 0th worker
+      stale? && current_process_is_parallel_worker?
+    end
+
+    def current_process_is_parallel_worker?
+      `ps -f -p #{Process.pid}`.chomp.match?(/Rails test worker [1-9]\d*/)
+    end
 
     def optionalRubyRunner
       bin_webpack_path = config.root_path.join("bin/webpacker")


### PR DESCRIPTION
When rails tests are run in parallel, multiple `webpack` compilations are kicked off at the same time.
This is _really_ resource intensive and slow.

For example, with 4 workers, `rails test:system` starts 4 webpack compilations:

Before:
![2022-06-03_16-57](https://user-images.githubusercontent.com/23721/171879651-7d058a79-f83d-464d-8c51-85a43cdc1ec5.png)

After:
![2022-06-03_18-07](https://user-images.githubusercontent.com/23721/171903968-9ce0aa0f-413f-4a96-9125-a2f92e57c381.png)


