### PR TITLE
Stop stripping top level dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ _Please add entries here for your pull requests that are not yet released._
 
   `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
 
-- Remove the arbitrary stripping of the top-level directory when generating static file paths [PR XX](https://github.com/shakacode/shakapacker/pull/XX) by [tomdracz](https://github.com/tomdracz).
+- Remove the arbitrary stripping of the top-level directory when generating static file paths. [PR 271](https://github.com/shakacode/shakapacker/pull/271) by [tomdracz](https://github.com/tomdracz).
 
   Prior to this change, top level directory of static assets like images and fonts was stripped. This meant that file in `app/javascript/images/image.png` would be output to `static/image.png` directory and could be referenced through helpers as `image_pack_tag("image.jpg")` or `image_pack_tag("static/image.jpg")`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,22 @@ _Please add entries here for your pull requests that are not yet released._
   - Deprecated `https` entry is removed from the default configuration file, allowing to set `server` or `https` as per the project requirements. For more detail, check Webpack documentation. The `https` entry can be effective only if there is no `server` entry in the config file.
   - `allowed_hosts` is now set to `auto` instead of `all` by default.
 
+- Removes defaults passed to `@babel/preset-typescript`. [PR 273](https://github.com/shakacode/shakapacker/pull/273) by [tomdracz](https://github.com/tomdracz).
+
+  `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
+
+- Remove the arbitrary stripping of the top-level directory when generating static file paths [PR XX](https://github.com/shakacode/shakapacker/pull/XX) by [tomdracz](https://github.com/tomdracz).
+
+  Prior to this change, top level directory of static assets like images and fonts was stripped. This meant that file in `app/javascript/images/image.png` would be output to `static/image.png` directory and could be referenced through helpers as `image_pack_tag("image.jpg")` or `image_pack_tag("static/image.jpg")`.
+
+  Going forward, the top level directory of static files will be retained so this will necessitate the update of file name references in asset helpers. In the example above, the file sourced from `app/javascript/images/image.png` will be now output to `static/images/image.png` and needs to be referenced as `image_pack_tag("images/image.jpg")` or `image_pack_tag("static/images/image.jpg")`.
+
 ### Removed
 - Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).
 
 ### Added
 - All standard Webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).    
+
 
 ## [v6.6.0] - March 7, 2023
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ _Please add entries here for your pull requests that are not yet released._
 
   `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
 
-- Remove the arbitrary stripping of the top-level directory when generating static file paths. [PR 271](https://github.com/shakacode/shakapacker/pull/271) by [tomdracz](https://github.com/tomdracz).
+- Remove the arbitrary stripping of the top-level directory when generating static file paths. [PR 283](https://github.com/shakacode/shakapacker/pull/283) by [tomdracz](https://github.com/tomdracz).
 
   Prior to this change, top level directory of static assets like images and fonts was stripped. This meant that file in `app/javascript/images/image.png` would be output to `static/image.png` directory and could be referenced through helpers as `image_pack_tag("image.jpg")` or `image_pack_tag("static/image.jpg")`.
 

--- a/package/rules/__tests__/file.js
+++ b/package/rules/__tests__/file.js
@@ -1,4 +1,5 @@
 const file = require('../file')
+const { source_path: sourcePath } = require('../../config');
 
 describe('file', () => {
   test('test expected file types', () => {
@@ -32,4 +33,22 @@ describe('file', () => {
     ]
     types.forEach(type => expect(file.exclude.test(type)).toBe(true))
   })
+
+  test('correct generated output path is returned for nested files', () => {
+    const pathData = {
+      filename: `${sourcePath}/images/image.svg`,
+    };
+    expect(file.generator.filename(pathData)).toEqual(
+      'static/images/[name]-[hash][ext][query]'
+    );
+  })
+
+  test('correct generated output path is returned for deeply nested files', () => {
+    const pathData = {
+      filename: `${sourcePath}/images/nested/deeply/image.svg`,
+    };
+    expect(file.generator.filename(pathData)).toEqual(
+      'static/images/nested/deeply/[name]-[hash][ext][query]'
+    );
+  });
 })

--- a/package/rules/__tests__/file.js
+++ b/package/rules/__tests__/file.js
@@ -34,6 +34,15 @@ describe('file', () => {
     types.forEach(type => expect(file.exclude.test(type)).toBe(true))
   })
 
+  test('correct generated output path is returned for top level files', () => {
+    const pathData = {
+      filename: `${sourcePath}/image.svg`,
+    };
+    expect(file.generator.filename(pathData)).toEqual(
+      'static/[name]-[hash][ext][query]'
+    );
+  });
+
   test('correct generated output path is returned for nested files', () => {
     const pathData = {
       filename: `${sourcePath}/images/image.svg`,

--- a/package/rules/__tests__/file.js
+++ b/package/rules/__tests__/file.js
@@ -1,5 +1,4 @@
 const file = require('../file')
-const { source_path: sourcePath } = require('../../config');
 
 describe('file', () => {
   test('test expected file types', () => {
@@ -36,7 +35,7 @@ describe('file', () => {
 
   test('correct generated output path is returned for top level files', () => {
     const pathData = {
-      filename: `${sourcePath}/image.svg`,
+      filename: 'app/javascript/image.svg',
     };
     expect(file.generator.filename(pathData)).toEqual(
       'static/[name]-[hash][ext][query]'
@@ -45,7 +44,7 @@ describe('file', () => {
 
   test('correct generated output path is returned for nested files', () => {
     const pathData = {
-      filename: `${sourcePath}/images/image.svg`,
+      filename: 'app/javascript/images/image.svg',
     };
     expect(file.generator.filename(pathData)).toEqual(
       'static/images/[name]-[hash][ext][query]'
@@ -54,7 +53,7 @@ describe('file', () => {
 
   test('correct generated output path is returned for deeply nested files', () => {
     const pathData = {
-      filename: `${sourcePath}/images/nested/deeply/image.svg`,
+      filename: 'app/javascript/images/nested/deeply/image.svg',
     };
     expect(file.generator.filename(pathData)).toEqual(
       'static/images/nested/deeply/[name]-[hash][ext][query]'

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -8,8 +8,9 @@ module.exports = {
   generator: {
     filename: (pathData) => {
       const folders = dirname(pathData.filename)
-        .replace(`${sourcePath}/`, '')
+        .replace(`${sourcePath}`, '')
         .split('/')
+        .filter(Boolean)
 
       const foldersWithStatic = ['static', ...folders].join('/')
       return `${foldersWithStatic}/[name]-[hash][ext][query]`

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -10,7 +10,6 @@ module.exports = {
       const folders = dirname(pathData.filename)
         .replace(`${sourcePath}/`, '')
         .split('/')
-        .slice(1)
 
       const foldersWithStatic = ['static', ...folders].join('/')
       return `${foldersWithStatic}/[name]-[hash][ext][query]`


### PR DESCRIPTION
### Summary
Fixes https://github.com/shakacode/shakapacker/issues/177

When generating file paths for static assets, a top level directory will no longer be stripped. Fixes also previously broken output of the files referenced from top level of the source directory and adds relevant tests.

This is a breaking change so best suited for v7 release
### Pull Request checklist


- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file  
