### PR TITLE
test: improve consistency of example names and general layout

### DIFF
--- a/spec/backward_compatibility_specs/compiler_strategy_spec.rb
+++ b/spec/backward_compatibility_specs/compiler_strategy_spec.rb
@@ -2,17 +2,19 @@ require_relative "spec_helper_initializer"
 
 describe "Webpacker::CompilerStrategy" do
   describe "#from_config" do
-    it "returns and instance of MtimeStrategy when compiler_strategy is set to mtime" do
+    it "returns an instance of MtimeStrategy when compiler_strategy is set to mtime" do
       allow(Webpacker.config).to receive(:compiler_strategy).and_return("mtime")
+
       expect(Webpacker::CompilerStrategy.from_config).to be_an_instance_of(Webpacker::MtimeStrategy)
     end
 
-    it "returns and instance of DigestStrategy when compiler_strategy is set to digest" do
+    it "returns an instance of DigestStrategy when compiler_strategy is set to digest" do
       allow(Webpacker.config).to receive(:compiler_strategy).and_return("digest")
+
       expect(Webpacker::CompilerStrategy.from_config).to be_an_instance_of(Webpacker::DigestStrategy)
     end
 
-    it "raise exception for unknown compiler_strategy in the config file" do
+    it "raise an exception for unknown compiler_strategy in the config file" do
       expected_error_message = "Unknown strategy 'other'. Available options are 'mtime' and 'digest'."
       allow(Webpacker.config).to receive(:compiler_strategy).and_return("other")
 

--- a/spec/backward_compatibility_specs/configuration_spec.rb
+++ b/spec/backward_compatibility_specs/configuration_spec.rb
@@ -14,36 +14,43 @@ describe "Webpacker::Configuration" do
 
     it "#source_path returns correct path" do
       source_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/app/packs").to_s
+
       expect(config.source_path.to_s).to eq source_path
     end
 
     it "#source_entry_path returns correct path" do
       source_entry_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/app/packs", "entrypoints").to_s
+
       expect(config.source_entry_path.to_s).to eq source_entry_path
     end
 
     it "#public_root_path returns correct path" do
       public_root_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/public").to_s
+
       expect(config.public_path.to_s).to eq public_root_path
     end
 
     it "#public_output_path returns correct path" do
       public_output_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/public/packs").to_s
+
       expect(config.public_output_path.to_s).to eq public_output_path
     end
 
     it "#public_manifest_path returns correct path" do
       public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/public/packs", "manifest.json").to_s
+
       expect(config.public_manifest_path.to_s).to eq public_manifest_path
     end
 
     it "#manifest_path returns correct path" do
       manifest_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/public/packs", "manifest.json").to_s
+
       expect(config.manifest_path.to_s).to eq manifest_path
     end
 
     it "#cache_path returns correct path" do
       cache_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/tmp/webpacker").to_s
+
       expect(config.cache_path.to_s).to eq cache_path
     end
 
@@ -186,6 +193,7 @@ describe "Webpacker::Configuration" do
 
     it "#public_output_path returns correct path" do
       expected_public_output_path = File.expand_path File.join(File.dirname(__FILE__), "public/packs").to_s
+
       expect(config.public_output_path.to_s).to eq expected_public_output_path
     end
   end
@@ -199,6 +207,7 @@ describe "Webpacker::Configuration" do
 
     it "#manifest_path returns correct expected value" do
       expected_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/app/packs", "manifest.json").to_s
+
       expect(config.manifest_path.to_s).to eq expected_manifest_path
     end
   end
@@ -206,8 +215,8 @@ describe "Webpacker::Configuration" do
   context "with webpacker_precompile entry set to false" do
     describe "#webpacker_precompile?" do
       before :each do
-        ENV.delete("WEBPACKER_PRECOMPILE")
         ENV.delete("SHAKAPACKER_PRECOMPILE")
+        ENV.delete("WEBPACKER_PRECOMPILE")
       end
 
       let(:config) {
@@ -229,9 +238,8 @@ describe "Webpacker::Configuration" do
         expect(subject).to be true
       end
 
-      it "returns false with WEBPACKER_PRECOMPILE set to falsy value" do
-        # ENV["WEBPACKER_PRECOMPILE"] = "no"
-        ENV.delete("WEBPACKER_PRECOMPILE")
+      it "returns false with WEBPACKER_PRECOMPILE set to nil" do
+        ENV["SHAKAPACKER_PRECOMPILE"] = nil
         expect(subject).to be false
       end
     end

--- a/spec/backward_compatibility_specs/dev_server_runner_spec.rb
+++ b/spec/backward_compatibility_specs/dev_server_runner_spec.rb
@@ -17,22 +17,25 @@ describe "DevServerRunner" do
 
   let(:test_app_path) { File.expand_path("webpacker_test_app", __dir__) }
 
-  it "run cmd via node modules" do
+  it "supports running via node modules" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
     verify_command(cmd, use_node_modules: true)
   end
 
-  it "run cmd via yarn" do
+  it "supports running via yarn" do
     cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
     verify_command(cmd, use_node_modules: false)
   end
 
-  it "run cmd argv" do
+  it "passes on arguments" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--quiet"]
+
     verify_command(cmd, argv: (["--quiet"]))
   end
 
-  it "run cmd argv with https" do
+  it "supports the https flag" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"]
 
     dev_server = double()
@@ -54,6 +57,7 @@ describe "DevServerRunner" do
     # ENV["WEBPACKER_CONFIG"] is the interface and env["SHAKAPACKER_CONFIG"] is internal
     ENV["WEBPACKER_CONFIG"] = env["SHAKAPACKER_CONFIG"] = "#{test_app_path}/config/webpacker_other_location.yml"
     env["WEBPACK_SERVE"] = "true"
+
     verify_command(cmd, env: env)
   end
 

--- a/spec/backward_compatibility_specs/dev_server_runner_spec.rb
+++ b/spec/backward_compatibility_specs/dev_server_runner_spec.rb
@@ -64,20 +64,17 @@ describe "DevServerRunner" do
   private
 
     def verify_command(cmd, use_node_modules: true, argv: [], env: Webpacker::Compiler.env)
-      cwd = Dir.pwd
-      Dir.chdir(test_app_path)
-      klass = Webpacker::DevServerRunner
-      instance = klass.new(argv)
+      Dir.chdir(test_app_path) do
+        klass = Webpacker::DevServerRunner
+        instance = klass.new(argv)
 
-      allow(klass).to receive(:new).and_return(instance)
-      allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
-      allow(Kernel).to receive(:exec).with(env, *cmd)
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
+        allow(Kernel).to receive(:exec).with(env, *cmd)
 
-      klass.run(argv)
+        klass.run(argv)
 
-      expect(Kernel).to have_received(:exec).with(env, *cmd)
-
-      ensure
-        Dir.chdir(cwd)
+        expect(Kernel).to have_received(:exec).with(env, *cmd)
+      end
     end
 end

--- a/spec/backward_compatibility_specs/dev_server_spec.rb
+++ b/spec/backward_compatibility_specs/dev_server_spec.rb
@@ -41,7 +41,7 @@ describe "DevServer" do
     end
   end
 
-  it "users SHAKAPACKER_DEV_SERVER for DEFAULT_ENV_PREFIX" do
+  it "uses SHAKAPACKER_DEV_SERVER for DEFAULT_ENV_PREFIX" do
     expect(Webpacker::DevServer::DEFAULT_ENV_PREFIX).to eq "SHAKAPACKER_DEV_SERVER"
   end
 end

--- a/spec/backward_compatibility_specs/digest_strategy_spec.rb
+++ b/spec/backward_compatibility_specs/digest_strategy_spec.rb
@@ -23,6 +23,7 @@ describe "DigestStrategy" do
 
   it "is fresh after compilation" do
     @digest_strategy.after_compile_hook
+
     expect(@digest_strategy.stale?).to be false
     expect(@digest_strategy.fresh?).to be true
   end
@@ -30,6 +31,7 @@ describe "DigestStrategy" do
   it "generates correct compilation_digest_path" do
     actual_path = @digest_strategy.send(:compilation_digest_path).basename.to_s
     expected_path = "last-compilation-digest-#{Webpacker.env}"
+
     expect(actual_path).to eq expected_path
   end
 end

--- a/spec/backward_compatibility_specs/engine_rake_tasks_spec.rb
+++ b/spec/backward_compatibility_specs/engine_rake_tasks_spec.rb
@@ -11,11 +11,12 @@ describe "EngineRakeTasks" do
 
   it "mounts app:webpacker task successfully" do
     output = Dir.chdir(mounted_app_path) { `rake -T` }
+
     expect(output).to match /app:webpacker.+DEPRECATED/
     expect(output).to match /app:webpacker:binstubs.+DEPRECATED/
   end
 
-  it "binstubs adds only expected files to bin directory" do
+  it "only adds expected files to bin directory when binstubs is run" do
     Dir.chdir(mounted_app_path) { `bundle exec rake app:webpacker:binstubs` }
     expected_binstub_paths.each { |path| expect(File.exist?(path)).to be true }
   end

--- a/spec/backward_compatibility_specs/helper_spec.rb
+++ b/spec/backward_compatibility_specs/helper_spec.rb
@@ -22,17 +22,17 @@ module ActionView::TestCase::Behavior
       @javascript_pack_tag_loaded = nil
     end
 
-    it "#asset_pack_path generates correct path" do
+    it "#asset_pack_path generates the correct path" do
       expect(asset_pack_path("bootstrap.js")).to eq "/packs/bootstrap-300631c4f0e0f9c865bc.js"
       expect(asset_pack_path("bootstrap.css")).to eq "/packs/bootstrap-c38deda30895059837cf.css"
     end
 
-    it "#asset_pack_url generates correct url" do
+    it "#asset_pack_url generates the correct url" do
       expect(asset_pack_url("bootstrap.js")).to eq "https://example.com/packs/bootstrap-300631c4f0e0f9c865bc.js"
       expect(asset_pack_url("bootstrap.css")).to eq "https://example.com/packs/bootstrap-c38deda30895059837cf.css"
     end
 
-    it "#image_pack_path generates correct path" do
+    it "#image_pack_path generates the correct path" do
       expect(image_pack_path("application.png")).to eq "/packs/application-k344a6d59eef8632c9d1.png"
       expect(image_pack_path("image.jpg")).to eq "/packs/static/image-c38deda30895059837cf.jpg"
       expect(image_pack_path("static/image.jpg")).to eq "/packs/static/image-c38deda30895059837cf.jpg"
@@ -40,7 +40,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_path("static/nested/image.jpg")).to eq "/packs/static/nested/image-c38deda30895059837cf.jpg"
     end
 
