### PR TITLE
Fix bin/setup modification failure in installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
+### Fixed
+- Fixed failing to update `bin/setup` file due to different formats of the file in different versions of Rails. [PR229](https://github.com/shakacode/shakapacker/pull/229) by [ahangarha](https://github.com/ahangarha)
 
 ## [v6.5.5] - December 28, 2022
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -36,26 +36,30 @@ else
   say %(        Add <%= javascript_pack_tag "application" %> within the <head> tag in your custom layout.)
 end
 
+# Ensure there is `system!("bin/yarn")` command in `./bin/setup` file
 if (setup_path = Rails.root.join("bin/setup")).exist?
   say "Run bin/yarn during bin/setup"
 
   if File.read(setup_path).match? Regexp.escape("  # system('bin/yarn')\n")
-    gsub_file(setup_path, "# system('bin/yarn')", 'system!("bin/yarn")')
+    gsub_file(setup_path, "# system('bin/yarn')", "system!('bin/yarn')")
   else
     # Due to the inconsistency of quotation usage in Rails 7 compared to
     # earlier versions, we check both single and double quotations here.
     pattern = /system\(['"]bundle check['"]\) \|\| system!\(['"]bundle install['"]\)\n/
 
-    if File.read(setup_path).match? pattern
-      insert_into_file(setup_path.to_s, <<-RUBY, after: pattern)
+    string_to_add = <<-RUBY
 
   # Install JavaScript dependencies
   system!("bin/yarn")
 RUBY
+
+    if File.read(setup_path).match? pattern
+      insert_into_file(setup_path, string_to_add, after: pattern)
     else
       say <<~MSG, :red
         It seems your `bin/setup` file doesn't have the expected content.
-        Please review the file and manually add `system!("bin/yarn")`.
+        Please review the file and manually add `system!("bin/yarn")` before any
+        other command that requires JavaScript dependencies being already installed.
       MSG
     end
   end

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -40,22 +40,22 @@ if (setup_path = Rails.root.join("bin/setup")).exist?
   say "Run bin/yarn during bin/setup"
 
   if File.read(setup_path).match? Regexp.escape("  # system('bin/yarn')\n")
-    gsub_file setup_path, "# system('bin/yarn')", 'system! "bin/yarn"'
+    gsub_file(setup_path, "# system('bin/yarn')", 'system!("bin/yarn")')
   else
     # Due to the inconsistency of quotation usage in Rails 7 compared to
     # earlier versions, we check both single and double quotations here.
     pattern = /system\(['"]bundle check['"]\) \|\| system!\(['"]bundle install['"]\)\n/
 
     if File.read(setup_path).match? pattern
-      insert_into_file setup_path.to_s, <<-RUBY, after: pattern
+      insert_into_file(setup_path.to_s, <<-RUBY, after: pattern)
 
   # Install JavaScript dependencies
-  system! "bin/yarn"
+  system!("bin/yarn")
 RUBY
     else
       say <<~MSG, :red
         It seems your `bin/setup` file doesn't have the expected content.
-        Please review the file and manually add `system! "bin/yarn"`.
+        Please review the file and manually add `system!("bin/yarn")`.
       MSG
     end
   end


### PR DESCRIPTION
Due to different content of `bin/setup` in different Rails versions, the earlier version of the generator couldn't modify this file properly in all circumstances.

This commit handles the following scenarios:
- If there is a commented line for `system('bin/yarn')`, uncomment it.
- Otherwise, regardless of using single or double quotations in different Rails versions, add `system! 'bin/yarn'` after the intended line.

I have manually checked the impact of this PR on the following Rails versions:
- `5.2.8`: where we already have commented `system('bin/yarn')`
- `6.1.7`: where we have `system('bundle check') || system!('bundle install')`
- `7.0.4`: where we have `system("bundle check") || system!("bundle install")`

closes #226 