### PR TITLE
test: properly verify dev server exec

### DIFF
--- a/spec/backward_compatibility_specs/dev_server_runner_spec.rb
+++ b/spec/backward_compatibility_specs/dev_server_runner_spec.rb
@@ -45,19 +45,52 @@ describe "DevServerRunner" do
         verify_command(cmd, argv: (["--quiet"]))
       end
 
+      it "does not automatically pass the --https flag" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"])
+
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "https",
+            hmr?: false
+          )
+        )
+
+        verify_command(cmd)
+      end
+
       it "supports the https flag" do
         cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"])
 
-        dev_server = double()
-        allow(dev_server).to receive(:host).and_return("localhost")
-        allow(dev_server).to receive(:port).and_return("3035")
-        allow(dev_server).to receive(:pretty?).and_return(false)
-        allow(dev_server).to receive(:https?).and_return(true)
-        allow(dev_server).to receive(:hmr?).and_return(false)
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "https",
+            hmr?: false
+          )
+        )
 
-        allow(Shakapacker::DevServer).to receive(:new) do
-          verify_command(cmd, argv: (["--https"]))
-        end.and_return(dev_server)
+        verify_command(cmd, argv: ["--https"])
+      end
+
+      it "supports hot module reloading" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"])
+
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "http",
+            hmr?: true
+          )
+        )
+
+        verify_command(cmd)
       end
 
       it "accepts environment variables" do
@@ -94,19 +127,52 @@ describe "DevServerRunner" do
       verify_command(cmd, argv: (["--quiet"]))
     end
 
+    it "does not automatically pass the --https flag" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "https",
+          hmr?: false
+        )
+      )
+
+      verify_command(cmd)
+    end
+
     it "supports the https flag" do
       cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"]
 
-      dev_server = double()
-      allow(dev_server).to receive(:host).and_return("localhost")
-      allow(dev_server).to receive(:port).and_return("3035")
-      allow(dev_server).to receive(:pretty?).and_return(false)
-      allow(dev_server).to receive(:https?).and_return(true)
-      allow(dev_server).to receive(:hmr?).and_return(false)
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "https",
+          hmr?: false
+        )
+      )
 
-      allow(Shakapacker::DevServer).to receive(:new) do
-        verify_command(cmd, argv: (["--https"]))
-      end.and_return(dev_server)
+      verify_command(cmd, argv: ["--https"])
+    end
+
+    it "supports hot module reloading" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"]
+
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "http",
+          hmr?: true
+        )
+      )
+
+      verify_command(cmd)
     end
 
     it "accepts environment variables" do

--- a/spec/shakapacker/dev_server_runner_spec.rb
+++ b/spec/shakapacker/dev_server_runner_spec.rb
@@ -44,19 +44,52 @@ describe "DevServerRunner" do
         verify_command(cmd, argv: (["--quiet"]))
       end
 
+      it "does not automatically pass the --https flag" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"])
+
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "https",
+            hmr?: false
+          )
+        )
+
+        verify_command(cmd)
+      end
+
       it "supports the https flag" do
         cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"])
 
-        dev_server = double()
-        allow(dev_server).to receive(:host).and_return("localhost")
-        allow(dev_server).to receive(:port).and_return("3035")
-        allow(dev_server).to receive(:pretty?).and_return(false)
-        allow(dev_server).to receive(:https?).and_return(true)
-        allow(dev_server).to receive(:hmr?).and_return(false)
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "https",
+            hmr?: false
+          )
+        )
 
-        allow(Shakapacker::DevServer).to receive(:new) do
-          verify_command(cmd, argv: (["--https"]))
-        end.and_return(dev_server)
+        verify_command(cmd, argv: ["--https"])
+      end
+
+      it "supports hot module reloading" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"])
+
+        allow(Shakapacker::DevServer).to receive(:new).and_return(
+          double(
+            host: "localhost",
+            port: "3035",
+            pretty?: false,
+            protocol: "http",
+            hmr?: true
+          )
+        )
+
+        verify_command(cmd)
       end
 
       it "accepts environment variables" do
@@ -92,19 +125,52 @@ describe "DevServerRunner" do
       verify_command(cmd, argv: (["--quiet"]))
     end
 
+    it "does not automatically pass the --https flag" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
+
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "https",
+          hmr?: false
+        )
+      )
+
+      verify_command(cmd)
+    end
+
     it "supports the https flag" do
       cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"]
 
-      dev_server = double()
-      allow(dev_server).to receive(:host).and_return("localhost")
-      allow(dev_server).to receive(:port).and_return("3035")
-      allow(dev_server).to receive(:pretty?).and_return(false)
-      allow(dev_server).to receive(:https?).and_return(true)
-      allow(dev_server).to receive(:hmr?).and_return(false)
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "https",
+          hmr?: false
+        )
+      )
 
-      allow(Shakapacker::DevServer).to receive(:new) do
-        verify_command(cmd, argv: (["--https"]))
-      end.and_return(dev_server)
+      verify_command(cmd, argv: ["--https"])
+    end
+
+    it "supports hot module reloading" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"]
+
+      allow(Shakapacker::DevServer).to receive(:new).and_return(
+        double(
+          host: "localhost",
+          port: "3035",
+          pretty?: false,
+          protocol: "http",
+          hmr?: true
+        )
+      )
+
+      verify_command(cmd)
     end
 
     it "accepts environment variables" do


### PR DESCRIPTION
### Summary

Currently some of the tests are not being run as their assertion code just isn't being called - from what I can tell, I don't think RSpec has ever supported passing a block to `receive` in a way that gets executed (except maybe if the mocked method actually expects a block but I've not tested that).

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

This does reveal some interesting behaviour with the `https` logic that is probably worth addressing:

1. determining if `https` is being used is based on checking the `protocol` but there's an `https?` method too - it looks like this generally just has not been deprecated properly
2. the runner errors if `--https` is provided but `https` isn't enabled but it doesn't do the inverse check; it also seems like the runner could automatically provide `--https` and so just encourage setting `server: "https"` in the config?
    * I've not done a lot with `--https` and co, so there might be some valid reason for why Shakapacker requires the user to provide both 
3. the runner exits using `exit!` which means those branches can't be easily tested - ideally it would be best to throw an error that could be caught, but even just switching to `exit` will make it easier to test (as under the hood that throws `SystemExit` which you can expect to receive); I would argue that's better anyway for a library because there might be cleanup hooks registered downstream that should be called