### PR TITLE
Allow configuration of webpacker.yml through env variable

### DIFF
--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -1,10 +1,12 @@
+require "pathname"
 class Webpacker::Instance
   cattr_accessor(:logger) { ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT)) }
 
   attr_reader :root_path, :config_path
 
   def initialize(root_path: Rails.root, config_path: Rails.root.join("config/webpacker.yml"))
-    @root_path, @config_path = root_path, config_path
+    @root_path = root_path
+    @config_path = Pathname.new(ENV["WEBPACKER_CONFIG"] || config_path)
   end
 
   def env

--- a/spec/webpacker_spec.rb
+++ b/spec/webpacker_spec.rb
@@ -33,6 +33,28 @@ describe "Webpacker" do
     end
   end
 
+  describe "configurable config" do
+    before do
+      @original_webpacker_config = ENV["WEBPACKER_CONFIG"]
+    end
+
+    after do
+      ENV["WEBPACKER_CONFIG"] = @original_webpacker_config
+    end
+
+    it "allows config file to be changed based on ENV variable" do
+      ENV.delete("WEBPACKER_CONFIG")
+      Webpacker.instance = nil
+      expect(Webpacker.config.config_path.to_s).to eq(Rails.root.join("config/webpacker.yml").to_s)
+    end
+
+    it "allows config file to be changed based on ENV variable" do
+      ENV["WEBPACKER_CONFIG"] = "/some/random/path.yml"
+      Webpacker.instance = nil
+      expect(Webpacker.config.config_path.to_s).to eq("/some/random/path.yml")
+    end
+  end
+
   it "has app_autoload_paths cleanup" do
     expect($test_app_autoload_paths_in_initializer).to eq []
   end


### PR DESCRIPTION
While working on implementing shakapacker to Decidim, i have came across a small issue that prevented me to continue upgrading.
At Decidim we have a runtime that allows us to inject paths dynamically to webpacker config, saving a new YAML file in the app's tmp folder. Unfortunately neither webpack, nor Shakapacker allows dynamic configuration. 

The functionality has implemented a while back in Webpacker  via [#2990](https://github.com/rails/webpacker/pull/2990), yet the Rails app is reading the default config. As running in Rails context, the`Webpacker.config` always returns the full path of `config/webpacker.yml`

Relevant files from #2990
https://github.com/shakacode/shakapacker/blob/4c92e2a956c443233a6f00b65df7db67b5cfb2ba/lib/webpacker/runner.rb#L12-L15

