### PR TITLE
fix: use `NODE_OPTIONS` instead of calling `node` directly for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+- Use `NODE_OPTIONS` to enable Node-specific debugging flags [PR 350](https://github.com/shakacode/shakapacker/pull/350)
+
 ## [v7.0.3] - July 7, 2023
 ### Fixed
 - Fixed commands execution for projects with space in absolute path [PR 322](https://github.com/shakacode/shakapacker/pull/322) by [kukicola](https://github.com/kukicola).

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -66,6 +66,7 @@ module Shakapacker
         env = Shakapacker::Compiler.env
         env["SHAKAPACKER_CONFIG"] = @shakapacker_config
         env["WEBPACK_SERVE"] = "true"
+        env["NODE_OPTIONS"] = ENV["NODE_OPTIONS"] || ""
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack", "serve"]
@@ -83,7 +84,7 @@ module Shakapacker
         end
 
         if @argv.delete("--debug-shakapacker") || @argv.delete("--debug-webpacker")
-          cmd = [ "node", "--inspect-brk", "--trace-warnings" ] + cmd
+          env["NODE_OPTIONS"] += " --inspect-brk --trace-warnings"
         end
 
         cmd += ["--config", @webpack_config]

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -84,7 +84,7 @@ module Shakapacker
         end
 
         if @argv.delete("--debug-shakapacker") || @argv.delete("--debug-webpacker")
-          env["NODE_OPTIONS"] += " --inspect-brk --trace-warnings"
+          env["NODE_OPTIONS"] = "#{ENV["NODE_OPTIONS"]} --inspect-brk --trace-warnings"
         end
 
         cmd += ["--config", @webpack_config]

--- a/lib/shakapacker/webpack_runner.rb
+++ b/lib/shakapacker/webpack_runner.rb
@@ -37,15 +37,15 @@ module Shakapacker
       end
 
       if @argv.delete("--debug-shakapacker") || @argv.delete("--debug-webpacker")
-        env["NODE_OPTIONS"] += " --inspect-brk"
+        env["NODE_OPTIONS"] = "#{ENV["NODE_OPTIONS"]} --inspect-brk"
       end
 
       if @argv.delete "--trace-deprecation"
-        env["NODE_OPTIONS"] += " --trace-deprecation"
+        env["NODE_OPTIONS"] = "#{ENV["NODE_OPTIONS"]} --trace-deprecation"
       end
 
       if @argv.delete "--no-deprecation"
-        env["NODE_OPTIONS"] += " --no-deprecation"
+        env["NODE_OPTIONS"] = "#{ENV["NODE_OPTIONS"]} --no-deprecation"
       end
 
       # Webpack commands are not compatible with --config option.

--- a/lib/shakapacker/webpack_runner.rb
+++ b/lib/shakapacker/webpack_runner.rb
@@ -19,6 +19,7 @@ module Shakapacker
     def run
       env = Shakapacker::Compiler.env
       env["SHAKAPACKER_CONFIG"] = @shakapacker_config
+      env["NODE_OPTIONS"] = ENV["NODE_OPTIONS"] || ""
 
       cmd = if node_modules_bin_exist?
         ["#{@node_modules_bin_path}/webpack"]
@@ -36,15 +37,15 @@ module Shakapacker
       end
 
       if @argv.delete("--debug-shakapacker") || @argv.delete("--debug-webpacker")
-        cmd = ["node", "--inspect-brk"] + cmd
+        env["NODE_OPTIONS"] += " --inspect-brk"
       end
 
       if @argv.delete "--trace-deprecation"
-        cmd = ["node", "--trace-deprecation"] + cmd
+        env["NODE_OPTIONS"] += " --trace-deprecation"
       end
 
       if @argv.delete "--no-deprecation"
-        cmd = ["node", "--no-deprecation"] + cmd
+        env["NODE_OPTIONS"] += " --no-deprecation"
       end
 
       # Webpack commands are not compatible with --config option.


### PR DESCRIPTION
### Summary

Currently debugging options for `node` are handled by switching to calling `node` which is fine except requires the absolute path to the javascript file to execute to be passed which isn't what happens if `node_modules_bin_exist?` is false because that falls back to just `yarn webpack` and `yarn webpack serve`:

```
cmd = if node_modules_bin_exist?
  ["#{@node_modules_bin_path}/webpack", "serve"]
else
  ["yarn", "webpack", "serve"]
end
```

This switches to providing those options using the [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions) env variable instead, which should ensure the options are always enabled regardless of how the desired commands are invoked.

This change also makes #349 / #195 a little easier.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [x] Update CHANGELOG file

### Other Information

I have tested this locally using `NODE_OPTIONS="--unhandled-rejections=warn"` and having a `Promise.reject()` in the webpack config  - I've not added any test cases since none exist already for this section, and it's a bit tricky to automate for the test suite.