### PR TITLE
Fix detection of version for npm during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ _Please add entries here for your pull requests that are not yet released._
 
   Going forward, the top level directory of static files will be retained so this will necessitate the update of file name references in asset helpers. In the example above, the file sourced from `app/javascript/images/image.png` will be now output to `static/images/image.png` and needs to be referenced as `image_pack_tag("images/image.jpg")` or `image_pack_tag("static/images/image.jpg")`.
 
+- Fixed RC version detection during installation. [PR312](https://github.com/shakacode/shakapacker/pull/312) by [ahangarha](https://github.com/ahangarha)
+
 ### Removed
 - Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).
 - Remove deprecated `check_yarn_integrity` from `Shakapacker::Configuration` [PR SP288](https://github.com/shakacode/shakapacker/pull/288) by [ahangarha](https://github.com/ahangarha).

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -1,3 +1,5 @@
+require "shakapacker/utils/version_syntax_converter"
+
 # Install Shakapacker
 copy_file "#{__dir__}/config/shakapacker.yml", "config/shakapacker.yml"
 copy_file "#{__dir__}/package.json", "package.json"
@@ -68,13 +70,9 @@ end
 results = []
 
 Dir.chdir(Rails.root) do
-  if Shakapacker::VERSION.match?(/^[0-9]+\.[0-9]+\.[0-9]+$/)
-    say "Installing shakapacker@#{Shakapacker::VERSION}"
-    results << run("yarn add shakapacker@#{Shakapacker::VERSION} --exact")
-  else
-    say "Installing shakapacker@next"
-    results << run("yarn add shakapacker@next --exact")
-  end
+  npm_version = Shakapacker::Utils::VersionSyntaxConverter.new.rubygem_to_npm(Shakapacker::VERSION)
+  say "Installing shakapacker@#{npm_version}"
+  results << run("yarn add shakapacker@#{npm_version} --exact")
 
   package_json = File.read("#{__dir__}/../../package.json")
   peers = JSON.parse(package_json)["peerDependencies"]


### PR DESCRIPTION
### Summary

Our installation code couldn't detect the right version for installing the npm package if we were on an RC version and as a result, it was trying to install the `next` version which is currently set to `v6.0.0-rc.14`. This PR fixes this issue.

### Pull Request checklist

- [ ] ~Add/update test to cover these changes~ will be added in #300 
- [x] ~Update documentation~ not needed
- [x] Update CHANGELOG file  
