### PR TITLE
Run bundle install after release-it version bump

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "after:bump": "bundle install"
+  }
+}


### PR DESCRIPTION
Fixes #128 

Hooks into `release-it` command lifecycle and runs bundle install command after version bump