### PR TITLE
fixed babel configuration for #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ _Please add entries here for your pull requests that are not yet released._
 
 - Added `prepend_javascript_pack_tag` to helpers. Allows to move an entry to the top of queue. Handy when calling from the layout to make sure an entry goes before the view and partial `append_javascript_pack_tag` entries. [PR 235](https://github.com/shakacode/shakapacker/pull/235) by [paypro-leon](https://github.com/paypro-leon).
 
+## [6.5.6] - January 30, 2023
+### Fixed
+- Fixed [issue](https://github.com/shakacode/shakapacker/issues/208) to support directories under `node_modules/*` in the `additional_paths` property of `webpacker.yml` [PR 238](https://github.com/shakacode/shakapacker/pull/238) by [vaukalak](https://github.com/vaukalak).
+
 ## [6.5.6] - January 15, 2023
 ### Fixed
 - Remove duplicate yarn installs. [PR 238](https://github.com/shakacode/shakapacker/pull/238) by [justin808](https://github/justin808).

--- a/package.json
+++ b/package.json
@@ -41,13 +41,19 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.26.0",
     "jest": "^28.1.3",
+    "memory-fs": "^0.5.0",
     "swc-loader": "^0.1.15",
+    "thenify": "^3.3.1",
     "webpack": "^5.72.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-merge": "^5.8.0"
   },
   "jest": {
     "testRegex": "(/__tests__/.*|(\\.|/))\\.jsx?$",
+    "testPathIgnorePatterns": [
+      "/__fixtures__/",
+      "/__utils__/"
+    ],
     "roots": [
       "<rootDir>/package"
     ]

--- a/package/rules/__tests__/__utils__/webpack.js
+++ b/package/rules/__tests__/__utils__/webpack.js
@@ -1,0 +1,50 @@
+const webpack = require("webpack");
+const MemoryFS = require("memory-fs");
+const thenify = require("thenify");
+const path = require("path");
+
+const createTrackLoader = () => {
+  const filesTracked = {};
+  return [
+    filesTracked,
+    (source) => {
+      filesTracked[source.resource] = true;
+      return source;
+    },
+  ];
+};
+
+const node_modules = path.resolve("node_modules");
+const node_modules_included = path.resolve("node_modules/included");
+const app_javascript = path.resolve("app/packs");
+
+const createInMemoryFs = () => {
+  const fs = new MemoryFS();
+
+  fs.mkdirpSync(node_modules);
+  fs.mkdirpSync(node_modules_included);
+  fs.mkdirpSync(app_javascript);
+
+  return fs;
+};
+
+const createTestCompiler = (config, fs = createInMemoryFs()) => {
+  Object.values(config.entry).forEach((file) => {
+    fs.writeFileSync(file, "console.log(1);");
+  });
+
+  const compiler = webpack(config);
+  compiler.run = thenify(compiler.run);
+  compiler.inputFileSystem = fs;
+  compiler.outputFileSystem = fs;
+  return compiler;
+};
+
+module.exports = {
+  createTrackLoader,
+  node_modules,
+  node_modules_included,
+  app_javascript,
+  createInMemoryFs,
+  createTestCompiler,
+};

--- a/package/rules/__tests__/babel.js
+++ b/package/rules/__tests__/babel.js
@@ -1,0 +1,63 @@
+const path = require("path");
+const {
+  app_javascript,
+  node_modules,
+  node_modules_included,
+  createTestCompiler,
+  createTrackLoader,
+} = require("./__utils__/webpack");
+const babelConfig = require("../babel");
+
+jest.mock("../../config", () => {
+  const original = jest.requireActual("../../config");
+  return {
+    ...original,
+    additional_paths: [...original.additional_paths, "node_modules/included"],
+  };
+});
+
+const createWebpackConfig = (file, use) => {
+  return {
+    entry: { file },
+    module: {
+      rules: [
+        {
+          ...babelConfig,
+          use,
+        },
+      ],
+    },
+    output: {
+      path: "/",
+      filename: "scripts-bundled.js",
+    },
+  };
+};
+
+describe("babel", () => {
+  test("process source path", async () => {
+    const normalPath = `${app_javascript}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(
+      createWebpackConfig(normalPath, loader)
+    );
+    await compiler.run();
+    expect(tracked[normalPath]).toBeTruthy();
+  });
+
+  test("exclude node_modules", async () => {
+    const ignored = `${node_modules}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(ignored, loader));
+    await compiler.run();
+    expect(tracked[ignored]).toBeUndefined();
+  });
+
+  test("explicitly included node_modules should be transpiled", async () => {
+    const included = `${node_modules_included}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(included, loader));
+    await compiler.run();
+    expect(tracked[included]).toBeTruthy();
+  });
+});

--- a/package/rules/__tests__/esbuild.js
+++ b/package/rules/__tests__/esbuild.js
@@ -1,0 +1,64 @@
+const path = require("path");
+const {
+  app_javascript,
+  node_modules,
+  node_modules_included,
+  createTestCompiler,
+  createTrackLoader,
+} = require("./__utils__/webpack");
+const esbuildConfig = require("../esbuild");
+
+jest.mock("../../config", () => {
+  const original = jest.requireActual("../../config");
+  return {
+    ...original,
+    webpack_loader: "esbuild",
+    additional_paths: [...original.additional_paths, "node_modules/included"],
+  };
+});
+
+const createWebpackConfig = (file, use) => {
+  return {
+    entry: { file },
+    module: {
+      rules: [
+        {
+          ...esbuildConfig,
+          use,
+        },
+      ],
+    },
+    output: {
+      path: "/",
+      filename: "scripts-bundled.js",
+    },
+  };
+};
+
+describe("swc", () => {
+  test("process source path", async () => {
+    const normalPath = `${app_javascript}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(
+      createWebpackConfig(normalPath, loader)
+    );
+    await compiler.run();
+    expect(tracked[normalPath]).toBeTruthy();
+  });
+
+  test("exclude node_modules", async () => {
+    const ignored = `${node_modules}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(ignored, loader));
+    await compiler.run();
+    expect(tracked[ignored]).toBeUndefined();
+  });
+
+  test("explicitly included node_modules should be transpiled", async () => {
+    const included = `${node_modules_included}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(included, loader));
+    await compiler.run();
+    expect(tracked[included]).toBeTruthy();
+  });
+});

--- a/package/rules/__tests__/index.js
+++ b/package/rules/__tests__/index.js
@@ -4,8 +4,4 @@ describe('index', () => {
   test('rule tests are regexes', () => {
     rules.forEach(rule => expect(rule.test instanceof RegExp).toBe(true))
   })
-
-  test('rule excludes are regexes', () => {
-    rules.forEach(rule => expect(rule.exclude instanceof RegExp).toBe(true))
-  })
 })

--- a/package/rules/__tests__/swc.js
+++ b/package/rules/__tests__/swc.js
@@ -1,0 +1,64 @@
+const path = require("path");
+const {
+  app_javascript,
+  node_modules,
+  node_modules_included,
+  createTestCompiler,
+  createTrackLoader,
+} = require("./__utils__/webpack");
+const swcConfig = require("../swc");
+
+jest.mock("../../config", () => {
+  const original = jest.requireActual("../../config");
+  return {
+    ...original,
+    webpack_loader: "swc",
+    additional_paths: [...original.additional_paths, "node_modules/included"],
+  };
+});
+
+const createWebpackConfig = (file, use) => {
+  return {
+    entry: { file },
+    module: {
+      rules: [
+        {
+          ...swcConfig,
+          use,
+        },
+      ],
+    },
+    output: {
+      path: "/",
+      filename: "scripts-bundled.js",
+    },
+  };
+};
+
+describe("swc", () => {
+  test("process source path", async () => {
+    const normalPath = `${app_javascript}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(
+      createWebpackConfig(normalPath, loader)
+    );
+    await compiler.run();
+    expect(tracked[normalPath]).toBeTruthy();
+  });
+
+  test("exclude node_modules", async () => {
+    const ignored = `${node_modules}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(ignored, loader));
+    await compiler.run();
+    expect(tracked[ignored]).toBeUndefined();
+  });
+
+  test("explicitly included node_modules should be transpiled", async () => {
+    const included = `${node_modules_included}/a.js`;
+    const [tracked, loader] = createTrackLoader();
+    const compiler = createTestCompiler(createWebpackConfig(included, loader));
+    await compiler.run();
+    expect(tracked[included]).toBeTruthy();
+  });
+});

