### PR TITLE
Add Append StyleSheet Pack Tag Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,36 +249,43 @@ While this also generally applies to `stylesheet_pack_tag`, you may use multiple
 <%= stylesheet_pack_tag 'print', media: 'print' %>
 ```
 
-#### View Helper `append_javascript_pack_tag`
+#### View Helper `append_javascript_pack_tag` and `append_stylesheet_pack_tag`
 
-If you need configure your script pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helper `append_javascript_pack_tag` can solve this problem. This helper will queue up script packs when the `javascript_pack_tag` is finally used.
+If you need configure your script pack names or stylesheet pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helpers, `append_javascript_pack_tag` and `append_stylesheet_pack_tag` can solve this problem. The helper `append_javascript_pack_tag` will queue up script packs when the `javascript_pack_tag` is finally used. Similarly,`append_stylesheet_pack_tag` will queue up style packs when the `stylesheet_pack_tag` is finally used.
 
 Main view:
 ```erb
 <% append_javascript_pack_tag 'calendar' %>
+<% append_stylesheet_pack_tag 'calendar' %>
 ```
 
 Some partial:
 ```erb
 <% append_javascript_pack_tag 'map' %>
+<% append_stylesheet_pack_tag 'map' %>
 ```
 
 And the main layout has:
 ```erb
 <%= javascript_pack_tag 'application' %>
+<%= stylesheet_pack_tag 'application' %>
 ```
 
 is the same as using this in the main layout:
 
 ```erb
 <%= javascript_pack_tag 'calendar', 'map', application' %>
