### PR TITLE
feat: add types for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.2",
   "description": "Use webpack to manage app-like JavaScript modules in Rails",
   "main": "package/index.js",
+  "types": "package/index.d.ts",
   "files": [
     "package",
     "lib/install/config/shakapacker.yml"
@@ -12,6 +13,7 @@
     "yarn": ">=1 <4"
   },
   "peerDependencies": {
+    "@types/webpack": "^5.0.0",
     "@babel/core": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
@@ -24,6 +26,11 @@
     "webpack-cli": "^4.9.2 || ^5.0.0",
     "webpack-dev-server": "^4.9.0",
     "webpack-merge": "^5.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/webpack": {
+      "optional": true
+    }
   },
   "dependencies": {
     "glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "yarn": ">=1 <4"
   },
   "peerDependencies": {
+    "@types/babel__core": "^7.0.0",
     "@types/webpack": "^5.0.0",
     "@babel/core": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",
@@ -28,6 +29,9 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependenciesMeta": {
+    "@types/babel__core": {
+      "optional": true
+    },
     "@types/webpack": {
       "optional": true
     }

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,0 +1,22 @@
+declare module 'shakapacker' {
+  import { Configuration } from 'webpack';
+
+  export { merge } from 'webpack-merge';
+  export const globalMutableWebpackConfig: Configuration;
+  export function generateWebpackConfig(): Configuration;
+}
+
+declare module 'shakapacker/package/babel/preset.js' {
+  import { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
+
+  interface RequiredTransformOptions {
+    plugins: PluginItem[];
+    presets: PluginItem[];
+  }
+
+  const defaultConfigFunc: (
+    api: ConfigAPI
+  ) => TransformOptions & RequiredTransformOptions;
+
+  export = defaultConfigFunc;
+}

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
-  export { merge } from 'webpack-merge'
+  export * from 'webpack-merge'
   export const globalMutableWebpackConfig: Configuration
   export function generateWebpackConfig(): Configuration
 }

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,10 +1,17 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
-  export * from 'webpack-merge'
-  export const globalMutableWebpackConfig: Configuration
+  export const config: unknown
+  export const devServer: unknown
   export function generateWebpackConfig(): Configuration
+  export const globalMutableWebpackConfig: Configuration
+  export const baseConfig: unknown
+  export const env: unknown
+  export const rules: unknown
+  export function moduleExists(...args: unknown[]): unknown
+  export function canProcess(...args: unknown[]): unknown
   export const inliningCss: boolean
+  export * from 'webpack-merge'
 }
 
 declare module 'shakapacker/package/babel/preset.js' {

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,13 +1,13 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
-  export const config: unknown
-  export const devServer: unknown
+  export const config: Record<string, unknown>
+  export const devServer: Record<string, unknown>
   export function generateWebpackConfig(): Configuration
   export const globalMutableWebpackConfig: Configuration
-  export const baseConfig: unknown
+  export const baseConfig: Record<string, unknown>
   export const env: unknown
-  export const rules: unknown
+  export const rules: Record<string, unknown>
   export function moduleExists(packageName: string): boolean
   export function canProcess<T = unknown>(rule: string, fn: (modulePath: string) => T): T | null
   export const inliningCss: boolean

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -4,6 +4,7 @@ declare module 'shakapacker' {
   export * from 'webpack-merge'
   export const globalMutableWebpackConfig: Configuration
   export function generateWebpackConfig(): Configuration
+  export const inliningCss: boolean
 }
 
 declare module 'shakapacker/package/babel/preset.js' {

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -8,7 +8,7 @@ declare module 'shakapacker' {
   export const baseConfig: unknown
   export const env: unknown
   export const rules: unknown
-  export function moduleExists(...args: unknown[]): unknown
+  export function moduleExists(packageName: string): boolean
   export function canProcess(...args: unknown[]): unknown
   export const inliningCss: boolean
   export * from 'webpack-merge'

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,6 +1,29 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
+  interface Config {
+    source_path: string
+    source_entry_path: string
+    nested_entries: boolean
+    css_extract_ignore_order_warnings: boolean
+    public_root_path: string
+    public_output_path: string
+    cache_path: string
+    webpack_compile_output: boolean
+    shakapacker_precompile: boolean
+    additional_paths: string[]
+    cache_manifest: boolean
+    webpack_loader: string
+    ensure_consistent_versioning: boolean
+    compiler_strategy: string
+    useContentHash: boolean
+    compile: boolean,
+    outputPath: string
+    publicPath: string
+    publicPathWithoutCDN: string
+    manifestPath: string
+  }
+
   interface Env {
     railsEnv: string
     nodeEnv: string
@@ -9,7 +32,7 @@ declare module 'shakapacker' {
     runningWebpackDevServer: boolean
   }
 
-  export const config: Record<string, unknown>
+  export const config: Config
   export const devServer: Record<string, unknown>
   export function generateWebpackConfig(): Configuration
   export const globalMutableWebpackConfig: Configuration

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
-  interface Config {
+  export interface Config {
     source_path: string
     source_entry_path: string
     nested_entries: boolean
@@ -24,7 +24,7 @@ declare module 'shakapacker' {
     manifestPath: string
   }
 
-  interface Env {
+  export interface Env {
     railsEnv: string
     nodeEnv: string
     isProduction: boolean

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,12 +1,20 @@
 declare module 'shakapacker' {
   import { Configuration } from 'webpack'
 
+  interface Env {
+    railsEnv: string
+    nodeEnv: string
+    isProduction: boolean
+    isDevelopment: boolean
+    runningWebpackDevServer: boolean
+  }
+
   export const config: Record<string, unknown>
   export const devServer: Record<string, unknown>
   export function generateWebpackConfig(): Configuration
   export const globalMutableWebpackConfig: Configuration
   export const baseConfig: Record<string, unknown>
-  export const env: unknown
+  export const env: Env
   export const rules: Record<string, unknown>
   export function moduleExists(packageName: string): boolean
   export function canProcess<T = unknown>(rule: string, fn: (modulePath: string) => T): T | null

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -9,7 +9,7 @@ declare module 'shakapacker' {
   export const env: unknown
   export const rules: unknown
   export function moduleExists(packageName: string): boolean
-  export function canProcess(...args: unknown[]): unknown
+  export function canProcess<T = unknown>(rule: string, fn: (modulePath: string) => T): T | null
   export const inliningCss: boolean
   export * from 'webpack-merge'
 }

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -13,7 +13,7 @@ declare module 'shakapacker' {
   export const devServer: Record<string, unknown>
   export function generateWebpackConfig(): Configuration
   export const globalMutableWebpackConfig: Configuration
-  export const baseConfig: Record<string, unknown>
+  export const baseConfig: Configuration
   export const env: Env
   export const rules: Record<string, unknown>
   export function moduleExists(packageName: string): boolean

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -1,22 +1,22 @@
 declare module 'shakapacker' {
-  import { Configuration } from 'webpack';
+  import { Configuration } from 'webpack'
 
-  export { merge } from 'webpack-merge';
-  export const globalMutableWebpackConfig: Configuration;
-  export function generateWebpackConfig(): Configuration;
+  export { merge } from 'webpack-merge'
+  export const globalMutableWebpackConfig: Configuration
+  export function generateWebpackConfig(): Configuration
 }
 
 declare module 'shakapacker/package/babel/preset.js' {
-  import { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
+  import { ConfigAPI, PluginItem, TransformOptions } from '@babel/core'
 
   interface RequiredTransformOptions {
-    plugins: PluginItem[];
-    presets: PluginItem[];
+    plugins: PluginItem[]
+    presets: PluginItem[]
   }
 
   const defaultConfigFunc: (
     api: ConfigAPI
-  ) => TransformOptions & RequiredTransformOptions;
+  ) => TransformOptions & RequiredTransformOptions
 
-  export = defaultConfigFunc;
+  export = defaultConfigFunc
 }


### PR DESCRIPTION
### Summary

This adds types to the npm package to allow using it in TypeScript-based files. This is effectively a port of https://github.com/ackama/rails-template/blob/main/variants/frontend-base-typescript/types.d.ts#L1-L21 (+ the changes for v7).

This is meant to be a starting point rather than completely type everything because once this is landed it should be very easier for the types of other functions and properties be added, whereas I don't have the bandwidth to pin down the exact types for everything.

I have tested this works by generating a new Rails project from our template, and then replacing the lines linked to above in `types.d.ts` with this change to `node_modules/shakapacker` and then running `typecheck`.

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [x] Update CHANGELOG file

### Other Information

I'm opening this as a draft to get it kicked off so maintainers let me know if they have any opinions - I'll get around to doing the changelog shortly.