### PR TITLE
install: add the boilplate application.js into packs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Fixed
 - Use `NODE_OPTIONS` to enable Node-specific debugging flags [PR 350](https://github.com/shakacode/shakapacker/pull/350)
+- Add the boilplate `application.js` into `packs/` [PR 363](https://github.com/shakacode/shakapacker/pull/363)
 
 ## [v7.0.3] - July 7, 2023
 ### Fixed

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -14,8 +14,8 @@ if Dir.exist?(Shakapacker.config.source_path)
   say "The packs app source directory already exists"
 else
   say "Creating packs app source directory"
-  empty_directory "app/javascript"
-  copy_file "#{__dir__}/application.js", "app/javascript/application.js"
+  empty_directory "app/javascript/packs"
+  copy_file "#{__dir__}/application.js", "app/javascript/packs/application.js"
 end
 
 apply "#{__dir__}/binstubs.rb"


### PR DESCRIPTION
`shakapaker.yml` has `source_entry_path: packs` instead of `/` by default.

### Summary

I've just bootstraped a new project and installed shakapacker. The default install yields `Shakapacker::Manifest::MissingEntryError` because `application.js` is put in `app/javascript/` instead of `app/javascript/pack/`.

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

