### PR TITLE
Fix check binstubs task by removing exit

### DIFF
--- a/lib/tasks/shakapacker/check_binstubs.rake
+++ b/lib/tasks/shakapacker/check_binstubs.rake
@@ -1,25 +1,24 @@
 namespace :shakapacker do
   desc "Verifies that bin/shakapacker is present"
   task :check_binstubs do
-    if File.exist?(Rails.root.join("bin/shakapacker"))
-      # pass
-    elsif File.exist?(Rails.root.join("bin/webpacker"))
-      Shakapacker.puts_deprecation_message(
-        Shakapacker.short_deprecation_message(
-          "bin/webpacker",
-          "bin/shakapacker"
+    unless File.exist?(Rails.root.join("bin/shakapacker"))
+      if File.exist?(Rails.root.join("bin/webpacker"))
+        Shakapacker.puts_deprecation_message(
+          Shakapacker.short_deprecation_message(
+            "bin/webpacker",
+            "bin/shakapacker"
+          )
         )
-      )
-      # pass
-    else
-      puts <<~MSG
-        Could't find shakapacker binstubs!
-        Possible solutions:
-         - Ensure you have run `rails shakapacker:install`.
-         - Run `rails shakapacker:binstubs` if you have already installed shakapacker.
-         - Ensure the `bin` directory and `bin/shakapacker` are not included in .gitignore.
-      MSG
-      exit!
+      else
+        puts <<~MSG
+          Could't find shakapacker binstubs!
+          Possible solutions:
+          - Ensure you have run `rails shakapacker:install`.
+          - Run `rails shakapacker:binstubs` if you have already installed shakapacker.
+          - Ensure the `bin` directory and `bin/shakapacker` are not included in .gitignore.
+        MSG
+        exit!
+      end
     end
   end
 end

--- a/lib/tasks/shakapacker/check_binstubs.rake
+++ b/lib/tasks/shakapacker/check_binstubs.rake
@@ -2,7 +2,7 @@ namespace :shakapacker do
   desc "Verifies that bin/shakapacker is present"
   task :check_binstubs do
     if File.exist?(Rails.root.join("bin/shakapacker"))
-      exit
+      # pass
     elsif File.exist?(Rails.root.join("bin/webpacker"))
       Shakapacker.puts_deprecation_message(
         Shakapacker.short_deprecation_message(
@@ -10,7 +10,7 @@ namespace :shakapacker do
           "bin/shakapacker"
         )
       )
-      exit
+      # pass
     else
       puts <<~MSG
         Could't find shakapacker binstubs!

--- a/lib/tasks/shakapacker/check_binstubs.rake
+++ b/lib/tasks/shakapacker/check_binstubs.rake
@@ -1,24 +1,29 @@
 namespace :shakapacker do
   desc "Verifies that bin/shakapacker is present"
   task :check_binstubs do
-    unless File.exist?(Rails.root.join("bin/shakapacker"))
-      if File.exist?(Rails.root.join("bin/webpacker"))
-        Shakapacker.puts_deprecation_message(
-          Shakapacker.short_deprecation_message(
-            "bin/webpacker",
-            "bin/shakapacker"
-          )
+    verify_file_existance("bin/shakapacker", "bin/webpacker")
+    verify_file_existance("bin/shakapacker-dev-server", "bin/webpacker-dev-server")
+  end
+end
+
+def verify_file_existance(main_file, alternative_file)
+  unless File.exist?(Rails.root.join(main_file))
+    if File.exist?(Rails.root.join(alternative_file))
+      Shakapacker.puts_deprecation_message(
+        Shakapacker.short_deprecation_message(
+          alternative_file,
+          main_file
         )
-      else
-        puts <<~MSG
-          Could't find shakapacker binstubs!
-          Possible solutions:
-          - Ensure you have run `rails shakapacker:install`.
-          - Run `rails shakapacker:binstubs` if you have already installed shakapacker.
-          - Ensure the `bin` directory and `bin/shakapacker` are not included in .gitignore.
-        MSG
-        exit!
-      end
+      )
+    else
+      puts <<~MSG
+        Couldn't find shakapacker binstubs!
+        Possible solutions:
+        - Ensure you have run `rails shakapacker:install`.
+        - Run `rails shakapacker:binstubs` if you have already installed shakapacker.
+        - Ensure the `bin` directory, `bin/shakapacker`, and `bin/shakapacker-dev-server` are not included in .gitignore.
+      MSG
+      exit!
     end
   end
 end

--- a/spec/shakapacker/rake_tasks_spec.rb
+++ b/spec/shakapacker/rake_tasks_spec.rb
@@ -1,10 +1,11 @@
+require "rake"
 require_relative "spec_helper_initializer"
 
 describe "RakeTasks" do
-  let(:test_app_path) { File.expand_path("../test_app", __dir__) }
+  TEST_APP_PATH = File.expand_path("../test_app", __dir__)
 
   it "`rake -T` lists Shakapacker tasks" do
-    output = Dir.chdir(test_app_path) { `rake -T` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake -T` }
     expect(output).to include "shakapacker"
     expect(output).to include "shakapacker:check_binstubs"
     expect(output).to include "shakapacker:check_node"
@@ -17,18 +18,77 @@ describe "RakeTasks" do
   end
 
   it "`shakapacker:check_binstubs` doesn't get 'webpack binstub not found' error" do
-    output = Dir.chdir(test_app_path) { `rake shakapacker:check_binstubs 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_binstubs 2>&1` }
     expect(output).to_not include "webpack binstub not found."
   end
 
   it "`shakapacker:check_node` doesn't get 'shakapacker requires Node.js' error" do
-    output = Dir.chdir(test_app_path) { `rake shakapacker:check_node 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_node 2>&1` }
     expect(output).to_not include "Shakapacker requires Node.js"
   end
 
   it "`shakapacker:check_yarn` doesn't get error related to yarn" do
-    output = Dir.chdir(test_app_path) { `rake shakapacker:check_yarn 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_yarn 2>&1` }
     expect(output).to_not include "Yarn not installed"
     expect(output).to_not include "Shakapacker requires Yarn"
   end
+
+  describe "shakapacker:check_binstubs" do
+    before :all do
+      Dir.chdir(TEST_APP_PATH)
+    end
+
+    context "with existing `./bin/shapapacker` and `./bin/shapapacker-dev-server`" do
+      it "passes" do
+        expect { system("bundle exec rake shakapacker:check_binstubs") }.to output("").to_stdout_from_any_process
+      end
+    end
+
+    context "without `./bin/shakapacker`" do
+      before :all do
+        Rake.move("bin/shakapacker", "bin/shakapacker_renamed")
+      end
+
+      after :all do
+        Rake.move("bin/shakapacker_renamed", "bin/shakapacker")
+      end
+
+      it "passes if `./bin/webpacker exist" do
+        with_temporary_file("bin/webpacker") do
+          expect { system("bundle exec rake shakapacker:check_binstubs") }.to output(/DEPRECATION/).to_stdout_from_any_process
+        end
+      end
+
+      it "fails otherwise" do
+        expect { system("bundle exec rake shakapacker:check_binstubs") }.to output(/Couldn't find shakapacker binstubs!/).to_stdout_from_any_process
+      end
+    end
+
+    context "without `./bin/shakapacker-dev-server`" do
+      before :all do
+        Rake.move("bin/shakapacker-dev-server", "bin/shakapacker-dev-server_renamed")
+      end
+
+      after :all do
+        Rake.move("bin/shakapacker-dev-server_renamed", "bin/shakapacker-dev-server")
+      end
+
+      it "passes if `./bin/webpacker-dev-server exist" do
+        with_temporary_file("bin/webpacker-dev-server") do
+          expect { system("bundle exec rake shakapacker:check_binstubs") }.to output(/DEPRECATION/).to_stdout_from_any_process
+        end
+      end
+
+      it "fails otherwise" do
+        expect { system("bundle exec rake shakapacker:check_binstubs") }.to output(/Couldn't find shakapacker binstubs!/).to_stdout_from_any_process
+      end
+    end
+  end
+end
+
+def with_temporary_file(file_name, &block)
+  Rake.touch(file_name)
+  yield if block_given?
+ensure
+  Rake.rm_f(file_name)
 end

--- a/spec/shakapacker/rake_tasks_spec.rb
+++ b/spec/shakapacker/rake_tasks_spec.rb
@@ -33,6 +33,13 @@ describe "RakeTasks" do
   end
 
   describe "`shakapacker:check_binstubs`" do
+    def with_temporary_file(file_name, &block)
+      FileUtils.touch(file_name, verbose: false)
+      yield if block_given?
+    ensure
+      FileUtils.rm_f(file_name, verbose: false)
+    end
+
     before :all do
       Dir.chdir(TEST_APP_PATH)
     end
@@ -83,11 +90,4 @@ describe "RakeTasks" do
       end
     end
   end
-end
-
-def with_temporary_file(file_name, &block)
-  FileUtils.touch(file_name, verbose: false)
-  yield if block_given?
-ensure
-  FileUtils.rm_f(file_name, verbose: false)
 end

--- a/spec/shakapacker/rake_tasks_spec.rb
+++ b/spec/shakapacker/rake_tasks_spec.rb
@@ -1,4 +1,3 @@
-require "rake"
 require_relative "spec_helper_initializer"
 
 describe "RakeTasks" do
@@ -33,7 +32,7 @@ describe "RakeTasks" do
     expect(output).to_not include "Shakapacker requires Yarn"
   end
 
-  describe "shakapacker:check_binstubs" do
+  describe "`shakapacker:check_binstubs`" do
     before :all do
       Dir.chdir(TEST_APP_PATH)
     end
@@ -46,11 +45,11 @@ describe "RakeTasks" do
 
     context "without `./bin/shakapacker`" do
       before :all do
-        Rake.move("bin/shakapacker", "bin/shakapacker_renamed")
+        FileUtils.mv("bin/shakapacker", "bin/shakapacker_renamed")
       end
 
       after :all do
-        Rake.move("bin/shakapacker_renamed", "bin/shakapacker")
+        FileUtils.mv("bin/shakapacker_renamed", "bin/shakapacker")
       end
 
       it "passes if `./bin/webpacker exist" do
@@ -66,11 +65,11 @@ describe "RakeTasks" do
 
     context "without `./bin/shakapacker-dev-server`" do
       before :all do
-        Rake.move("bin/shakapacker-dev-server", "bin/shakapacker-dev-server_renamed")
+        FileUtils.mv("bin/shakapacker-dev-server", "bin/shakapacker-dev-server_renamed")
       end
 
       after :all do
-        Rake.move("bin/shakapacker-dev-server_renamed", "bin/shakapacker-dev-server")
+        FileUtils.mv("bin/shakapacker-dev-server_renamed", "bin/shakapacker-dev-server")
       end
 
       it "passes if `./bin/webpacker-dev-server exist" do
@@ -87,8 +86,8 @@ describe "RakeTasks" do
 end
 
 def with_temporary_file(file_name, &block)
-  Rake.touch(file_name)
+  FileUtils.touch(file_name, verbose: false)
   yield if block_given?
 ensure
-  Rake.rm_f(file_name)
+  FileUtils.rm_f(file_name, verbose: false)
 end


### PR DESCRIPTION
### Summary

Because of exiting from `shakapacker:check_binstubs`, `shakapacker:verify_install` couldn't pass. As a result, `shakapacker:compile` couldn't be added to `assets:precompile` task.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ (no need)
- [x] ~Update CHANGELOG file~ (Since this is not a fix on any earlier release, no need for updating changelog)

### Other Information

This PR should resolve and close #305 issue.