### PR TITLE
Remove #192 introduce extra split() call.

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -73,7 +73,7 @@ const getPlugins = () => {
     plugins.push(
       new MiniCssExtractPlugin({
         filename: `css/[name]${hash}.css`,
-        chunkFilename: `css/[id]${hash}.css`.split(),
+        chunkFilename: `css/[id]${hash}.css`,
         // For projects where css ordering has been mitigated through consistent use of scoping or naming conventions,
         // the css order warnings can be disabled by setting the ignoreOrder flag.
         // Read: https://stackoverflow.com/questions/51971857/mini-css-extract-plugin-warning-in-chunk-chunkname-mini-css-extract-plugin-con


### PR DESCRIPTION
It will cause below error if not removed.


```log
─▪ bin/webpacker-dev-server 
[webpack-cli] Failed to load '/Users/guochunzhong/git/shin/pagila-rails-portal/config/webpack/webpack.config.js' config
[webpack-cli] Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
 - options.chunkFilename should be one of these:
   non-empty string | function
   -> This option determines the name of non-entry chunk files.
   -> Read more at https://github.com/webpack-contrib/mini-css-extract-plugin#chunkfilename
   Details:
    * options.chunkFilename should be a non-empty string.
    * options.chunkFilename should be an instance of function.
```