### PR TITLE
Fix the guide url in deprecation message

### DIFF
--- a/lib/shakapacker/deprecation_helper.rb
+++ b/lib/shakapacker/deprecation_helper.rb
@@ -1,7 +1,7 @@
 require "thor"
 
 module Shakapacker
-  DEPRECATION_GUIDE_URL = "https://github.com/shakacode/shakapacker/docs/v7_upgrade.md"
+  DEPRECATION_GUIDE_URL = "https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md"
   DEPRECATION_MESSAGE = <<~MSG
     DEPRECATION NOTICE:
 


### PR DESCRIPTION
### Summary

Correct the v7 upgrade guide URL in the deprecation message

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Closes #358