+<%= stylesheet_pack_tag 'calendar', 'map', application' %>
 ```
+
 
 However, you typically can't do that in the main layout, as the view and partial codes will depend on the route.
 
 Thus, you can distribute the logic of what packs are needed for any route. All the magic of splitting up the code was automatic!
 
 **Important:** `append_javascript_pack_tag` can be used anywhere in your application as long as it is executed BEFORE the `javascript_pack_tag`. If you attempt to call `append_javascript_pack_tag` helper after `javascript_pack_tag`, an error will be raised. You should have only a single `javascript_pack_tag` invocation in your page load.
+
+**Important** Similar to `append_javascript_pack_tag`, the `append_stylesheet_pack_tag` should be used anywhere in your application as long as it is executed BEFORE the `stylesheet_pack_tag`. However, if you attempt to call `append_stylesheet_pack_tag` helper after `stylesheet_pack_tag`, an error will be **NOT** be raised.
                                                                                                     
 The typical issue is that your layout might reference some partials that need to configure packs. A good way to solve this problem is to use `content_for` to ensure that the code to render your partial comes before the call to `javascript_pack_tag`.
 
@@ -292,34 +299,6 @@ The typical issue is that your layout might reference some partials that need to
 ```
 
 For alternative options of setting the additional packs, [see this discussion](https://github.com/shakacode/shakapacker/issues/39).
-
-#### View Helper append_stylesheet_pack_tag
-If you need configure your stylesheet pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helper append_stylesheet_pack_tag can solve this problem. This helper will queue up packs when the stylesheet_pack_tag is finally used.
-
-Main view:
-```erb
-<% append_stylesheet_pack_tag 'calendar' %>
-```
-
-Some partial:
-```erb
-<% append_stylesheet_pack_tag 'map' %>
-```
-
-And the main layout has:
-```erb
-<%= stylesheet_pack_tag 'application' %>
-```
-
-is the same as using this in the main layout:
-
-```erb
-<%= stylesheet_pack_tag 'calendar', 'map', application' %>
-```
-
-However, you typically can't do that in the main layout, as the view and partial codes will depend on the route.
-
-Thus, you can distribute the logic of what packs are needed for any route. All the magic of splitting up the code was automatic!
 
 #### View Helper: `asset_pack_path`
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ While this also generally applies to `stylesheet_pack_tag`, you may use multiple
 
 #### View Helper `append_javascript_pack_tag`
 
-If you need configure your pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helper `append_javascript_pack_tag` can solve this problem. This helper will queue up packs when the `javascript_pack_tag` is finally used.
+If you need configure your script pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helper `append_javascript_pack_tag` can solve this problem. This helper will queue up script packs when the `javascript_pack_tag` is finally used.
 
 Main view:
 ```erb
@@ -292,6 +292,34 @@ The typical issue is that your layout might reference some partials that need to
 ```
 
 For alternative options of setting the additional packs, [see this discussion](https://github.com/shakacode/shakapacker/issues/39).
+
+#### View Helper append_stylesheet_pack_tag
+If you need configure your stylesheet pack names from the view for a route or partials, then you will need some logic to ensure you call the helpers only once with multiple arguments. The new view helper append_stylesheet_pack_tag can solve this problem. This helper will queue up packs when the stylesheet_pack_tag is finally used.
+
+Main view:
+```erb
+<% append_stylesheet_pack_tag 'calendar' %>
+```
+
+Some partial:
+```erb
+<% append_stylesheet_pack_tag 'map' %>
+```
+
+And the main layout has:
+```erb
+<%= stylesheet_pack_tag 'application' %>
+```
+
+is the same as using this in the main layout:
+
+```erb
+<%= stylesheet_pack_tag 'calendar', 'map', application' %>
+```
+
+However, you typically can't do that in the main layout, as the view and partial codes will depend on the route.
+
+Thus, you can distribute the logic of what packs are needed for any route. All the magic of splitting up the code was automatic!
 
 #### View Helper: `asset_pack_path`
 

--- a/README.md
+++ b/README.md
@@ -278,10 +278,9 @@ is the same as using this in the main layout:
 <%= stylesheet_pack_tag 'calendar', 'map', application' %>
 ```
 
-
 However, you typically can't do that in the main layout, as the view and partial codes will depend on the route.
 
-Thus, you can distribute the logic of what packs are needed for any route. All the magic of splitting up the code was automatic!
+Thus, you can distribute the logic of what packs are needed for any route. All the magic of splitting up the code and CSS was automatic!
 
 **Important:** `append_javascript_pack_tag` can be used anywhere in your application as long as it is executed BEFORE the `javascript_pack_tag`. If you attempt to call `append_javascript_pack_tag` helper after `javascript_pack_tag`, an error will be raised. You should have only a single `javascript_pack_tag` invocation in your page load.
 

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -158,7 +158,26 @@ module Webpacker::Helper
   def stylesheet_pack_tag(*names, **options)
     return "" if Webpacker.inlining_css?
 
+    if @stylesheet_pack_tag_loaded
+      raise "To prevent duplicated stylesheet on the page, you should call stylesheet_pack_tag only once on the page. " \
+      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
+    end
+
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)
+    appended_stylesheets = sources_from_manifest_entrypoints(@stylesheet_pack_tag_queue || [], type: :stylesheet)
+
+    @stylesheet_pack_tag_loaded = true
+
+    stylesheet_link_tag(*appended_stylesheets, **options)
+  end
+
+  def append_stylesheet_pack_tag(*names)
+    if @stylesheet_pack_tag_loaded
+      raise "You can only call append_stylesheet_pack_tag before stylesheet_pack_tag helper. " \
+      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
+    end
+
+    @stylesheet_pack_tag_queue = names
   end
 
   def append_javascript_pack_tag(*names, defer: true)

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -168,10 +168,7 @@ module Webpacker::Helper
 
     @stylesheet_pack_tag_loaded = true
 
-    capture do
-      concat stylesheet_link_tag(*requested_packs, **options)
-      concat stylesheet_link_tag(*appended_packs, **options)
-    end
+    stylesheet_link_tag(*(requested_packs | appended_packs), **options)
   end
 
   def append_stylesheet_pack_tag(*names)

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -158,11 +158,6 @@ module Webpacker::Helper
   def stylesheet_pack_tag(*names, **options)
     return "" if Webpacker.inlining_css?
 
-    if @stylesheet_pack_tag_loaded
-      puts "To prevent duplicated stylesheet on the page, you should call stylesheet_pack_tag only once on the page. " \
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
-    end
-
     requested_packs = sources_from_manifest_entrypoints(names, type: :stylesheet)
     appended_packs = available_sources_from_manifest_entrypoints(@stylesheet_pack_tag_queue || [], type: :stylesheet)
 

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -159,16 +159,19 @@ module Webpacker::Helper
     return "" if Webpacker.inlining_css?
 
     if @stylesheet_pack_tag_loaded
-      raise "To prevent duplicated stylesheet on the page, you should call stylesheet_pack_tag only once on the page. " \
+      puts "To prevent duplicated stylesheet on the page, you should call stylesheet_pack_tag only once on the page. " \
       "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
     end
 
-    stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)
-    appended_stylesheets = sources_from_manifest_entrypoints(@stylesheet_pack_tag_queue || [], type: :stylesheet)
+    requested_packs = sources_from_manifest_entrypoints(names, type: :stylesheet)
+    appended_packs = available_sources_from_manifest_entrypoints(@stylesheet_pack_tag_queue || [], type: :stylesheet)
 
     @stylesheet_pack_tag_loaded = true
 
-    stylesheet_link_tag(*appended_stylesheets, **options)
+    capture do
+      concat stylesheet_link_tag(*requested_packs, **options)
+      concat stylesheet_link_tag(*appended_packs, **options)
+    end
   end
 
   def append_stylesheet_pack_tag(*names)
@@ -177,7 +180,8 @@ module Webpacker::Helper
       "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#usage for the usage guide"
     end
 
-    @stylesheet_pack_tag_queue = names
+    @stylesheet_pack_tag_queue ||= []
+    @stylesheet_pack_tag_queue.concat names
   end
 
   def append_javascript_pack_tag(*names, defer: true)
@@ -201,6 +205,10 @@ module Webpacker::Helper
 
     def sources_from_manifest_entrypoints(names, type:)
       names.map { |name| current_webpacker_instance.manifest.lookup_pack_with_chunks!(name.to_s, type: type) }.flatten.uniq
+    end
+
+    def available_sources_from_manifest_entrypoints(names, type:)
+      names.map { |name| current_webpacker_instance.manifest.lookup_pack_with_chunks(name.to_s, type: type) }.flatten.compact.uniq
     end
 
     def resolve_path_to_image(name, **options)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -205,4 +205,21 @@ class HelperTest < ActionView::TestCase
       hello_stimulus_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stimulus_style
   end
+
+  def test_stylesheet_pack_with_append
+    append_stylesheet_pack_tag(:hello_stimulus)
+
+    assert_equal \
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
+      stylesheet_pack_tag(:application)
+  end
+
+  def test_stylesheet_pack_with_duplicate_append
+    append_stylesheet_pack_tag(:hello_stimulus)
+    append_stylesheet_pack_tag(:application)
+
+    assert_equal \
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
+      stylesheet_pack_tag(:application)
+  end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -244,10 +244,5 @@ class HelperTest < ActionView::TestCase
     assert_equal \
       hello_stimulus_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk, media: "all") }.join("\n"),
       hello_stimulus_style_with_media
-
-    assert_nothing_raised do
-      stylesheet_pack_tag(:application)
-      stylesheet_pack_tag(:application, media: "print")
-    end
   end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -204,6 +204,11 @@ class HelperTest < ActionView::TestCase
     assert_equal \
       hello_stimulus_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stimulus_style
+
+    assert_nothing_raised do
+      stylesheet_pack_tag(:application)
+      stylesheet_pack_tag(:hello_stimulus)
+    end
   end
 
   def test_stylesheet_pack_with_append
@@ -224,6 +229,22 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_multiple_stylesheet_pack_with_different_media_attr
+    app_style = stylesheet_pack_tag(:application)
+    app_style_with_media = stylesheet_pack_tag(:application, media: "print")
+    hello_stimulus_style_with_media = stylesheet_pack_tag(:hello_stimulus, media: "all")
+
+    assert_equal \
+      application_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
+      app_style
+
+    assert_equal \
+      application_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk, media: "print") }.join("\n"),
+      app_style_with_media
+
+    assert_equal \
+      hello_stimulus_stylesheet_chunks.map { |chunk| stylesheet_link_tag(chunk, media: "all") }.join("\n"),
+      hello_stimulus_style_with_media
+
     assert_nothing_raised do
       stylesheet_pack_tag(:application)
       stylesheet_pack_tag(:application, media: "print")

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -222,4 +222,11 @@ class HelperTest < ActionView::TestCase
       (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq.map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stylesheet_pack_tag(:application)
   end
+
+  def test_multiple_stylesheet_pack_with_different_media_attr
+    assert_nothing_raised do
+      stylesheet_pack_tag(:application)
+      stylesheet_pack_tag(:application, media: "print")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
To add stylesheets for the new filesystem-based Component Registry API, We need a stylesheet to append helper. This PR Adds the` stylesheet_append_tag` helper to Shakapacker Codebase