### PR TITLE
Change NODE_ENV defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
+- Fixed NODE_ENV default and moved it from binstubs to the runner [PR 185](https://github.com/shakacode/shakapacker/pull/185) by [mage1711](https://github.com/mage1711).
 
 ## [v6.5.1] - August 15, 2022
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ Note, if you are using server-side rendering of JavaScript with dynamic code-spl
 ### Development
 
 Webpacker ships with two binstubs: `./bin/webpacker` and `./bin/webpacker-dev-server`. Both are thin wrappers around the standard `webpack.js` and `webpack-dev-server.js` executables to ensure that the right configuration files and environmental variables are loaded based on your environment.
-The setting of the NODE_ENV should be removed from the binstubs.
+
+Older Shakapacker installations had the setting of a missing NODE_ENV in the binstubs as the default per RAILS_ENV, it is no longer set there.
 
 #### Automatic Webpack Code Building
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Note, if you are using server-side rendering of JavaScript with dynamic code-spl
 ### Development
 
 Webpacker ships with two binstubs: `./bin/webpacker` and `./bin/webpacker-dev-server`. Both are thin wrappers around the standard `webpack.js` and `webpack-dev-server.js` executables to ensure that the right configuration files and environmental variables are loaded based on your environment.
+The setting of the NODE_ENV should be removed from the binstubs.
 
 #### Automatic Webpack Code Building
 

--- a/lib/install/bin/webpacker
+++ b/lib/install/bin/webpacker
@@ -6,7 +6,7 @@ require "webpacker"
 require "webpacker/webpack_runner"
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
+ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
 
 APP_ROOT = File.expand_path("..", __dir__)

--- a/lib/install/bin/webpacker
+++ b/lib/install/bin/webpacker
@@ -6,7 +6,6 @@ require "webpacker"
 require "webpacker/webpack_runner"
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
 
 APP_ROOT = File.expand_path("..", __dir__)

--- a/lib/install/bin/webpacker-dev-server
+++ b/lib/install/bin/webpacker-dev-server
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
+ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",

--- a/lib/install/bin/webpacker-dev-server
+++ b/lib/install/bin/webpacker-dev-server
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -2,7 +2,7 @@ module Webpacker
   class Runner
     def self.run(argv)
       $stdout.sync = true
-
+      ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "development"
       new(argv).run
     end
 


### PR DESCRIPTION
changed NODE_ENV defaults from

```ruby
ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
```
to
```ruby
ENV['NODE_ENV'] ||= (ENV['RAILS_ENV'] == production) ? 'production' : 'development'
```
