### PR TITLE
feat: pass through `hot: only` to `webpack-dev-server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Added
 - Experimental support for other JS package managers using `package_json` gem [PR 349](https://github.com/shakacode/shakapacker/pull/349) by [G-Rath](https://github.com/g-rath).
+- Support `hmr: only` configuration [PR 378](https://github.com/shakacode/shakapacker/pull/378) by [SimenB](https://github.com/SimenB).
 
 ## [v7.1.0] - September 30, 2023
 

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -87,6 +87,8 @@ module Shakapacker
         cmd += ["--progress", "--color"] if @pretty
 
         cmd += ["--hot"] if @hot
+        cmd += ["only"] if @hot == "only"
+
         cmd += @argv
 
         Dir.chdir(@app_path) do

--- a/spec/shakapacker/dev_server_runner_spec.rb
+++ b/spec/shakapacker/dev_server_runner_spec.rb
@@ -173,6 +173,22 @@ describe "DevServerRunner" do
       verify_command(cmd)
     end
 
+    it "supports --hot being 'only'" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot", "only"]
+
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "http",
+          hmr?: "only"
+        )
+      )
+
+      verify_command(cmd)
+    end
+
     it "accepts environment variables" do
       cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
       env = Shakapacker::Compiler.env.dup


### PR DESCRIPTION
### Summary

 Webpack `devServer.hot` property can be set to the string `only` if you don't want an automatic refresh of the page it the update isn't accepted.

https://webpack.js.org/configuration/dev-server/#devserverhot

This PR adds support for that setting in `shakapacker.yml`.

I tried adding tests, but changing e.g.

https://github.com/shakacode/shakapacker/blob/c78a5c032f9b654dcd3151a3dfb5a1359187bc88/spec/shakapacker/dev_server_runner_spec.rb#L58

to `verify_command(cmd, argv: (["--nope, not here"]))` does not fail the test - it still passes. So I'm not sure how to test it 😅 

It does _work_ though - I've verified in my own project.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file