### PR TITLE
Remove redundant code for enhancing precompile task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Please add entries here for your pull requests that are not yet released._
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
 
+### Removed
+- Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).
+
 ## [v6.6.0] - March 7, 2023
 ### Improved
 - Allow configuration of webpacker.yml through env variable. [PR 254](https://github.com/shakacode/shakapacker/pull/254) by [alecslupu](https://github.com/alecslupu).

--- a/lib/tasks/shakapacker/compile.rake
+++ b/lib/tasks/shakapacker/compile.rake
@@ -1,13 +1,5 @@
 $stdout.sync = true
 
-def enhance_assets_precompile
-  Rake::Task["assets:precompile"].enhance do |task|
-    prefix = task.name.split(/#|assets:precompile/).first
-
-    Rake::Task["#{prefix}shakapacker:compile"].invoke
-  end
-end
-
 namespace :shakapacker do
   desc "Compile JavaScript packs using webpack for production with digests"
   task compile: ["shakapacker:verify_install", :environment] do
@@ -24,14 +16,16 @@ namespace :shakapacker do
   end
 end
 
+def invoke_shakapacker_compile_in_assets_precompile_task
+  Rake::Task["assets:precompile"].enhance do |task|
+    prefix = task.name.split(/#|assets:precompile/).first
+
+    Rake::Task["#{prefix}shakapacker:compile"].invoke
+  end
+end
+
 if Shakapacker.config.shakapacker_precompile?
   if Rake::Task.task_defined?("assets:precompile")
-    # Rails already adds `yarn install` after 5.2
-    # https://github.com/shakacode/shakapacker/issues/237
-    enhance_assets_precompile
-  else
-    # Only add `yarn install` if Rails was not doing it (precompile was not defined).
-    # TODO: Remove this in Shakapacker 7.0
-    Rake::Task.define_task("assets:precompile" => ["shakapacker:yarn_install", "shakapacker:compile"])
+    invoke_shakapacker_compile_in_assets_precompile_task
   end
 end


### PR DESCRIPTION
### Summary

As per comments in the source code, we drop the feature to add `yarn:install` rake task.

### Pull Request checklist
- [x] ~Add/update test to cover these changes~ (Doesn't need)
- [x] ~Update documentation~ (Doesn't need)
- [x] Update CHANGELOG file  

---
Related Issue #237
Related PR #238 