### PR TITLE
Add accessor method for `nested_entries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Please add entries here for your pull requests that are not yet released._
 - `append_javascript_pack_tag` and `append_stylesheet_pack_tag` helpers return `nil` to prevent rendering the queue into view when using `<%= … %>` ERB syntax. [PR 167](https://github.com/shakacode/shakapacker/pull/167) by [ur5us](https://github.com/ur5us)
 - fix non-runnable test due to wrong code nesting [PR 173](https://github.com/shakacode/shakapacker/pull/173) by [ur5us](https://github.com/ur5us)
 - fix default configurations not working for custom Rails environments [PR 168](https://github.com/shakacode/shakapacker/pull/168) by [ur5us](https://github.com/ur5us)
+- Add accessor method for `nested_entries` configuration. [PR 176](https://github.com/shakacode/shakapacker/pull/176) by [pulkitkkr](https://github.com/pulkitkkr)
 
 ## [v6.5.0] - July 4, 2022
 ### Added

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -23,6 +23,10 @@ class Webpacker::Configuration
     fetch(:compile)
   end
 
+  def nested_entries?
+    fetch(:nested_entries)
+  end
+
   def ensure_consistent_versioning?
     fetch(:ensure_consistent_versioning)
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -90,6 +90,18 @@ class ConfigurationTest < Webpacker::Test
     end
   end
 
+  def test_nested_entries?
+    refute @config.nested_entries?
+
+    with_rails_env("development") do
+      refute Webpacker.config.nested_entries?
+    end
+
+    with_rails_env("test") do
+      refute Webpacker.config.nested_entries?
+    end
+  end
+
   def test_ensure_consistent_versioning?
     refute @config.ensure_consistent_versioning?
 


### PR DESCRIPTION
## Summary
React on Rails requires access to the `nested_entries` shakapacker configuration for file-system-based automated bundle generation feature to handle misc edge-cases. This PR adds an accessor method for the `nested_entries` attribute.