### PR TITLE
Bring back automatic yarn install run with deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+- Restores automatic installation of yarn packages removed in [#131](https://github.com/shakacode/shakapacker/pull/131), with added deprecation notice. [PR 140](https://github.com/shakacode/shakapacker/pull/140) by [tomdracz](https://github.com/tomdracz).
+
+  This will be again removed in Shakapacker v7 so you need to ensure you are installing yarn packages explicitly before the asset compilation, rather than relying on this behaviour through `asset:precompile` task (e.g. Capistrano deployment).
+
 ## [v6.4.0] - June 2, 2022
 ### Fixed
 - Fixed [Issue 123: Rails 7.0.3 - Webpacker configuration file not found when running rails webpacker:install (shakapacker v6.3)](https://github.com/shakacode/shakapacker/issues/123) in [PR 136: Don't enhance precompile if no config #136](https://github.com/shakacode/shakapacker/pull/136) by [justin808](https://github.com/justin808).

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -1,8 +1,16 @@
 $stdout.sync = true
 
+def yarn_install_available?
+  rails_major = Rails::VERSION::MAJOR
+  rails_minor = Rails::VERSION::MINOR
+
+  rails_major > 5 || (rails_major == 5 && rails_minor >= 1)
+end
+
 def enhance_assets_precompile
   # yarn:install was added in Rails 5.1
-  Rake::Task["assets:precompile"].enhance do |task|
+  deps = yarn_install_available? ? [] : ["webpacker:yarn_install"]
+  Rake::Task["assets:precompile"].enhance(deps) do |task|
     prefix = task.name.split(/#|assets:precompile/).first
 
     Rake::Task["#{prefix}webpacker:compile"].invoke
@@ -29,6 +37,6 @@ if Webpacker.config.webpacker_precompile?
   if Rake::Task.task_defined?("assets:precompile")
     enhance_assets_precompile
   else
-    Rake::Task.define_task("assets:precompile" => ["webpacker:compile"])
+    Rake::Task.define_task("assets:precompile" => ["webpacker:yarn_install", "webpacker:compile"])
   end
 end

--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -6,7 +6,7 @@ namespace :webpacker do
       Automatic installation of yarn packages when assets are precompiled is deprecated and will be removed in Shakapacker v7.
       Please ensure you are installing yarn packages explicitly before the asset compilation.
     MSG
-    
+
     valid_node_envs = %w[test development production]
     node_env = ENV.fetch("NODE_ENV") do
       valid_node_envs.include?(Rails.env) ? Rails.env : "production"

--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -1,0 +1,24 @@
+namespace :webpacker do
+  desc "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn"
+  task :yarn_install do
+    warn <<~MSG.strip
+      Shakapacker - Automatic installation of yarn packages is deprecated
+      Automatic installation of yarn packages when assets are precompiled is deprecated and will be removed in Shakapacker v7.
+      Please ensure you are installing yarn packages explicitly before the asset compilation.
+    MSG
+    
+    valid_node_envs = %w[test development production]
+    node_env = ENV.fetch("NODE_ENV") do
+      valid_node_envs.include?(Rails.env) ? Rails.env : "production"
+    end
+    Dir.chdir(Rails.root) do
+      yarn_flags =
+        if `yarn --version`.start_with?("1")
+          "--no-progress --frozen-lockfile"
+        else
+          "--immutable"
+        end
+      system({ "NODE_ENV" => node_env }, "yarn install #{yarn_flags}")
+    end
+  end
+end

--- a/lib/tasks/yarn.rake
+++ b/lib/tasks/yarn.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Duplicate of the yarn tasks still present in Rails until Webpacker <5 have been deprecated
+
+namespace :yarn do
+  desc "Install all JavaScript dependencies as specified via Yarn"
+  task :install do
+    begin
+      # Install only production deps when for not usual envs.
+      valid_node_envs = %w[test development production]
+      node_env = ENV.fetch("NODE_ENV") do
+        valid_node_envs.include?(Rails.env) ? Rails.env : "production"
+      end
+
+      yarn_flags =
+        if `#{RbConfig.ruby} "#{Rails.root}/bin/yarn" --version`.start_with?("1")
+          "--no-progress --frozen-lockfile"
+        else
+          "--immutable"
+        end
+
+      system(
+        { "NODE_ENV" => node_env },
+        "#{RbConfig.ruby} \"#{Rails.root}/bin/yarn\" install #{yarn_flags}",
+        exception: true
+      )
+    rescue Errno::ENOENT
+      $stderr.puts "bin/yarn was not found."
+      $stderr.puts "Please run `bundle exec rails app:update:bin` to create it."
+      exit 1
+    end
+  end
+end
+
+# Run Yarn prior to Sprockets assets precompilation, so dependencies are available for use.
+if Rake::Task.task_defined?("assets:precompile") && File.exist?(Rails.root.join("bin", "yarn"))
+  warn <<~MSG.strip
+    Shakapacker - Automatic installation of yarn packages is deprecated
+    Automatic installation of yarn packages when assets are precompiled is deprecated and will be removed in Shakapacker v7.
+    Please ensure you are installing yarn packages explicitly before the asset compilation.
+  MSG
+
+  Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
+end


### PR DESCRIPTION
Restores behaviour removed in #131 and adds deprecation notice as we should only remove this in Shakapacker v7