-    it "#image_pack_url generates correct path" do
+    it "#image_pack_url generates the correct path" do
       expect(image_pack_url("application.png")).to eq "https://example.com/packs/application-k344a6d59eef8632c9d1.png"
       expect(image_pack_url("image.jpg")).to eq "https://example.com/packs/static/image-c38deda30895059837cf.jpg"
       expect(image_pack_url("static/image.jpg")).to eq "https://example.com/packs/static/image-c38deda30895059837cf.jpg"
@@ -48,7 +48,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_url("static/nested/image.jpg")).to eq "https://example.com/packs/static/nested/image-c38deda30895059837cf.jpg"
     end
 
-    it "#image_pack_tag generates correct tags" do
+    it "#image_pack_tag generates the correct tags" do
       expect(image_pack_tag("application.png", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />"
       expect(image_pack_tag("image.jpg", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />"
       expect(image_pack_tag("static/image.jpg", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />"
@@ -57,7 +57,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_tag("static/image.jpg", srcset: { "static/image-2x.jpg" => "2x" })).to eq "<img srcset=\"/packs/static/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" />"
     end
 
-    it "#favicon_pack_tag generates correct tags" do
+    it "#favicon_pack_tag generates the correct tags" do
       expect(favicon_pack_tag("application.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/application-k344a6d59eef8632c9d1.png\" />"
       expect(favicon_pack_tag("mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />"
       expect(favicon_pack_tag("static/mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />"
@@ -65,7 +65,7 @@ module ActionView::TestCase::Behavior
       expect(favicon_pack_tag("static/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/nested/mb-icon-c38deda30895059837cf.png\" />"
     end
 
-    it "#preload_pack_asset generates correct tag" do
+    it "#preload_pack_asset generates the correct tag" do
       if self.class.method_defined?(:preload_link_tag)
         expect(preload_pack_asset("fonts/fa-regular-400.woff2")).to eq %(<link rel="preload" href="/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">)
       else
@@ -73,7 +73,7 @@ module ActionView::TestCase::Behavior
       end
     end
 
-    it "#javascript_pack_tag generates correct tags" do
+    it "#javascript_pack_tag generates the correct tags" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -84,7 +84,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", "bootstrap")).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct tags by passing `defer: false`" do
+    it "#javascript_pack_tag generates the correct tags when passing `defer: false`" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>
@@ -95,7 +95,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", "bootstrap", defer: false)).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct appended tag" do
+    it "#javascript_pack_tag generates the correct appended tag" do
       append_javascript_pack_tag("bootstrap", defer: false)
 
       expected = <<~HTML.chomp
@@ -108,7 +108,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application")).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct prepended tag" do
+    it "#javascript_pack_tag generates the correct prepended tag" do
       append_javascript_pack_tag("bootstrap")
       prepend_javascript_pack_tag("main")
 
@@ -123,7 +123,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application")).to eq expected
     end
 
-    it "#append_javascript_pack_tag raises error if called after calling #javascript_pack_tag" do
+    it "#append_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " +
         "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
@@ -134,7 +134,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#prepend_javascript_pack_tag raises error if called after calling #javascript_pack_tag" do
+    it "#prepend_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call prepend_javascript_pack_tag before javascript_pack_tag helper. " +
         "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
@@ -145,7 +145,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#javascript_pack_tag generates correct tags by passing `defer: true`" do
+    it "#javascript_pack_tag generates the correct tags when passing `defer: true`" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -155,7 +155,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", defer: true)).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct tags by passing symbol" do
+    it "#javascript_pack_tag generates the correct tags when passing a symbol" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -175,7 +175,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with string arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with string arguments" do
       expected = (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .uniq
         .map { |chunk| stylesheet_link_tag(chunk) }
@@ -184,7 +184,7 @@ module ActionView::TestCase::Behavior
       expect(stylesheet_pack_tag("application", "hello_stimulus")).to eq expected
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with symbol arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with symbol arguments" do
       expected = (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .uniq
         .map { |chunk| stylesheet_link_tag(chunk) }
@@ -193,7 +193,7 @@ module ActionView::TestCase::Behavior
       expect(stylesheet_pack_tag(:application, :hello_stimulus)).to eq expected
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with mixed arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with mixed arguments" do
       expected = (application_stylesheet_chunks)
         .map { |chunk| stylesheet_link_tag(chunk, media: "all") }
         .join("\n")
@@ -215,7 +215,7 @@ module ActionView::TestCase::Behavior
       }.to_not raise_error
     end
 
-    it "#stylesheet_pack_tag appends" do
+    it "#stylesheet_pack_tag appends tags" do
       append_stylesheet_pack_tag(:hello_stimulus)
 
       expect(stylesheet_pack_tag(:application)).to eq \
@@ -230,7 +230,7 @@ module ActionView::TestCase::Behavior
         (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq.map { |chunk| stylesheet_link_tag(chunk) }.join("\n")
     end
 
-    it "#stylesheet_pack_tag supports multiple invocations with different media attr" do
+    it "#stylesheet_pack_tag supports multiple invocations with different media attr values" do
       app_style = stylesheet_pack_tag(:application)
       app_style_with_media = stylesheet_pack_tag(:application, media: "print")
       hello_stimulus_style_with_media = stylesheet_pack_tag(:hello_stimulus, media: "all")

--- a/spec/backward_compatibility_specs/instance_spec.rb
+++ b/spec/backward_compatibility_specs/instance_spec.rb
@@ -13,19 +13,19 @@ describe "Webpacker::Instance" do
     Webpacker.instance = Webpacker::Instance.new
   end
 
-  it "uses default config path if no env variable defined" do
+  it "uses the default config path if no env variable defined" do
     actual_config_path = Rails.root.join("config/webpacker.yml")
     expected_config_path = Webpacker.config.config_path
 
     expect(expected_config_path).to eq(actual_config_path)
   end
 
-  it "uses WEBPACKER_CONFIG env variable for config file" do
+  it "uses the WEBPACKER_CONFIG env variable for the config file path" do
     ENV["WEBPACKER_CONFIG"] = "/some/random/path.yml"
 
     actual_config_path = "/some/random/path.yml"
     expected_config_path = Webpacker.config.config_path.to_s
 
-    expect(Webpacker.config.config_path.to_s).to eq("/some/random/path.yml")
+    expect(expected_config_path).to eq(actual_config_path)
   end
 end

--- a/spec/backward_compatibility_specs/manifest_spec.rb
+++ b/spec/backward_compatibility_specs/manifest_spec.rb
@@ -3,7 +3,7 @@ require_relative "spec_helper_initializer"
 describe "Webpacker::Manifest" do
   let(:manifest_path) { File.expand_path File.join(File.dirname(__FILE__), "webpacker_test_app/public/packs", "manifest.json").to_s }
 
-  it "#lookup! throws exception for a non-existing asset file" do
+  it "#lookup! raises an exception for a non-existing asset file" do
     asset_file = "calendar.js"
     expected_error_message = "Shakapacker can't find #{asset_file} in #{manifest_path}"
 
@@ -14,7 +14,7 @@ describe "Webpacker::Manifest" do
     }.to raise_error(Webpacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup! throws exception for a non-existing asset file with type and without extension" do
+  it "#lookup! raises an exception for a non-existing asset file with type and without an extension" do
     asset_file = "calendar"
     expected_error_message = "Shakapacker can't find #{asset_file}.js in #{manifest_path}"
 
@@ -25,57 +25,57 @@ describe "Webpacker::Manifest" do
     }.to raise_error(Webpacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup! returns path to bundled bootstrap.js" do
+  it "#lookup! returns the path to the bundled bootstrap.js" do
     actual = Webpacker.manifest.lookup!("bootstrap.js")
     expected = "/packs/bootstrap-300631c4f0e0f9c865bc.js"
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_pack_with_chunks! returns array of path to bundled bootstrap with type of javascript" do
+  it "#lookup_pack_with_chunks! returns an array of paths to the bundled bootstrap of type javascript" do
     actual = Webpacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript)
     expected = ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled bootstrap.js with type of javascript" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled bootstrap.js of type javascript" do
     actual = Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript)
     expected = ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled 'print/application' without extension and in a sub-directory" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled 'print/application' without an extension and in a sub-directory" do
     actual = Webpacker.manifest.lookup_pack_with_chunks!("print/application", type: :css)
     expected = ["/packs/print/application-983b6c164a47f7ed49cd.css"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled 'print/application.css' in a sub-directory" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled 'print/application.css' in a sub-directory" do
     actual = Webpacker.manifest.lookup_pack_with_chunks!("print/application.css", type: :css)
     expected = ["/packs/print/application-983b6c164a47f7ed49cd.css"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup returns nil for non-existing asset file" do
+  it "#lookup returns nil for non-existing asset files" do
     expect(Webpacker.manifest.lookup("foo.js")).to be nil
   end
 
-  it "#lookup_pack_with_chunks returns nil for non-existing asset file" do
+  it "#lookup_pack_with_chunks returns nil for non-existing asset files" do
     expect(Webpacker.manifest.lookup_pack_with_chunks("foo.js")).to be nil
   end
 
-  it "#lookup returns path for bootstrap.js" do
+  it "#lookup returns the path for bootstrap.js" do
     actual = Webpacker.manifest.lookup("bootstrap.js")
     expected = "/packs/bootstrap-300631c4f0e0f9c865bc.js"
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_pack_with_chunks! throws exception for a non-existing asset file" do
+  it "#lookup_pack_with_chunks! raises an exception for non-existing asset files" do
     asset_file = "calendar"
 
     expected_error_message = "Shakapacker can't find #{asset_file}.js in #{manifest_path}"
@@ -87,7 +87,7 @@ describe "Webpacker::Manifest" do
     }.to raise_error(Shakapacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup_pack_with_chunks! returns array of paths to bundled js files with 'application' in their name" do
+  it "#lookup_pack_with_chunks! returns an array of paths to bundled js files with 'application' in their name" do
     actual_application_entrypoints = Webpacker.manifest.lookup_pack_with_chunks!("application", type: :javascript)
     expected_application_entrypoints = [
       "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",

--- a/spec/backward_compatibility_specs/mtime_strategy_spec.rb
+++ b/spec/backward_compatibility_specs/mtime_strategy_spec.rb
@@ -5,7 +5,7 @@ describe "Webpacker::MtimeStrategy" do
   let(:manifest_timestamp) { Time.parse("2021-01-01 12:34:56 UTC") }
 
   describe "#fresh?" do
-    it "returns false when manifest is missing" do
+    it "returns false when the manifest is missing" do
       latest_timestamp = manifest_timestamp + 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i, manifest_exists: false) do
@@ -13,7 +13,7 @@ describe "Webpacker::MtimeStrategy" do
       end
     end
 
-    it "returns false when manifest is older" do
+    it "returns false when the manifest is older" do
       latest_timestamp = manifest_timestamp + 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i) do
@@ -21,7 +21,7 @@ describe "Webpacker::MtimeStrategy" do
       end
     end
 
-    it "returns true when manifest is new" do
+    it "returns true when the manifest is new" do
       latest_timestamp = manifest_timestamp - 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i) do

--- a/spec/backward_compatibility_specs/rake_tasks_spec.rb
+++ b/spec/backward_compatibility_specs/rake_tasks_spec.rb
@@ -1,10 +1,11 @@
 require_relative "spec_helper_initializer"
 
 describe "RakeTasks" do
-  let(:test_app_path) { File.expand_path("webpacker_test_app", __dir__) }
+  TEST_APP_PATH = File.expand_path("webpacker_test_app", __dir__)
 
   it "`rake -T` lists Webpacker tasks" do
-    output = Dir.chdir(test_app_path) { `rake -T` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake -T` }
+
     expect(output).to match /webpacker .+DEPRECATED/
     expect(output).to match /webpacker:check_binstubs.+DEPRECATED/
     expect(output).to match /webpacker:check_node.+DEPRECATED/
@@ -17,19 +18,22 @@ describe "RakeTasks" do
   end
 
   it "`webpacker:check_binstubs` doesn't get 'webpack binstub not found' error" do
-    output = Dir.chdir(test_app_path) { `rake webpacker:check_binstubs 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake webpacker:check_binstubs 2>&1` }
+
     expect(output).to_not include "webpack binstub not found."
     expect(output).to include "DEPRECATION"
   end
 
   it "`webpacker:check_node` doesn't get 'webpacker requires Node.js' error" do
-    output = Dir.chdir(test_app_path) { `rake webpacker:check_node 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake webpacker:check_node 2>&1` }
+
     expect(output).to_not include "Shakapacker requires Node.js"
     expect(output).to include "DEPRECATION"
   end
 
   it "`webpacker:check_yarn` doesn't get error related to yarn" do
-    output = Dir.chdir(test_app_path) { `rake webpacker:check_yarn 2>&1` }
+    output = Dir.chdir(TEST_APP_PATH) { `rake webpacker:check_yarn 2>&1` }
+
     expect(output).to_not include "Yarn not installed"
     expect(output).to_not include "Shakapacker requires Yarn"
     expect(output).to include "DEPRECATION"

--- a/spec/backward_compatibility_specs/webpack_runner_spec.rb
+++ b/spec/backward_compatibility_specs/webpack_runner_spec.rb
@@ -13,28 +13,27 @@ describe "WebpackRunner" do
     ENV["RAILS_ENV"] = @original_rails_env
   end
 
-  it "runs cmd via node_modules" do
+  let(:test_app_path) { File.expand_path("./webpacker_test_app", __dir__) }
+
+  it "supports running via node_modules" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: true)
   end
 
-  it "runs cmd via yarn" do
+  it "supports running via yarn" do
     cmd = ["yarn", "webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: false)
   end
 
-  it "runs cmd argv" do
+  it "passes on arguments" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--watch"]
 
     verify_command(cmd, argv: ["--watch"])
   end
 
   private
-    def test_app_path
-      File.expand_path("webpacker_test_app", __dir__)
-    end
 
     def verify_command(cmd, use_node_modules: true, argv: [])
       cwd = Dir.pwd

--- a/spec/backward_compatibility_specs/webpack_runner_spec.rb
+++ b/spec/backward_compatibility_specs/webpack_runner_spec.rb
@@ -36,20 +36,17 @@ describe "WebpackRunner" do
   private
 
     def verify_command(cmd, use_node_modules: true, argv: [])
-      cwd = Dir.pwd
-      Dir.chdir(test_app_path)
+      Dir.chdir(test_app_path) do
+        klass = Webpacker::WebpackRunner
+        instance = klass.new(argv)
 
-      klass = Webpacker::WebpackRunner
-      instance = klass.new(argv)
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
+        allow(Kernel).to receive(:exec)
 
-      allow(klass).to receive(:new).and_return(instance)
-      allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
-      allow(Kernel).to receive(:exec)
+        klass.run(argv)
 
-      klass.run(argv)
-
-      expect(Kernel).to have_received(:exec).with(Webpacker::Compiler.env, *cmd)
-    ensure
-      Dir.chdir(cwd)
+        expect(Kernel).to have_received(:exec).with(Webpacker::Compiler.env, *cmd)
+      end
     end
 end

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -53,13 +53,13 @@ describe "Generator" do
         expect(actual_content).to eq expected_content
       end
 
-      it "replaces package.json with template file" do
+      it "replaces package.json with the template file" do
         actual_content = read(path_in_the_app("package.json"))
 
         expect(actual_content).to match /"name": "app",/
       end
 
-      it "creates webpack config directory and its files" do
+      it "creates the webpack config directory and its files" do
         expected_files = [
           "webpack.config.js"
         ]
@@ -78,6 +78,7 @@ describe "Generator" do
 
         Dir.chdir(File.join(TEMP_RAILS_APP_PATH, "bin")) do
           actual_binstubs = Dir.glob("*")
+
           expect(actual_binstubs).to include(*expected_binstubs)
         end
       end
@@ -96,10 +97,11 @@ describe "Generator" do
 
       it "updates `bin/setup`" do
         setup_file_content = read(path_in_the_app("bin/setup"))
+
         expect(setup_file_content).to match %r(^\s*system!\(['"]bin/yarn['"]\))
       end
 
-      it "adds relevant shakapacker version in package.json depending on gem version" do
+      it "uses the shakapacker version in package.json depending on gem version" do
         npm_version = Shakapacker::Utils::VersionSyntaxConverter.new.rubygem_to_npm(Shakapacker::VERSION)
 
         actual_content = read(path_in_the_app("package.json"))
@@ -143,6 +145,7 @@ describe "Generator" do
         it "passes the test for rendering react component on the page" do
           Bundler.with_unbundled_env do
             sh_in_dir(TEMP_RAILS_APP_PATH, "./bin/rails app:template LOCATION=../e2e_template/template.rb")
+
             expect(sh_in_dir(TEMP_RAILS_APP_PATH, "bundle exec rspec")).to be_truthy
           end
         end
@@ -151,6 +154,7 @@ describe "Generator" do
   end
 
   private
+
     def path_in_the_app(relative_path = nil)
       Pathname.new(File.join([TEMP_RAILS_APP_PATH, relative_path].compact))
     end

--- a/spec/shakapacker/compiler_strategy_spec.rb
+++ b/spec/shakapacker/compiler_strategy_spec.rb
@@ -2,17 +2,19 @@ require_relative "spec_helper_initializer"
 
 describe "Shakapacker::CompilerStrategy" do
   describe "#from_config" do
-    it "returns and instance of MtimeStrategy when compiler_strategy is set to mtime" do
+    it "returns an instance of MtimeStrategy when compiler_strategy is set to mtime" do
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("mtime")
+
       expect(Shakapacker::CompilerStrategy.from_config).to be_an_instance_of(Shakapacker::MtimeStrategy)
     end
 
-    it "returns and instance of DigestStrategy when compiler_strategy is set to digest" do
+    it "returns an instance of DigestStrategy when compiler_strategy is set to digest" do
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("digest")
+
       expect(Shakapacker::CompilerStrategy.from_config).to be_an_instance_of(Shakapacker::DigestStrategy)
     end
 
-    it "raise exception for unknown compiler_strategy in the config file" do
+    it "raise an exception for unknown compiler_strategy in the config file" do
       expected_error_message = "Unknown strategy 'other'. Available options are 'mtime' and 'digest'."
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("other")
 

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -14,36 +14,43 @@ describe "Shakapacker::Configuration" do
 
     it "#source_path returns correct path" do
       source_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/app/javascript").to_s
+
       expect(config.source_path.to_s).to eq source_path
     end
 
     it "#source_entry_path returns correct path" do
       source_entry_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/app/javascript", "entrypoints").to_s
+
       expect(config.source_entry_path.to_s).to eq source_entry_path
     end
 
     it "#public_root_path returns correct path" do
       public_root_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/public").to_s
+
       expect(config.public_path.to_s).to eq public_root_path
     end
 
     it "#public_output_path returns correct path" do
       public_output_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/public/packs").to_s
+
       expect(config.public_output_path.to_s).to eq public_output_path
     end
 
     it "#public_manifest_path returns correct path" do
       public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/public/packs", "manifest.json").to_s
+
       expect(config.public_manifest_path.to_s).to eq public_manifest_path
     end
 
     it "#manifest_path returns correct path" do
       manifest_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/public/packs", "manifest.json").to_s
+
       expect(config.manifest_path.to_s).to eq manifest_path
     end
 
     it "#cache_path returns correct path" do
       cache_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/tmp/shakapacker").to_s
+
       expect(config.cache_path.to_s).to eq cache_path
     end
 
@@ -125,7 +132,7 @@ describe "Shakapacker::Configuration" do
 
     describe "#shakapacker_precompile?" do
       before :each do
-        ENV["SHAKAPACKER_PRECOMPILE"] = nil
+        ENV.delete("SHAKAPACKER_PRECOMPILE")
       end
 
       subject { config.shakapacker_precompile? }
@@ -185,6 +192,7 @@ describe "Shakapacker::Configuration" do
 
     it "#public_output_path returns correct path" do
       expected_public_output_path = File.expand_path File.join(File.dirname(__FILE__), "./public/packs").to_s
+
       expect(config.public_output_path.to_s).to eq expected_public_output_path
     end
   end
@@ -198,6 +206,7 @@ describe "Shakapacker::Configuration" do
 
     it "#manifest_path returns correct expected value" do
       expected_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "./test_app/app/javascript", "manifest.json").to_s
+
       expect(config.manifest_path.to_s).to eq expected_manifest_path
     end
   end
@@ -205,7 +214,7 @@ describe "Shakapacker::Configuration" do
   context "with shakapacker_precompile entry set to false" do
     describe "#shakapacker_precompile?" do
       before :each do
-        ENV["SHAKAPACKER_PRECOMPILE"] = nil
+        ENV.delete("SHAKAPACKER_PRECOMPILE")
       end
 
       let(:config) {
@@ -276,6 +285,7 @@ describe "Shakapacker::Configuration" do
     it "#cache_manifest? fall back to 'production' config from bundled file" do
       expect(config.cache_manifest?).to be true
     end
+
     it "#shakapacker_precompile? use 'staging' config from custom file" do
       expect(config.shakapacker_precompile?).to be false
     end

--- a/spec/shakapacker/dev_server_runner_spec.rb
+++ b/spec/shakapacker/dev_server_runner_spec.rb
@@ -62,20 +62,17 @@ describe "DevServerRunner" do
   private
 
     def verify_command(cmd, use_node_modules: true, argv: [], env: Shakapacker::Compiler.env)
-      cwd = Dir.pwd
-      Dir.chdir(test_app_path)
-      klass = Shakapacker::DevServerRunner
-      instance = klass.new(argv)
+      Dir.chdir(test_app_path) do
+        klass = Shakapacker::DevServerRunner
+        instance = klass.new(argv)
 
-      allow(klass).to receive(:new).and_return(instance)
-      allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
-      allow(Kernel).to receive(:exec).with(env, *cmd)
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
+        allow(Kernel).to receive(:exec).with(env, *cmd)
 
-      klass.run(argv)
+        klass.run(argv)
 
-      expect(Kernel).to have_received(:exec).with(env, *cmd)
-
-      ensure
-        Dir.chdir(cwd)
+        expect(Kernel).to have_received(:exec).with(env, *cmd)
+      end
     end
 end

--- a/spec/shakapacker/dev_server_runner_spec.rb
+++ b/spec/shakapacker/dev_server_runner_spec.rb
@@ -16,19 +16,25 @@ describe "DevServerRunner" do
 
   let(:test_app_path) { File.expand_path("./test_app", __dir__) }
 
-  it "run cmd via node modules" do
+  it "supports running via node modules" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
     verify_command(cmd, use_node_modules: true)
   end
-  it "run cmd via yarn" do
+
+  it "supports running via yarn" do
     cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
     verify_command(cmd, use_node_modules: false)
   end
-  it "run cmd argv" do
+
+  it "passes on arguments" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--quiet"]
+
     verify_command(cmd, argv: (["--quiet"]))
   end
-  it "run cmd argv with https" do
+
+  it "supports the https flag" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"]
 
     dev_server = double()
@@ -42,11 +48,14 @@ describe "DevServerRunner" do
       verify_command(cmd, argv: (["--https"]))
     end.and_return(dev_server)
   end
+
   it "accepts environment variables" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
     env = Shakapacker::Compiler.env.dup
+
     ENV["SHAKAPACKER_CONFIG"] = env["SHAKAPACKER_CONFIG"] = "#{test_app_path}/config/shakapacker_other_location.yml"
     env["WEBPACK_SERVE"] = "true"
+
     verify_command(cmd, env: env)
   end
 

--- a/spec/shakapacker/dev_server_spec.rb
+++ b/spec/shakapacker/dev_server_spec.rb
@@ -41,7 +41,7 @@ describe "DevServer" do
     end
   end
 
-  it "users SHAKAPACKER_DEV_SERVER for DEFAULT_ENV_PREFIX" do
+  it "uses SHAKAPACKER_DEV_SERVER for DEFAULT_ENV_PREFIX" do
     expect(Shakapacker::DevServer::DEFAULT_ENV_PREFIX).to eq "SHAKAPACKER_DEV_SERVER"
   end
 

--- a/spec/shakapacker/digest_strategy_spec.rb
+++ b/spec/shakapacker/digest_strategy_spec.rb
@@ -23,6 +23,7 @@ describe "DigestStrategy" do
 
   it "is fresh after compilation" do
     @digest_strategy.after_compile_hook
+
     expect(@digest_strategy.stale?).to be false
     expect(@digest_strategy.fresh?).to be true
   end
@@ -30,6 +31,7 @@ describe "DigestStrategy" do
   it "generates correct compilation_digest_path" do
     actual_path = @digest_strategy.send(:compilation_digest_path).basename.to_s
     expected_path = "last-compilation-digest-#{Shakapacker.env}"
+
     expect(actual_path).to eq expected_path
   end
 end

--- a/spec/shakapacker/engine_rake_tasks_spec.rb
+++ b/spec/shakapacker/engine_rake_tasks_spec.rb
@@ -11,10 +11,11 @@ describe "EngineRakeTasks" do
 
   it "mounts app:shakapacker task successfully" do
     output = Dir.chdir(mounted_app_path) { `rake -T` }
+
     expect(output).to include "app:shakapacker"
   end
 
-  it "binstubs adds only expected files to bin directory" do
+  it "only adds expected files to bin directory when binstubs is run" do
     Dir.chdir(mounted_app_path) { `bundle exec rake app:shakapacker:binstubs` }
     expected_binstub_paths.each { |path| expect(File.exist?(path)).to be true }
   end

--- a/spec/shakapacker/helper_spec.rb
+++ b/spec/shakapacker/helper_spec.rb
@@ -22,17 +22,17 @@ module ActionView::TestCase::Behavior
       @javascript_pack_tag_loaded = nil
     end
 
-    it "#asset_pack_path generates correct path" do
+    it "#asset_pack_path generates the correct path" do
       expect(asset_pack_path("bootstrap.js")).to eq "/packs/bootstrap-300631c4f0e0f9c865bc.js"
       expect(asset_pack_path("bootstrap.css")).to eq "/packs/bootstrap-c38deda30895059837cf.css"
     end
 
-    it "#asset_pack_url generates correct url" do
+    it "#asset_pack_url generates the correct url" do
       expect(asset_pack_url("bootstrap.js")).to eq "https://example.com/packs/bootstrap-300631c4f0e0f9c865bc.js"
       expect(asset_pack_url("bootstrap.css")).to eq "https://example.com/packs/bootstrap-c38deda30895059837cf.css"
     end
 
-    it "#image_pack_path generates correct path" do
+    it "#image_pack_path generates the correct path" do
       expect(image_pack_path("application.png")).to eq "/packs/application-k344a6d59eef8632c9d1.png"
       expect(image_pack_path("image.jpg")).to eq "/packs/static/image-c38deda30895059837cf.jpg"
       expect(image_pack_path("static/image.jpg")).to eq "/packs/static/image-c38deda30895059837cf.jpg"
@@ -40,7 +40,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_path("static/nested/image.jpg")).to eq "/packs/static/nested/image-c38deda30895059837cf.jpg"
     end
 
-    it "#image_pack_url generates correct path" do
+    it "#image_pack_url generates the correct path" do
       expect(image_pack_url("application.png")).to eq "https://example.com/packs/application-k344a6d59eef8632c9d1.png"
       expect(image_pack_url("image.jpg")).to eq "https://example.com/packs/static/image-c38deda30895059837cf.jpg"
       expect(image_pack_url("static/image.jpg")).to eq "https://example.com/packs/static/image-c38deda30895059837cf.jpg"
@@ -48,7 +48,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_url("static/nested/image.jpg")).to eq "https://example.com/packs/static/nested/image-c38deda30895059837cf.jpg"
     end
 
-    it "#image_pack_tag generates correct tags" do
+    it "#image_pack_tag generates the correct tags" do
       expect(image_pack_tag("application.png", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />"
       expect(image_pack_tag("image.jpg", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />"
       expect(image_pack_tag("static/image.jpg", size: "16x10", alt: "Edit Entry")).to eq "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />"
@@ -57,7 +57,7 @@ module ActionView::TestCase::Behavior
       expect(image_pack_tag("static/image.jpg", srcset: { "static/image-2x.jpg" => "2x" })).to eq "<img srcset=\"/packs/static/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" />"
     end
 
-    it "#favicon_pack_tag generates correct tags" do
+    it "#favicon_pack_tag generates the correct tags" do
       expect(favicon_pack_tag("application.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/application-k344a6d59eef8632c9d1.png\" />"
       expect(favicon_pack_tag("mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />"
       expect(favicon_pack_tag("static/mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />"
@@ -65,7 +65,7 @@ module ActionView::TestCase::Behavior
       expect(favicon_pack_tag("static/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")).to eq "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/nested/mb-icon-c38deda30895059837cf.png\" />"
     end
 
-    it "#preload_pack_asset generates correct tag" do
+    it "#preload_pack_asset generates the correct tag" do
       if self.class.method_defined?(:preload_link_tag)
         expect(preload_pack_asset("fonts/fa-regular-400.woff2")).to eq %(<link rel="preload" href="/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">)
       else
@@ -73,7 +73,7 @@ module ActionView::TestCase::Behavior
       end
     end
 
-    it "#javascript_pack_tag generates correct tags" do
+    it "#javascript_pack_tag generates the correct tags" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -84,7 +84,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", "bootstrap")).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct tags by passing `defer: false`" do
+    it "#javascript_pack_tag generates the correct tags when passing `defer: false`" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>
@@ -95,7 +95,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", "bootstrap", defer: false)).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct appended tag" do
+    it "#javascript_pack_tag generates the correct appended tag" do
       append_javascript_pack_tag("bootstrap", defer: false)
 
       expected = <<~HTML.chomp
@@ -108,7 +108,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application")).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct prepended tag" do
+    it "#javascript_pack_tag generates the correct prepended tag" do
       append_javascript_pack_tag("bootstrap")
       prepend_javascript_pack_tag("main")
 
@@ -123,7 +123,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application")).to eq expected
     end
 
-    it "#append_javascript_pack_tag raises error if called after calling #javascript_pack_tag" do
+    it "#append_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " +
         "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
@@ -134,7 +134,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#prepend_javascript_pack_tag raises error if called after calling #javascript_pack_tag" do
+    it "#prepend_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call prepend_javascript_pack_tag before javascript_pack_tag helper. " +
         "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
@@ -145,7 +145,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#javascript_pack_tag generates correct tags by passing `defer: true`" do
+    it "#javascript_pack_tag generates the correct tags when passing `defer: true`" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -155,7 +155,7 @@ module ActionView::TestCase::Behavior
       expect(javascript_pack_tag("application", defer: true)).to eq expected
     end
 
-    it "#javascript_pack_tag generates correct tags by passing symbol" do
+    it "#javascript_pack_tag generates the correct tags when passing a symbol" do
       expected = <<~HTML.chomp
         <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
         <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
@@ -175,7 +175,7 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with string arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with string arguments" do
       expected = (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .uniq
         .map { |chunk| stylesheet_link_tag(chunk) }
@@ -184,7 +184,7 @@ module ActionView::TestCase::Behavior
       expect(stylesheet_pack_tag("application", "hello_stimulus")).to eq expected
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with symbol arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with symbol arguments" do
       expected = (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .uniq
         .map { |chunk| stylesheet_link_tag(chunk) }
@@ -193,7 +193,7 @@ module ActionView::TestCase::Behavior
       expect(stylesheet_pack_tag(:application, :hello_stimulus)).to eq expected
     end
 
-    it "#stylesheet_pack_tag generates correct link tag with mixed arguments" do
+    it "#stylesheet_pack_tag generates the correct link tag with mixed arguments" do
       expected = (application_stylesheet_chunks)
         .map { |chunk| stylesheet_link_tag(chunk, media: "all") }
         .join("\n")
@@ -215,7 +215,7 @@ module ActionView::TestCase::Behavior
       }.to_not raise_error
     end
 
-    it "#stylesheet_pack_tag appends" do
+    it "#stylesheet_pack_tag appends tags" do
       append_stylesheet_pack_tag(:hello_stimulus)
 
       expect(stylesheet_pack_tag(:application)).to eq \
@@ -230,7 +230,7 @@ module ActionView::TestCase::Behavior
         (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks).uniq.map { |chunk| stylesheet_link_tag(chunk) }.join("\n")
     end
 
-    it "#stylesheet_pack_tag supports multiple invocations with different media attr" do
+    it "#stylesheet_pack_tag supports multiple invocations with different media attr values" do
       app_style = stylesheet_pack_tag(:application)
       app_style_with_media = stylesheet_pack_tag(:application, media: "print")
       hello_stimulus_style_with_media = stylesheet_pack_tag(:hello_stimulus, media: "all")

--- a/spec/shakapacker/instance_spec.rb
+++ b/spec/shakapacker/instance_spec.rb
@@ -13,14 +13,14 @@ describe "Shakapacker::Instance" do
     Shakapacker.instance = Shakapacker::Instance.new
   end
 
-  it "uses default config path if no env variable defined" do
+  it "uses the default config path if no env variable defined" do
     actual_config_path = Rails.root.join("config/shakapacker.yml")
     expected_config_path = Shakapacker.config.config_path
 
     expect(expected_config_path).to eq(actual_config_path)
   end
 
-  it "uses SHAKAPACKER_CONFIG env variable for config file" do
+  it "uses the SHAKAPACKER_CONFIG env variable for the config file path" do
     ENV["SHAKAPACKER_CONFIG"] = "/some/random/path.yml"
 
     actual_config_path = "/some/random/path.yml"

--- a/spec/shakapacker/manifest_spec.rb
+++ b/spec/shakapacker/manifest_spec.rb
@@ -3,7 +3,7 @@ require_relative "spec_helper_initializer"
 describe "Shakapacker::Manifest" do
   let(:manifest_path) { File.expand_path File.join(File.dirname(__FILE__), "./test_app/public/packs", "manifest.json").to_s }
 
-  it "#lookup! throws exception for a non-existing asset file" do
+  it "#lookup! raises an exception for a non-existing asset file" do
     asset_file = "calendar.js"
     expected_error_message = "Shakapacker can't find #{asset_file} in #{manifest_path}"
 
@@ -14,7 +14,7 @@ describe "Shakapacker::Manifest" do
     }.to raise_error(Shakapacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup! throws exception for a non-existing asset file with type and without extension" do
+  it "#lookup! raises an exception for a non-existing asset file with type and without an extension" do
     asset_file = "calendar"
     expected_error_message = "Shakapacker can't find #{asset_file}.js in #{manifest_path}"
 
@@ -25,57 +25,57 @@ describe "Shakapacker::Manifest" do
     }.to raise_error(Shakapacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup! returns path to bundled bootstrap.js" do
+  it "#lookup! returns the path to the bundled bootstrap.js" do
     actual = Shakapacker.manifest.lookup!("bootstrap.js")
     expected = "/packs/bootstrap-300631c4f0e0f9c865bc.js"
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_pack_with_chunks! returns array of path to bundled bootstrap with type of javascript" do
+  it "#lookup_pack_with_chunks! returns an array of paths to the bundled bootstrap of type javascript" do
     actual = Shakapacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript)
     expected = ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled bootstrap.js with type of javascript" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled bootstrap.js of type javascript" do
     actual = Shakapacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript)
     expected = ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled 'print/application' without extension and in a sub-directory" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled 'print/application' without an extension and in a sub-directory" do
     actual = Shakapacker.manifest.lookup_pack_with_chunks!("print/application", type: :css)
     expected = ["/packs/print/application-983b6c164a47f7ed49cd.css"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_with_chunks! returns array of path to bundled 'print/application.css' in a sub-directory" do
+  it "#lookup_with_chunks! returns an array of paths to the bundled 'print/application.css' in a sub-directory" do
     actual = Shakapacker.manifest.lookup_pack_with_chunks!("print/application.css", type: :css)
     expected = ["/packs/print/application-983b6c164a47f7ed49cd.css"]
 
     expect(actual).to eq expected
   end
 
-  it "#lookup returns nil for non-existing asset file" do
+  it "#lookup returns nil for non-existing asset files" do
     expect(Shakapacker.manifest.lookup("foo.js")).to be nil
   end
 
-  it "#lookup_pack_with_chunks returns nil for non-existing asset file" do
+  it "#lookup_pack_with_chunks returns nil for non-existing asset files" do
     expect(Shakapacker.manifest.lookup_pack_with_chunks("foo.js")).to be nil
   end
 
-  it "#lookup returns path for bootstrap.js" do
+  it "#lookup returns the path for bootstrap.js" do
     actual = Shakapacker.manifest.lookup("bootstrap.js")
     expected = "/packs/bootstrap-300631c4f0e0f9c865bc.js"
 
     expect(actual).to eq expected
   end
 
-  it "#lookup_pack_with_chunks! throws exception for a non-existing asset file" do
+  it "#lookup_pack_with_chunks! raises an exception for non-existing asset files" do
     asset_file = "calendar"
 
     expected_error_message = "Shakapacker can't find #{asset_file}.js in #{manifest_path}"
@@ -87,7 +87,7 @@ describe "Shakapacker::Manifest" do
     }.to raise_error(Shakapacker::Manifest::MissingEntryError, /#{expected_error_message}/)
   end
 
-  it "#lookup_pack_with_chunks! returns array of paths to bundled js files with 'application' in their name" do
+  it "#lookup_pack_with_chunks! returns an array of paths to bundled js files with 'application' in their name" do
     actual_application_entrypoints = Shakapacker.manifest.lookup_pack_with_chunks!("application", type: :javascript)
     expected_application_entrypoints = [
       "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",

--- a/spec/shakapacker/mtime_strategy_spec.rb
+++ b/spec/shakapacker/mtime_strategy_spec.rb
@@ -5,7 +5,7 @@ describe "Shakapacker::MtimeStrategy" do
   let(:manifest_timestamp) { Time.parse("2021-01-01 12:34:56 UTC") }
 
   describe "#fresh?" do
-    it "returns false when manifest is missing" do
+    it "returns false when the manifest is missing" do
       latest_timestamp = manifest_timestamp + 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i, manifest_exists: false) do
@@ -13,7 +13,7 @@ describe "Shakapacker::MtimeStrategy" do
       end
     end
 
-    it "returns false when manifest is older" do
+    it "returns false when the manifest is older" do
       latest_timestamp = manifest_timestamp + 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i) do
@@ -21,7 +21,7 @@ describe "Shakapacker::MtimeStrategy" do
       end
     end
 
-    it "returns true when manifest is new" do
+    it "returns true when the manifest is new" do
       latest_timestamp = manifest_timestamp - 3600
 
       with_stubs(latest_timestamp: latest_timestamp.to_i) do

--- a/spec/shakapacker/rake_tasks_spec.rb
+++ b/spec/shakapacker/rake_tasks_spec.rb
@@ -36,7 +36,7 @@ describe "RakeTasks" do
   end
 
   describe "`shakapacker:check_binstubs`" do
-    def with_temporary_file(file_name, &block)
+    def with_temporary_file(file_name)
       FileUtils.touch(file_name, verbose: false)
       yield if block_given?
     ensure

--- a/spec/shakapacker/rake_tasks_spec.rb
+++ b/spec/shakapacker/rake_tasks_spec.rb
@@ -18,16 +18,19 @@ describe "RakeTasks" do
 
   it "`shakapacker:check_binstubs` doesn't get 'webpack binstub not found' error" do
     output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_binstubs 2>&1` }
+
     expect(output).to_not include "webpack binstub not found."
   end
 
   it "`shakapacker:check_node` doesn't get 'shakapacker requires Node.js' error" do
     output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_node 2>&1` }
+
     expect(output).to_not include "Shakapacker requires Node.js"
   end
 
-  it "`shakapacker:check_yarn` doesn't get error related to yarn" do
+  it "`shakapacker:check_yarn` doesn't get errors related to yarn" do
     output = Dir.chdir(TEST_APP_PATH) { `rake shakapacker:check_yarn 2>&1` }
+
     expect(output).to_not include "Yarn not installed"
     expect(output).to_not include "Shakapacker requires Yarn"
   end

--- a/spec/shakapacker/shakapacker_spec.rb
+++ b/spec/shakapacker/shakapacker_spec.rb
@@ -12,11 +12,11 @@ describe "Shakapacker" do
       allow(dev_server).to receive(:running?).and_return(true)
     end
 
-    it "returns nil with disabled dev_server" do
+    it "returns nil when the dev server is disabled" do
       expect(Shakapacker.inlining_css?).to be nil
     end
 
-    it "returns true with enabled hmr" do
+    it "returns true when hmr is enabled" do
       allow(dev_server).to receive(:hmr?).and_return(true)
       allow(dev_server).to receive(:inline_css?).and_return(true)
 
@@ -25,7 +25,7 @@ describe "Shakapacker" do
       expect(Shakapacker.inlining_css?).to be true
     end
 
-    it "returns false with enabled hmr and explicitly setting inline_css to false" do
+    it "returns false when hmr is enabled and inline_css is explicitly set to false" do
       allow(dev_server).to receive(:hmr?).and_return(true)
       allow(dev_server).to receive(:inline_css?).and_return(false)
 
@@ -35,7 +35,7 @@ describe "Shakapacker" do
     end
   end
 
-  it "has app_autoload_paths cleanup" do
+  it "automatically cleans up app_autoload_paths" do
     expect($test_app_autoload_paths_in_initializer).to eq []
   end
 end

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -45,53 +45,53 @@ describe "VersionChecker" do
       .to_stderr
   end
 
-  it "raises exception on different major version" do
+  it "raises an exception on different major versions" do
     node_package_version = NodePackageVersionDouble.new(raw: "6.1.0", major_minor_patch: ["6", "1", "0"])
 
     expect { check_version(node_package_version, "7.0.0") }
       .to raise_error(/\*\*ERROR\*\* Shakapacker: Shakapacker gem and node package versions do not match/)
   end
 
-  it "raises exception on different minor version" do
+  it "raises an exception on different minor versions" do
     node_package_version = NodePackageVersionDouble.new(raw: "6.1.0", major_minor_patch: ["6", "1", "0"])
 
     expect { check_version(node_package_version, "6.2.0") }
       .to raise_error(/\*\*ERROR\*\* Shakapacker: Shakapacker gem and node package versions do not match/)
   end
 
-  it "raises exception on different patch version" do
+  it "raises an exception on different patch versions" do
     node_package_version = NodePackageVersionDouble.new(raw: "6.1.1", major_minor_patch: ["6", "1", "1"])
 
     expect { check_version(node_package_version, "6.1.2") }
       .to raise_error(/\*\*ERROR\*\* Shakapacker: Shakapacker gem and node package versions do not match/)
   end
 
-  it "raises exception on semver wildcard" do
+  it "raises an exception on a semver wildcard" do
     node_package_version = NodePackageVersionDouble.new(raw: "^6.0.0", major_minor_patch: ["6", "0", "0"], semver_wildcard: true)
 
     expect { check_version(node_package_version, "6.0.0") }
       .to raise_error(/\*\*ERROR\*\* Shakapacker: Your node package version for shakapacker contains a \^ or ~/)
   end
 
-  it "doesn't raise exception on matching versions" do
+  it "doesn't raise an exception on matching versions" do
     node_package_version = NodePackageVersionDouble.new(raw: "6.0.0", major_minor_patch: ["6", "0", "0"])
 
     expect { check_version(node_package_version, "6.0.0") }.to_not raise_error
   end
 
-  it "doesn't raise exception on matching versions beta" do
+  it "doesn't raise an exception on matching beta versions" do
     node_package_version = NodePackageVersionDouble.new(raw: "6.0.0-beta.1", major_minor_patch: ["6", "0", "0"])
 
     expect { check_version(node_package_version, "6.0.0.beta.1") }.to_not raise_error
   end
 
-  it "doesn't raise exception on no package" do
+  it "doesn't raise an exception on no package" do
     node_package_version = NodePackageVersionDouble.new(raw: nil, skip_processing: true)
 
     expect { check_version(node_package_version, "6.0.0") }.to_not raise_error
   end
 
-  it "doesn't raise exception on skipped path" do
+  it "doesn't raise an exception on skipped paths" do
     node_package_version = NodePackageVersionDouble.new(raw: "../..", skip_processing: true)
 
     expect { check_version(node_package_version, "6.0.0") }.to_not raise_error
@@ -109,14 +109,14 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw returns raw version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -129,14 +129,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns raw version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -149,14 +149,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "^6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -169,10 +169,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "~6.0.0"
       end
 
@@ -189,10 +189,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns relative path" do
+      it "#raw returns the relative path" do
         expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
@@ -209,10 +209,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns git url" do
+      it "#raw returns the git url" do
         expect(node_package_version_from_git_url.raw).to eq "git@github.com:shakacode/shakapacker.git"
       end
 
@@ -229,10 +229,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
-      let (:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
+    context "when using a github url" do
+      let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw returns GitHub repo address" do
+      it "#raw returns the GitHub repo address" do
         expect(node_package_version_from_github_url.raw).to eq "shakacode/shakapacker#master"
       end
 
@@ -249,10 +249,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -280,14 +280,14 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -300,14 +300,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -320,14 +320,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -340,14 +340,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "2"]
       end
 
@@ -360,14 +360,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_relative_path.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_relative_path.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -380,14 +380,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_git_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_git_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -403,11 +403,11 @@ describe "VersionChecker::NodePackageVersion" do
     context "from GitHub url" do
       let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_github_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_github_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -420,10 +420,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -451,14 +451,14 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -471,14 +471,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -491,14 +491,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -511,14 +511,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "2"]
       end
 
@@ -531,14 +531,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_relative_path.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_relative_path.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -551,14 +551,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_git_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_git_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -571,30 +571,30 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
-      let (:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
+    context "when using a github url" do
+      let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw return version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_github_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch return version array" do
+      it "#major_minor_patch returns version array" do
         expect(node_package_version_from_github_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
-      it "#skip_processing? return false" do
+      it "#skip_processing? returns false" do
         expect(node_package_version_from_github_url.skip_processing?).to be false
       end
 
-      it "#semver_wildcard? return false" do
+      it "#semver_wildcard? returns false" do
         expect(node_package_version_from_github_url.semver_wildcard?).to be false
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -622,14 +622,14 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -642,14 +642,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -662,14 +662,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -682,14 +682,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "2"]
       end
 
@@ -702,10 +702,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns relative path" do
+      it "#raw returns the relative path" do
         expect(node_package_version_from_relative_path.raw).to eq "file:../.."
       end
 
@@ -722,10 +722,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns git url" do
+      it "#raw returns the git url" do
         expect(node_package_version_from_git_url.raw).to eq "git+ssh://git@github.com/shakacode/shakapacker.git#31854a58be49f736f3486a946b72d7e4f334e2b2"
       end
 
@@ -742,10 +742,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
-      let (:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
+    context "when using a github url" do
+      let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw returns GitHub address" do
+      it "#raw returns the GitHub repo address" do
         expect(node_package_version_from_github_url.raw).to eq "github:shakacode/shakapacker#31854a58be49f736f3486a946b72d7e4f334e2b2"
       end
 
@@ -762,10 +762,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -793,14 +793,14 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -813,14 +813,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -833,14 +833,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version(fixture_version: "semver_caret").raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version(fixture_version: "semver_caret").major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -853,14 +853,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "2"]
       end
 
@@ -873,10 +873,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns relative path" do
+      it "#raw returns the relative path" do
         expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
@@ -893,14 +893,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_git_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_git_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -913,14 +913,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
-      let (:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
+    context "when using a github url" do
+      let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_github_url.raw).to eq "6.5.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_github_url.major_minor_patch).to eq ["6", "5", "0"]
       end
 
@@ -933,10 +933,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -964,34 +964,34 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw retruns version" do
+      it "#raw returns version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch retruns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
-      it "#skip_processing? retruns false" do
+      it "#skip_processing? returns false" do
         expect(node_package_version_from_semver_exact.skip_processing?).to be false
       end
 
-      it "#semver_wildcard? retruns false" do
+      it "#semver_wildcard? returns false" do
         expect(node_package_version_from_semver_exact.semver_wildcard?).to be false
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -1004,14 +1004,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "6.6.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "6", "0"]
       end
 
@@ -1024,14 +1024,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "2"]
       end
 
@@ -1044,10 +1044,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
@@ -1064,14 +1064,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_git_url.raw).to eq "7.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_git_url.major_minor_patch).to eq ["7", "0", "2"]
       end
 
@@ -1084,30 +1084,30 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
+    context "when using a github url" do
       let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw return version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_github_url.raw).to eq "7.0.2"
       end
 
-      it "#major_minor_patch return version array" do
+      it "#major_minor_patch returns version array" do
         expect(node_package_version_from_github_url.major_minor_patch).to eq ["7", "0", "2"]
       end
 
-      it "#skip_processing? return false" do
+      it "#skip_processing? returns false" do
         expect(node_package_version_from_github_url.skip_processing?).to be false
       end
 
-      it "#semver_wildcard? return false" do
+      it "#semver_wildcard? returns false" do
         expect(node_package_version_from_github_url.semver_wildcard?).to be false
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 
@@ -1135,34 +1135,34 @@ describe "VersionChecker::NodePackageVersion" do
       )
     end
 
-    context "from exact semantic version" do
+    context "when using an exact semantic version" do
       let(:node_package_version_from_semver_exact) { node_package_version(fixture_version: "semver_exact") }
 
-      it "#raw retruns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_exact.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch retruns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_exact.major_minor_patch).to eq ["6", "0", "0"]
       end
 
-      it "#skip_processing? retruns false" do
+      it "#skip_processing? returns false" do
         expect(node_package_version_from_semver_exact.skip_processing?).to be false
       end
 
-      it "#semver_wildcard? retruns false" do
+      it "#semver_wildcard? returns false" do
         expect(node_package_version_from_semver_exact.semver_wildcard?).to be false
       end
     end
 
-    context "from beta version" do
+    context "when using a beta version" do
       let(:node_package_version_from_beta) { node_package_version(fixture_version: "beta") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_beta.raw).to eq "6.1.0-beta.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_beta.major_minor_patch).to eq ["6", "1", "0"]
       end
 
@@ -1175,14 +1175,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from caret semantic version" do
+    context "when using a caret constraint" do
       let(:node_package_version_from_semver_caret) { node_package_version(fixture_version: "semver_caret") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_caret.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_caret.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -1195,14 +1195,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from tilde semantic version" do
+    context "when using a tilde constraint" do
       let(:node_package_version_from_semver_tilde) { node_package_version(fixture_version: "semver_tilde") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_semver_tilde.raw).to eq "6.0.0"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_semver_tilde.major_minor_patch).to eq ["6", "0", "0"]
       end
 
@@ -1215,10 +1215,10 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from relative path" do
+    context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
@@ -1235,14 +1235,14 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from git url" do
+    context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 
-      it "#raw returns version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_git_url.raw).to eq "7.0.2"
       end
 
-      it "#major_minor_patch returns version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_git_url.major_minor_patch).to eq ["7", "0", "2"]
       end
 
@@ -1255,30 +1255,30 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
-    context "from github url" do
+    context "when using a github url" do
       let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
-      it "#raw return version" do
+      it "#raw returns the raw version" do
         expect(node_package_version_from_github_url.raw).to eq "7.0.2"
       end
 
-      it "#major_minor_patch return version array" do
+      it "#major_minor_patch returns an array" do
         expect(node_package_version_from_github_url.major_minor_patch).to eq ["7", "0", "2"]
       end
 
-      it "#skip_processing? return false" do
+      it "#skip_processing? returns false" do
         expect(node_package_version_from_github_url.skip_processing?).to be false
       end
 
-      it "#semver_wildcard? return false" do
+      it "#semver_wildcard? returns false" do
         expect(node_package_version_from_github_url.semver_wildcard?).to be false
       end
     end
 
-    context "from package.json without shakapacker entry" do
+    context "when shakapacker is not a dependency" do
       let(:node_package_version_from_without) { node_package_version(fixture_version: "without") }
 
-      it "#raw returns empty string" do
+      it "#raw returns an empty string" do
         expect(node_package_version_from_without.raw).to eq ""
       end
 

--- a/spec/shakapacker/webpack_runner_spec.rb
+++ b/spec/shakapacker/webpack_runner_spec.rb
@@ -12,28 +12,27 @@ describe "WebpackRunner" do
     ENV["RAILS_ENV"] = @original_rails_env
   end
 
-  it "runs cmd via node_modules" do
+  let(:test_app_path) { File.expand_path("./test_app", __dir__) }
+
+  it "supports running via node_modules" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: true)
   end
 
-  it "runs cmd via yarn" do
+  it "supports running via yarn" do
     cmd = ["yarn", "webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: false)
   end
 
-  it "runs cmd argv" do
+  it "passes on arguments" do
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--watch"]
 
     verify_command(cmd, argv: ["--watch"])
   end
 
   private
-    def test_app_path
-      File.expand_path("./test_app", __dir__)
-    end
 
     def verify_command(cmd, use_node_modules: true, argv: [])
       cwd = Dir.pwd

--- a/spec/shakapacker/webpack_runner_spec.rb
+++ b/spec/shakapacker/webpack_runner_spec.rb
@@ -35,20 +35,17 @@ describe "WebpackRunner" do
   private
 
     def verify_command(cmd, use_node_modules: true, argv: [])
-      cwd = Dir.pwd
-      Dir.chdir(test_app_path)
+      Dir.chdir(test_app_path) do
+        klass = Shakapacker::WebpackRunner
+        instance = klass.new(argv)
 
-      klass = Shakapacker::WebpackRunner
-      instance = klass.new(argv)
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
+        allow(Kernel).to receive(:exec)
 
-      allow(klass).to receive(:new).and_return(instance)
-      allow(instance).to receive(:node_modules_bin_exist?).and_return(use_node_modules)
-      allow(Kernel).to receive(:exec)
+        klass.run(argv)
 
-      klass.run(argv)
-
-      expect(Kernel).to have_received(:exec).with(Shakapacker::Compiler.env, *cmd)
-    ensure
-      Dir.chdir(cwd)
+        expect(Kernel).to have_received(:exec).with(Shakapacker::Compiler.env, *cmd)
+      end
     end
 end


### PR DESCRIPTION
### Summary

This:
  * improves the overall grammar of a lot of the example titles
    * including a spelling mistake of my own, and replacing "throws" with "raises" as I find that to more idiomatic in Ruby
  * makes the layout more consistent by adding a newline before the assertion in a lot of cases
    * imo this reads better, and it is also consistent with some of the existing examples
  * making the specs more consistent with each other and the backward compatible specs

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~