### PR TITLE
Improve handling devDependencies in installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _Please add entries here for your pull requests that are not yet released._
   Going forward, the top level directory of static files will be retained so this will necessitate the update of file name references in asset helpers. In the example above, the file sourced from `app/javascript/images/image.png` will be now output to `static/images/image.png` and needs to be referenced as `image_pack_tag("images/image.jpg")` or `image_pack_tag("static/images/image.jpg")`.
 
 - Fixed RC version detection during installation. [PR312](https://github.com/shakacode/shakapacker/pull/312) by [ahangarha](https://github.com/ahangarha)
+- Fix addition of webpack-dev-server to devDependencies during installation. [PR310](https://github.com/shakacode/shakapacker/pull/310) by [ahangarha](https://github.com/ahangarha)
 
 ### Removed
 - Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -79,7 +79,7 @@ Dir.chdir(Rails.root) do
 
   package_json = File.read("#{__dir__}/../../package.json")
   peers = JSON.parse(package_json)["peerDependencies"]
-  dev_dependencies = ["webpack-dev-server"]
+  dev_dependency_packages = ["webpack-dev-server"]
 
   dependencies_to_add = []
   dev_dependencies_to_add = []
@@ -88,7 +88,7 @@ Dir.chdir(Rails.root) do
     major_version = version.match(/(\d+)/)[1]
     entry = "#{package}@#{major_version}"
 
-    if dev_dependencies.include? package
+    if dev_dependency_packages.include? package
       dev_dependencies_to_add << entry
     else
       dependencies_to_add << entry

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -79,16 +79,27 @@ Dir.chdir(Rails.root) do
 
   package_json = File.read("#{__dir__}/../../package.json")
   peers = JSON.parse(package_json)["peerDependencies"]
-  peers_to_add = peers.reduce([]) do |result, (package, version)|
+  dev_dependencies = ["webpack-dev-server"]
+
+  dependencies_to_add = []
+  dev_dependencies_to_add = []
+
+  peers.each do |(package, version)|
     major_version = version.match(/(\d+)/)[1]
-    result << "#{package}@#{major_version}"
-  end.join(" ")
+    entry = "#{package}@#{major_version}"
+
+    if dev_dependencies.include? package
+      dev_dependencies_to_add << entry
+    else
+      dependencies_to_add << entry
+    end
+  end
 
   say "Adding shakapacker peerDependencies"
-  results << run("yarn add #{peers_to_add}")
+  results << run("yarn add #{dependencies_to_add.join(' ')}")
 
   say "Installing webpack-dev-server for live reloading as a development dependency"
-  results << run("yarn add --dev webpack-dev-server")
+  results << run("yarn add --dev #{dev_dependencies_to_add.join(' ')}")
 end
 
 unless results.all?


### PR DESCRIPTION
### Summary

Currently, we add Shakapacker peer dependencies as dependencies in `shakapacker:install` task. This results in failure in adding `webpack-dev-server` to devDepenencies.

This PR fixes this issue issue.

### Pull Request checklist
- [ ] ~Add/update test to cover these changes~ Will be added in #300.~
- [x] ~Update documentation~ not needed
- [x] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._

