### PR TITLE
Fix js test failure due to wrong app_javascript value

### DIFF
--- a/package/rules/__tests__/__utils__/webpack.js
+++ b/package/rules/__tests__/__utils__/webpack.js
@@ -16,7 +16,7 @@ const createTrackLoader = () => {
 
 const node_modules = path.resolve("node_modules");
 const node_modules_included = path.resolve("node_modules/included");
-const app_javascript = path.resolve("app/packs");
+const app_javascript = path.resolve("app/javascript");
 
 const createInMemoryFs = () => {
   const fs = new MemoryFS();


### PR DESCRIPTION


### Summary

This value is now set to be included in the `source_path` entry in shakapacker config file (which is `app/javascript`)

### Pull Request checklist
- [x] ~Add/update test to cover these changes~ (doesn't need)
- [x] ~Update documentation~ (doesn't need)
- [x] ~Update CHANGELOG file~ (doesn't need)

### Other Information

This is already fixed in other PRs for version 7, but we need this here since we may have some other PRs for some releases on version 6.