### PR TITLE
Improve source_entry_path robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ _Please add entries here for your pull requests that are not yet released._
 - Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility.
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
-- Set `source_entry_path` to relative `packs` rather absolute `/` in `webpacker.yml` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha)
+- Set `source_entry_path` to `packs` in`shakapacker.yml` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha).
+
+### Fixed
+- Process `source_entry_path` with values starting with `/` as a relative path to `source_path` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha).
 
 - Dev server configuration is modified to follow [webpack recommended configurations](https://webpack.js.org/configuration/dev-server/) for dev server. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha):
   - Deprecated `https` entry is removed from the default configuration file, allowing to set `server` or `https` as per the project requirements. For more detail, check Webpack documentation. The `https` entry can be effective only if there is no `server` entry in the config file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility.
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
-- Set `source_entry_path` to `packs` in`shakapacker.yml` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
+- Set `source_entry_path` to `packs` and `nested_entries` to `true` in`shakapacker.yml` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
 
 ### Fixed
 - Process `source_entry_path` with values starting with `/` as a relative path to `source_path` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility.
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
+- Set `source_entry_path` to relative `packs` rather absolute `/` in `webpacker.yml` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha)
 
 - Dev server configuration is modified to follow [webpack recommended configurations](https://webpack.js.org/configuration/dev-server/) for dev server. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha):
   - Deprecated `https` entry is removed from the default configuration file, allowing to set `server` or `https` as per the project requirements. For more detail, check Webpack documentation. The `https` entry can be effective only if there is no `server` entry in the config file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ _Please add entries here for your pull requests that are not yet released._
 - Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility.
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
-- Set `source_entry_path` to `packs` in`shakapacker.yml` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha).
+- Set `source_entry_path` to `packs` in`shakapacker.yml` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
 
 ### Fixed
-- Process `source_entry_path` with values starting with `/` as a relative path to `source_path` [PR 205](https://github.com/shakacode/shakapacker/pull/205) by [ahangarha](https://github.com/ahangarha).
+- Process `source_entry_path` with values starting with `/` as a relative path to `source_path` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
 
 - Dev server configuration is modified to follow [webpack recommended configurations](https://webpack.js.org/configuration/dev-server/) for dev server. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha):
   - Deprecated `https` entry is removed from the default configuration file, allowing to set `server` or `https` as per the project requirements. For more detail, check Webpack documentation. The `https` entry can be effective only if there is no `server` entry in the config file.

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -5,7 +5,7 @@ default: &default
 
   # You can have a subdirectory of the source_path, like 'packs' (recommended).
   # Alternatively, you can use '/' to use the whole source_path directory.
-  source_entry_path: /
+  source_entry_path: packs
 
   # If nested_entries is true, then we'll pick up subdirectories within the source_entry_path.
   # You cannot set this option to true if you set source_entry_path to '/'

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -10,7 +10,7 @@ default: &default
 
   # If nested_entries is true, then we'll pick up subdirectories within the source_entry_path.
   # You cannot set this option to true if you set source_entry_path to '/'
-  nested_entries: false
+  nested_entries: true
 
   #  While using a File-System-based automated bundle generation feature, miscellaneous warnings suggesting css order
   #  conflicts may arise due to the mini-css-extract-plugin. For projects where css ordering has been mitigated through

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -5,6 +5,7 @@ default: &default
 
   # You can have a subdirectory of the source_path, like 'packs' (recommended).
   # Alternatively, you can use '/' to use the whole source_path directory.
+  # Notice that this is a relative path to source_path
   source_entry_path: packs
 
   # If nested_entries is true, then we'll pick up subdirectories within the source_entry_path.

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -63,7 +63,7 @@ class Shakapacker::Configuration
   end
 
   def source_entry_path
-    source_path.join(fetch(:source_entry_path))
+    source_path.join(relative_path(fetch(:source_entry_path)))
   end
 
   def manifest_path
@@ -169,5 +169,11 @@ class Shakapacker::Configuration
         end
         HashWithIndifferentAccess.new(config[env] || config[Shakapacker::DEFAULT_ENV])
       end
+    end
+
+    def relative_path(path)
+      return ".#{path}" if path.start_with?("/")
+
+      path
     end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -280,4 +280,44 @@ describe "Shakapacker::Configuration" do
       expect(config.shakapacker_precompile?).to be false
     end
   end
+
+  context "#source_entry_path" do
+    let(:config) do
+      Shakapacker::Configuration.new(
+        root_path: ROOT_PATH,
+        config_path: Pathname.new(File.expand_path("./test_app/config/shakapacker.yml", __dir__)),
+        env: "production"
+      )
+    end
+
+    it "returns correct path with source_entry_path starting with 'extra_path'" do
+      allow(config).to receive(:fetch).with(:source_path).and_return("the_source_path")
+      allow(config).to receive(:fetch).with(:source_entry_path).and_return("extra_path")
+
+      actual = config.source_entry_path.to_s
+      expected = "#{config.source_path.to_s}/extra_path"
+
+      expect(actual).to eq(expected)
+    end
+
+    it "returns correct path with source_entry_path starting with /" do
+      allow(config).to receive(:fetch).with(:source_path).and_return("the_source_path")
+      allow(config).to receive(:fetch).with(:source_entry_path).and_return("/")
+
+      actual = config.source_entry_path.to_s
+      expected = config.source_path.to_s
+
+      expect(actual).to eq(expected)
+    end
+
+    it "returns correct path with source_entry_path starting with /extra_path" do
+      allow(config).to receive(:fetch).with(:source_path).and_return("the_source_path")
+      allow(config).to receive(:fetch).with(:source_entry_path).and_return("/extra_path")
+
+      actual = config.source_entry_path.to_s
+      expected = "#{config.source_path.to_s}/extra_path"
+
+      expect(actual).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Set `source_entry_path` to `packs` by default.
- Process `source_entry_path` as a relative path to `source_path`, allowing to accept values starting with '/'.
- Set `nested_entry` to `true` by default.

## PR Requirements
- [x] Add tests
- [x] Update documentation
- [x] Update Changelog

For additional discussion, check the old PR: #205 

Closes #204 