### PR TITLE
Don't run Spring in erb loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _Please add entries here for your pull requests that are not yet released._
 
   This will be again removed in Shakapacker v7 so you need to ensure you are installing yarn packages explicitly before the asset compilation, rather than relying on this behaviour through `asset:precompile` task (e.g. Capistrano deployment).
 
+- Disable Spring from being used by `rails-erb-loader`. [PR 141](https://github.com/shakacode/shakapacker/pull/141) by [tomdracz](https://github.com/tomdracz).
+
 ## [v6.4.0] - June 2, 2022
 ### Fixed
 - Fixed [Issue 123: Rails 7.0.3 - Webpacker configuration file not found when running rails webpacker:install (shakapacker v6.3)](https://github.com/shakacode/shakapacker/issues/123) in [PR 136: Don't enhance precompile if no config #136](https://github.com/shakacode/shakapacker/pull/136) by [justin808](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _Please add entries here for your pull requests that are not yet released._
 
   This will be again removed in Shakapacker v7 so you need to ensure you are installing yarn packages explicitly before the asset compilation, rather than relying on this behaviour through `asset:precompile` task (e.g. Capistrano deployment).
 
-- Disable Spring from being used by `rails-erb-loader`. [PR 141](https://github.com/shakacode/shakapacker/pull/141) by [tomdracz](https://github.com/tomdracz).
+- Disable Spring being used by `rails-erb-loader`. [PR 141](https://github.com/shakacode/shakapacker/pull/141) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.4.0] - June 2, 2022
 ### Fixed

--- a/package/rules/erb.js
+++ b/package/rules/erb.js
@@ -9,7 +9,13 @@ module.exports = canProcess('rails-erb-loader', (resolvedPath) => ({
   use: [
     {
       loader: resolvedPath,
-      options: { runner: `${runner}bin/rails runner` }
+      options: {
+        runner: `${runner}bin/rails runner`,
+        env: {
+          ...process.env,
+          DISABLE_SPRING: 1
+        }
+      }
     }
   ]
 }))


### PR DESCRIPTION
Fixes #137 

Reference https://github.com/usabilityhub/rails-erb-loader/issues/63

Running `rails-erb-loader` through runner with spring enabled is likely to cause random issues and failures. This will now pass `DISABLE_SPRING` env to runner explicitly in order to skip Spring being used