### PR TITLE
[Docs] Update turbolinks references to turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,16 +234,16 @@ packs with the chunks in your view, which creates html tags for all the chunks.
 You can provide multiple packs and other attributes. Note, `defer` defaults to showing.
 
 ```erb
-<%= javascript_pack_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %>
+<%= javascript_pack_tag 'calendar', 'map', 'data-turbo-track': 'reload' %>
 ```
 
 The resulting HTML would look like:
 ```
-<script src="/packs/vendor-16838bab065ae1e314.js" data-turbolinks-track="reload" defer></script>
-<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload" defer></script>
-<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload" defer"></script>
-<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload" defer></script>
-<script src="/packs/map-16838bab065ae1e314.js" data-turbolinks-track="reload" defer></script>
+<script src="/packs/vendor-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
+<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
+<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbo-track="reload" defer"></script>
+<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
+<script src="/packs/map-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
 ```
 
 In this output, both the calendar and map codes might refer to other common libraries. Those get placed something like the vendor bundle. The view helper removes any duplication.


### PR DESCRIPTION
### Summary

[Closes #264]

The [turbolinks](https://github.com/turbolinks/turbolinks) project isn't maintained anymore, so the docs needed updating to refer to refer to `@hotwired/turbo-rails` instead: https://github.com/hotwired/turbo-rails

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [X] Update documentation
- [ ] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._

### Other Information

N/A
