### PR TITLE
Move compilation lock file into the working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _Please add entries here for your pull requests that are not yet released._
 
   `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
 
+### Improved
+- Move compilation lock file into the working directory. [PR 272](https://github.com/shakacode/shakapacker/pull/272) by [tomdracz](https://github.com/tomdracz).
+
 ## [v6.6.0] - March 7, 2023
 ### Improved
 - Allow configuration of webpacker.yml through env variable. [PR 254](https://github.com/shakacode/shakapacker/pull/254) by [alecslupu](https://github.com/alecslupu).

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -1,5 +1,6 @@
 require "open3"
 require "webpacker/compiler_strategy"
+require "fileutils"
 
 class Webpacker::Compiler
   # Additional environment variables that the compiler is being run with
@@ -55,10 +56,20 @@ class Webpacker::Compiler
     end
 
     def open_lock_file
-      lock_file_name = config.root_path.join("tmp/shakapacker.lock")
-      File.open(lock_file_name, File::CREAT) do |lf|
+      create_lock_file_dir unless File.exist?(lock_file_path)
+
+      File.open(lock_file_path, File::CREAT) do |lf|
         return yield lf
       end
+    end
+
+    def create_lock_file_dir
+      dirname = File.dirname(lock_file_path)
+      FileUtils.mkdir_p(dirname)
+    end
+
+    def lock_file_path
+      config.root_path.join("tmp/shakapacker.lock")
     end
 
     def optionalRubyRunner

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -55,7 +55,7 @@ class Webpacker::Compiler
     end
 
     def open_lock_file
-      lock_file_name = config.root_path.join('tmp/shakapacker.lock')
+      lock_file_name = config.root_path.join("tmp/shakapacker.lock")
       File.open(lock_file_name, File::CREAT) do |lf|
         return yield lf
       end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -55,7 +55,7 @@ class Webpacker::Compiler
     end
 
     def open_lock_file
-      lock_file_name = File.join(Dir.tmpdir, "shakapacker.lock")
+      lock_file_name = config.root_path.join('tmp/shakapacker.lock')
       File.open(lock_file_name, File::CREAT) do |lf|
         return yield lf
       end


### PR DESCRIPTION
### Summary

Fixes #158 

Potentially addresses #269 ?

Moves `shakapacker.lock` file from system tmp dir into project tmp directory.

### Pull Request checklist

- [x] Update CHANGELOG file  
