### PR TITLE
ci: actually run shakapacker specs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,4 +36,4 @@ jobs:
           bundler-cache: true
 
       - name: Ruby specs
-        run: bundle exec rake run_spec:gem_bc
+        run: bundle exec rake run_spec:gem


### PR DESCRIPTION
### Summary

#299 mistakenly changed the `ruby` workflow to run the backwards compatible specs, meaning they were being run twice and the `shakapacker` specs were never being run.

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