--- a/package/rules/babel.js
+++ b/package/rules/babel.js
@@ -1,24 +1,13 @@
-const { resolve } = require('path')
-const { realpathSync } = require('fs')
 const { loaderMatches } = require('../utils/helpers')
-
 const {
-  source_path: sourcePath,
-  additional_paths: additionalPaths,
   webpack_loader: webpackLoader
 } = require('../config')
 const { isProduction } = require('../env')
+const jscommon = require('./jscommon')
 
 module.exports = loaderMatches(webpackLoader, 'babel', () => ({
     test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
-    include: [sourcePath, ...additionalPaths].map((p) => {
-      try {
-        return realpathSync(p)
-      } catch (e) {
-        return resolve(p)
-      }
-    }),
-    exclude: /node_modules/,
+    ...jscommon,
     use: [
       {
         loader: require.resolve('babel-loader'),
@@ -29,4 +18,4 @@ module.exports = loaderMatches(webpackLoader, 'babel', () => ({
         }
       }
     ]
-  }))
+}))

--- a/package/rules/esbuild.js
+++ b/package/rules/esbuild.js
@@ -1,23 +1,12 @@
-const { resolve } = require('path')
-const { realpathSync } = require('fs')
 const { loaderMatches } = require('../utils/helpers')
 const { getEsbuildLoaderConfig } = require('../esbuild')
