### PR TITLE
Fix typo in v7 upgrade guide

### DIFF
--- a/docs/v7_upgrade.md
+++ b/docs/v7_upgrade.md
@@ -35,7 +35,7 @@ When generating file paths for static assets, a top-level directory will no long
 ## The `webpackConfig` property is changed
 
 The `webpackConfig` property in the `shakapacker` module has been changed. The shakapacker module has two options:
-1. `generatedWebpackConfig`: a function that returns a new webpack configuration object, which ensures that any modifications made to it will not affect any other usage of the webpack configuration.
+1. `generateWebpackConfig`: a function that returns a new webpack configuration object, which ensures that any modifications made to it will not affect any other usage of the webpack configuration.
 2. `globalMutableWebpackConfig`: if a project still desires the old mutable object. You can rename your imports of `webpackConfig` with `globalMutableWebpackConfig`.
 
 ## Example Upgrade


### PR DESCRIPTION
### Summary

The function _generateWebpackConfig_ was misspelled as _generate**d**WebpackConfig_, which could cause build issues if someone copy-and-paste the function name from the docs.

Fixes #335.

<!--
### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file
-->