### PR TITLE
Support spaces in app path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
+- Fix commands execution for projects with space in absolute path
 
 ### Fixed
 - Fixed the condition for showing warning for setting `useContentHash` to `false` in the production environment. [PR 320](https://github.com/shakacode/shakapacker/pull/320) by [ahangarha](https://github.com/ahangarha).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
-- Fix commands execution for projects with space in absolute path
+- Fix commands execution for projects with space in absolute path [PR 322](https://github.com/shakacode/shakapacker/pull/322) by [kukicola](https://github.com/kukicola).
 
 ### Fixed
 - Fixed the condition for showing warning for setting `useContentHash` to `false` in the production environment. [PR 320](https://github.com/shakacode/shakapacker/pull/320) by [ahangarha](https://github.com/ahangarha).

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -82,7 +82,7 @@ class Shakapacker::Compiler
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
-        "#{optionalRubyRunner} #{bin_shakapacker_path}",
+        "#{optionalRubyRunner} '#{bin_shakapacker_path}'",
         chdir: File.expand_path(config.root_path)
       )
 

--- a/lib/shakapacker/utils/misc.rb
+++ b/lib/shakapacker/utils/misc.rb
@@ -29,7 +29,7 @@ module Shakapacker
 
       # Executes a string or an array of strings in a shell in the given directory in an unbundled environment
       def self.sh_in_dir(dir, *shell_commands)
-        shell_commands.flatten.each { |shell_command| sh %(cd #{dir} && #{shell_command.strip}) }
+        shell_commands.flatten.each { |shell_command| sh %(cd '#{dir}' && #{shell_command.strip}) }
       end
     end
   end

--- a/lib/tasks/shakapacker/binstubs.rake
+++ b/lib/tasks/shakapacker/binstubs.rake
@@ -7,9 +7,9 @@ namespace :shakapacker do
     prefix = task.name.split(/#|shakapacker:binstubs/).first
 
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION='#{binstubs_template_path}'"
+      exec "#{RbConfig.ruby} '#{bin_path}/rails' #{prefix}app:template LOCATION='#{binstubs_template_path}'"
     else
-      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION='#{binstubs_template_path}'"
+      exec "#{RbConfig.ruby} '#{bin_path}/rake' #{prefix}rails:template LOCATION='#{binstubs_template_path}'"
     end
   end
 end

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -9,9 +9,9 @@ namespace :shakapacker do
     prefix = task.name.split(/#|shakapacker:install/).first
 
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION='#{install_template_path}'"
+      exec "#{RbConfig.ruby} '#{bin_path}/rails' #{prefix}app:template LOCATION='#{install_template_path}'"
     else
-      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION='#{install_template_path}'"
+      exec "#{RbConfig.ruby} '#{bin_path}/rake' #{prefix}rails:template LOCATION='#{install_template_path}'"
     end
   end
 end

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -33,7 +33,7 @@ describe "Generator" do
   describe "shakapacker:install" do
     context "in a normal Rails project" do
       before :all do
-        sh_in_dir(SPEC_PATH, "cp -r #{BASE_RAILS_APP_PATH} #{TEMP_RAILS_APP_PATH}")
+        sh_in_dir(SPEC_PATH, "cp -r '#{BASE_RAILS_APP_PATH}' '#{TEMP_RAILS_APP_PATH}'")
 
         Bundler.with_unbundled_env do
           sh_in_dir(TEMP_RAILS_APP_PATH, "FORCE=true bundle exec rails shakapacker:install")


### PR DESCRIPTION
### Summary

Hello, when upgrading my app from v6 to v7, I noticed some commands are failing because I have a space in the absolute path of my project. 

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information