### PR TITLE
Allow babel-loader 9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Improved
 - Allow webpack-cli v5 [PR 216](https://github.com/shakacode/shakapacker/pull/216) by [tagliala](https://github.com/tagliala).
+- Allow babel-loader v9 [PR 215](https://github.com/shakacode/shakapacker/pull/215) by [tagliala](https://github.com/tagliala).
 
 ## [v6.5.4] - November 4, 2022
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/runtime": "^7.17.9",
-    "babel-loader": "^8.2.4",
+    "babel-loader": "^8.2.4 || ^9.0.0",
     "compression-webpack-plugin": "^9.0.0 || ^10.0.0",
     "terser-webpack-plugin": "^5.3.1",
     "webpack": "^5.72.0",


### PR DESCRIPTION
Keep using babel-loader 8.x for development to avoid dropping support for Node 12

Close #196

---

### Disclaimer ⚠️ 

I've tested with a local application by running `npm pack` and referencing shakapacker as `"file:../shakapacker/shakapacker-6.5.4.tgz"` in `package.json`. I'm not a javascript developer, so I may miss something important, please double check