### PR TITLE
Set CSS modules mode depending on file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
+### Improved
+- Set CSS modules mode depending on file type. [PR 261](https://github.com/shakacode/shakapacker/pull/261) by [talyuk](https://github.com/talyuk).
 
 ## [v6.6.0] - March 7, 2023
 ### Improved
@@ -22,7 +24,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 - Fixed [issue](https://github.com/shakacode/shakapacker/issues/208) to support directories under `node_modules/*` in the `additional_paths` property of `webpacker.yml` [PR 240](https://github.com/shakacode/shakapacker/pull/240) by [vaukalak](https://github.com/vaukalak).
 - Remove duplicate yarn installs. [PR 238](https://github.com/shakacode/shakapacker/pull/238) by [justin808](https://github/justin808).
-- Remove unneeded code related to CSP config for generator. [PR 223](https://github.com/shakacode/shakapacker/pull/223) by [ahangarha](https://github/ahangarha). 
+- Remove unneeded code related to CSP config for generator. [PR 223](https://github.com/shakacode/shakapacker/pull/223) by [ahangarha](https://github/ahangarha).
 
 ## [v6.5.5] - December 28, 2022
 

--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -20,7 +20,7 @@ const getStyleRule = (test, preprocessors = []) => {
           sourceMap: true,
           importLoaders: 2,
           modules: {
-            mode: 'auto'
+            auto: true
           }
         }
       },

--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -2,8 +2,6 @@
 const { canProcess, moduleExists } = require('./helpers')
 const inliningCss = require('../inliningCss')
 
-const isModuleFile = (filename) => !!filename.match(/\.module\.\w+(\.erb)?$/i)
-
 const getStyleRule = (test, preprocessors = []) => {
   if (moduleExists('css-loader')) {
     const tryPostcss = () =>
@@ -22,7 +20,7 @@ const getStyleRule = (test, preprocessors = []) => {
           sourceMap: true,
           importLoaders: 2,
           modules: {
-            mode: resourcePath => isModuleFile(resourcePath) ? 'local' : 'icss'
+            mode: 'auto'
           }
         }
       },

--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -2,6 +2,8 @@
 const { canProcess, moduleExists } = require('./helpers')
 const inliningCss = require('../inliningCss')
 
+const isModuleFile = (filename) => !!filename.match(/\.module\.\w+(\.erb)?$/i)
+
 const getStyleRule = (test, preprocessors = []) => {
   if (moduleExists('css-loader')) {
     const tryPostcss = () =>
@@ -18,7 +20,10 @@ const getStyleRule = (test, preprocessors = []) => {
         loader: require.resolve('css-loader'),
         options: {
           sourceMap: true,
-          importLoaders: 2
+          importLoaders: 2,
+          modules: {
+            mode: resourcePath => isModuleFile(resourcePath) ? 'local' : 'icss'
+          }
         }
       },
       tryPostcss(),


### PR DESCRIPTION
### Summary
Set CSS modules mode to `icss` if a style file is not a module, `local` otherwise. It allows using `ICSS` features such as `:import` and `:export` without using further `CSS Module` functionality. ICSS features were applied by default to all files before `css-loader@v4`, but it's been changed in the next versions. (Please refer to `css-loader` [example](https://github.com/webpack-contrib/css-loader#separating-interoperable-css-only-and-css-module-features))