### PR TITLE
Include PR as a trigger for CI

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,6 +1,6 @@
 name: Dummy specs
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -1,6 +1,6 @@
 name: Generator specs
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,6 +1,6 @@
 name: Jest specs
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   jest:

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -1,6 +1,6 @@
 name: JS lint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,6 @@
 name: Rubocop
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   rubocop:

--- a/.github/workflows/ruby-backward-compatibility.yml
+++ b/.github/workflows/ruby-backward-compatibility.yml
@@ -1,6 +1,6 @@
 name: Ruby specs - Backward compatibility
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby specs
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
To run CI on PR made by contributors other than the official team, we need to include `pull_request` in the list of triggers.