### PR TITLE
Use correct name of mini-css-extract-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 - Make manifest_path configurable, to keep manifest.json private if desired. [PR 78](https://github.com/shakacode/shakapacker/pull/78) by [jdelStrother](https://github.com/jdelStrother).
 - Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan).
 - Initialization check to ensure shakapacker gem and NPM package version are consistent. Opt-in behaviour enabled by setting `ensure_consistent_versioning` configuration variable. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
-- Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-extract-css-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald).
+- Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-css-extract-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald).
 
 ### Improved
 - Increase default connect timeout for dev server connections, establishing connections more reliably for busy machines. [PR 74](https://github.com/shakacode/shakapacker/pull/74) by [stevecrozz](https://github.com/stevecrozz).

--- a/docs/style_loader_vs_mini_css.md
+++ b/docs/style_loader_vs_mini_css.md
@@ -31,7 +31,7 @@ style-loader is how you are probably are used to serving CSS in development with
 * Adds an extra dependency
 * Divergence in delivery mechanism from production
 
-## Why would I pick mini-extract-css-plugin?
+## Why would I pick mini-css-extract-plugin?
 
 mini-css-extract-plugin's behavior is much more true to a production deployment's behavior, in that CSS is loaded via `link rel=stylsheet` tags, rather than injected by Javascript into `style` tags.
 

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -58,10 +58,10 @@ development:
     # If HMR is on, CSS will by inlined by delivering it as part of the script payload via style-loader. Be sure
     # that you add style-loader to your project dependencies.
     #
-    # If you want to instead deliver CSS via <link> with the mini-extract-css-plugin, set inline_css to false.
+    # If you want to instead deliver CSS via <link> with the mini-css-extract-plugin, set inline_css to false.
     # In that case, style-loader is not needed as a dependency.
     #
-    # mini-extract-css-plugin is a required dependency in both cases.
+    # mini-css-extract-plugin is a required dependency in both cases.
     inline_css: true
     # Defaults to the inverse of hmr. Uncomment to manually set this.
     # live_reload: true


### PR DESCRIPTION
The docs and comments use "mini-extract-css-plugin" name sometimes where "mini-css-extract-plugin" was meant. This fixes these four places.

I know it's nitpicky, but it actually lands in generated `webpacker.yml` and I was confused for a moment why I cannot install `mini-extract-css-plugin` because it does not exist (opens a possibility of name squatting as well).