-
 const {
-  source_path: sourcePath,
-  additional_paths: additionalPaths,
   webpack_loader: webpackLoader
 } = require('../config')
+const jscommon = require('./jscommon')
 
 module.exports = loaderMatches(webpackLoader, 'esbuild', () => ({
   test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
-  include: [sourcePath, ...additionalPaths].map((p) => {
-    try {
-      return realpathSync(p)
-    } catch (e) {
-      return resolve(p)
-    }
-  }),
-  exclude: /node_modules/,
+  ...jscommon,
   use: ({ resource }) => getEsbuildLoaderConfig(resource)
 }))

--- a/package/rules/jscommon.js
+++ b/package/rules/jscommon.js
@@ -1,0 +1,26 @@
+const { resolve } = require('path')
+const { realpathSync } = require('fs')
+const {
+    source_path: sourcePath,
+    additional_paths: additionalPaths
+} = require('../config')
+
+const inclusions = [sourcePath, ...additionalPaths].map(p => {
+    try {
+        return realpathSync(p)
+    } catch (e) {
+        return resolve(p)
+    }
+})
+
+module.exports = {
+    include: inclusions,
+    exclude: [
+        {
+            // exclude all node_modules from running through babel-loader
+            and: [resolve('node_modules')],
+            // Do not exclude inclusions, as otherwise these won't be transpiled
+            not: [...inclusions]
+        }
+    ]
+}

--- a/package/rules/swc.js
+++ b/package/rules/swc.js
@@ -1,23 +1,12 @@
-const { resolve } = require('path')
-const { realpathSync } = require('fs')
 const { loaderMatches } = require('../utils/helpers')
 const { getSwcLoaderConfig } = require('../swc')
-
 const {
-  source_path: sourcePath,
-  additional_paths: additionalPaths,
   webpack_loader: webpackLoader
 } = require('../config')
+const jscommon = require('./jscommon')
 
 module.exports = loaderMatches(webpackLoader, 'swc', () => ({
   test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
-  include: [sourcePath, ...additionalPaths].map((p) => {
-    try {
-      return realpathSync(p)
-    } catch (e) {
-      return resolve(p)
-    }
-  }),
-  exclude: /node_modules/,
+  ...jscommon,
   use: ({ resource }) => getSwcLoaderConfig(resource)
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,6 +1145,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
 anymatch@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
@@ -1514,6 +1519,11 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.2.tgz#c10bffdc3028d25c2aae505819a05543db61544f"
   integrity sha512-Lb+/XT4WC4PaCWWtZpNPaXmjiNDUe5CJuUtbkMrIM1kb1T/jJoAIp+bkVP/r5lHzMr+ZAAF8XHp7+my6Ol0ysQ==
 
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1640,6 +1650,13 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+errno@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"
+  integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
+  dependencies:
+    prr "~1.0.1"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2360,7 +2377,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2499,6 +2516,11 @@ is-weakref@^1.0.2:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3125,6 +3147,14 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+memory-fs@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
+  integrity sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3434,6 +3464,11 @@ pretty-format@^28.1.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -3456,6 +3491,11 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+  integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -3477,6 +3517,19 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+readable-stream@^2.0.1:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"
@@ -3558,7 +3611,7 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3759,6 +3812,13 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -3884,6 +3944,13 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+thenify@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -3957,6 +4024,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
In specific scenarios, you would need to transpile some of `node_modules`. This addition allows to specify `node_modules` to include via `webpacker.yml => additional_paths` configuration.

closes #208 