### PR TITLE
Have Webpacker constant output a deprecation message

### DIFF
--- a/lib/shakapacker.rb
+++ b/lib/shakapacker.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/inquiry"
 require "active_support/logger"
 require "active_support/tagged_logging"
+require_relative "./shakapacker/webpacker"
 
 module Shakapacker
   extend self
@@ -45,7 +46,4 @@ require "shakapacker/compiler"
 require "shakapacker/commands"
 require "shakapacker/dev_server"
 require "shakapacker/deprecation_helper"
-
 require "shakapacker/railtie" if defined?(Rails)
-
-Webpacker = Shakapacker

--- a/lib/shakapacker/webpacker.rb
+++ b/lib/shakapacker/webpacker.rb
@@ -1,0 +1,8 @@
+class Webpacker
+  def self.method_missing(method_name, *args, &block)
+    puts "The Webpacker constant has been superseded by the Shakapacker constant. "\
+         "Please change all references to the Webpacker constant, such as Webpacker.#{method_name}, "\
+         "to their Shakpacker equivalent, such as Shakapacker.#{method_name}"
+    Shakapacker.send(method_name, *args, &block)
+  end
+end

--- a/lib/shakapacker/webpacker.rb
+++ b/lib/shakapacker/webpacker.rb
@@ -5,4 +5,12 @@ class Webpacker
          "to their Shakpacker equivalent, such as Shakapacker.#{method_name}"
     Shakapacker.send(method_name, *args, &block)
   end
+
+  def self.const_missing(const_name)
+    puts "The Webpacker constant has been superseded by the Shakapacker constant. "\
+         "Please change all references to the Webpacker constant, such as Webpacker::#{const_name}, "\
+         "to their Shakpacker equivalent, such as Shakapacker::#{const_name}"
+    super unless const_name == :Manifest
+    Shakapacker::Manifest
+  end
 end

--- a/lib/shakapacker/webpacker.rb
+++ b/lib/shakapacker/webpacker.rb
@@ -10,7 +10,6 @@ class Webpacker
     puts "The Webpacker constant has been superseded by the Shakapacker constant. "\
          "Please change all references to the Webpacker constant, such as Webpacker::#{const_name}, "\
          "to their Shakpacker equivalent, such as Shakapacker::#{const_name}"
-    super unless const_name == :Manifest
-    Shakapacker::Manifest
+    Shakapacker.const_get(const_name)
   end
 end


### PR DESCRIPTION
This change causes a deprecation message to be output anytime a method or constant under `Webpacker` is called.