### PR TITLE
Stop rescuing connection issues

### DIFF
--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -18,8 +18,6 @@ class Webpacker::DevServer
     else
       false
     end
-  rescue
-    false
   end
 
   def host


### PR DESCRIPTION
I think it's reasonable to assume that if the config file has a
`dev_server` section then it's expected that the webpack dev server is
running therefore any issues connecting should be raised as an
exception. Curious to know what others think though.

My personal experience with this was my computer taking more than 10ms
(using the original webpacker gem) to open the TCP socket and the
timeout error was swallowed by this `rescue`. Consequently it took me
quite some digging to figure out what was going on.