### PR TITLE
Add feature to force override in installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ _Please add entries here for your pull requests that are not yet released._
 - Remove deprecated `check_yarn_integrity` from `Shakapacker::Configuration` [PR SP288](https://github.com/shakacode/shakapacker/pull/288) by [ahangarha](https://github.com/ahangarha).
 
 ### Added
-- All standard Webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).    
-
+- All standard Webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).
+- The `shakapacker:install` rake task now has an option to force overriding files using `FORCE=true` environment variable [PR300](https://github.com/shakacode/shakapacker/pull/300) by [ahangarha](https://github.com/ahangarha).
 
 ## [v6.6.0] - March 7, 2023
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Added
 - All standard Webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).
-- The `shakapacker:install` rake task now has an option to force overriding files using `FORCE=true` environment variable [PR300](https://github.com/shakacode/shakapacker/pull/300) by [ahangarha](https://github.com/ahangarha).
+- The `shakapacker:install` rake task now has an option to force overriding files using `FORCE=true` environment variable [PR311](https://github.com/shakacode/shakapacker/pull/311) by [ahangarha](https://github.com/ahangarha).
 
 ## [v6.6.0] - March 7, 2023
 ### Improved

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Then run the following to install Shakapacker:
 ./bin/rails shakapacker:install
 ```
 
+Before initiating the installation process, ensure you have committed all the changes. While installing Shakapacker, there might be some conflict between the existing file content and what Shakapacker tries to copy. You can either approve all the prompts for overriding these files or use the `FORCE=true` environment variable before the installation command to force the override without any prompt.
+
 When `package.json` and/or `yarn.lock` changes, such as when pulling down changes to your local environment in team settings, be sure to keep your NPM packages up-to-date:
 
 ```bash

--- a/lib/install/binstubs.rb
+++ b/lib/install/binstubs.rb
@@ -1,4 +1,6 @@
+force_option = ENV["FORCE"] ? { force: true } : {}
+
 say "Copying binstubs"
-directory "#{__dir__}/bin", "bin"
+directory "#{__dir__}/bin", "bin", force_option
 
 chmod "bin", 0755 & ~File.umask, verbose: false

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -1,9 +1,12 @@
 # Install Shakapacker
-copy_file "#{__dir__}/config/shakapacker.yml", "config/shakapacker.yml"
-copy_file "#{__dir__}/package.json", "package.json"
+
+force_option = ENV["FORCE"] ? { force: true } : {}
+
+copy_file "#{__dir__}/config/shakapacker.yml", "config/shakapacker.yml", force_option
+copy_file "#{__dir__}/package.json", "package.json", force_option
 
 say "Copying webpack core config"
-directory "#{__dir__}/config/webpack", "config/webpack"
+directory "#{__dir__}/config/webpack", "config/webpack", force_option
 
 if Dir.exist?(Shakapacker.config.source_path)
   say "The packs app source directory already exists"


### PR DESCRIPTION
### Summary

Adding a feature to use `FORCE=true` env variable to force overriding files during installation. Besides making it easier to install, this feature is particularly needed for #300.

### Pull Request checklist

- [ ] Add/update test to cover these changes (will be added in #300)
- [x] Update documentation
- [x] Update CHANGELOG file

