### PR TITLE
Remove check_yarn_integrity method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Removed
 - Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).
+- Remove deprecated `check_yarn_integrity` from `Shakapacker::Configuration` [PR SP288](https://github.com/shakacode/shakapacker/pull/288) by [ahangarha](https://github.com/ahangarha).
 
 ### Added
 - All standard Webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).    

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -94,14 +94,6 @@ class Shakapacker::Configuration
     root_path.join(fetch(:cache_path))
   end
 
-  def check_yarn_integrity=(value)
-    warn <<~EOS
-      Shakapacker::Configuration#check_yarn_integrity=(value) is obsolete. The integrity
-      check has been removed from Webpacker (https://github.com/rails/webpacker/pull/2518)
-      so changing this setting will have no effect.
-    EOS
-  end
-
   def webpack_compile_output?
     fetch(:webpack_compile_output)
   end


### PR DESCRIPTION
### Summary

Remove the deprecated method `check_yarn_integrity` from `Shakapacker::Configuration`.

### Pull Request checklist
- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file
