### PR TITLE
Fix broken CI due to version of Rubygems

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,9 @@ jobs:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
           - gemfiles/Gemfile-rails.7.0.x
-          - gemfiles/Gemfile-rails-edge
+          # Uncomment the following line only to ensure compatibility with the
+          # upcomming Rails versions, maybe before a release.
+          #- gemfiles/Gemfile-rails-edge
         exclude:
           - ruby: 2.6
             os: ubuntu-latest


### PR DESCRIPTION
Set Rubygems to use version 3.3.13 in CI.

It seems our test for edge version of Rails causes this issue. Rails 7.1.0-alpha depends on Rubygems 3.3.13 and since this version is not installed by default, we get into such a break.

More info: https://github.com/rails/rails/commit/3aa32f2176389d563deff0c799198378666d9f17