### PR TITLE
Remove @babel/preset-typescript defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Breaking changes
+- Removes defaults passed to `@babel/preset-typescript`. [PR 273](https://github.com/shakacode/shakapacker/pull/273) by [tomdracz](https://github.com/tomdracz).
+
+  `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
+
 ## [v6.6.0] - March 7, 2023
 ### Improved
 - Allow configuration of webpacker.yml through env variable. [PR 254](https://github.com/shakacode/shakapacker/pull/254) by [alecslupu](https://github.com/alecslupu).

--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -28,10 +28,7 @@ module.exports = function config(api) {
           exclude: ['transform-typeof-symbol']
         }
       ],
-      moduleExists('@babel/preset-typescript') && [
-        '@babel/preset-typescript',
-        { allExtensions: true, isTSX: true }
-      ]
+      moduleExists('@babel/preset-typescript') && '@babel/preset-typescript'
     ].filter(Boolean),
     plugins: [
       ['@babel/plugin-transform-runtime', { helpers: false }]


### PR DESCRIPTION
### Summary

Fixes #267 

I was thinking of doing something similar to SWC rules https://github.com/shakacode/shakapacker/blob/master/package/swc/index.js#L28-L33 but in the end decided it brings no value realistically.
The setting in SWC to figure out config from the file was added to go around the limitations there, Babel should be already correctly figuring out file types and behaviour from the extensions with the default preset settings.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by 

- [x] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._
