### PR TITLE
fix: don't recommend deprecated `https` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Please add entries here for your pull requests that are not yet released._
 ### Added
 - Experimental support for other JS package managers using `package_json` gem [PR 349](https://github.com/shakacode/shakapacker/pull/349) by [G-Rath](https://github.com/g-rath).
 
+### Fixed
+- Recommend `server` option instead of deprecated `https` option when `--https` is provided [PR 380](https://github.com/shakacode/shakapacker/pull/380) by [G-Rath](https://github.com/g-rath)
+
 ## [v7.1.0] - September 30, 2023
 
 ### Added

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -48,7 +48,7 @@ module Shakapacker
         end
 
         if @argv.include?("--https") && !@https
-          $stdout.puts "Please set https: true in shakapacker.yml to use the --https command line flag."
+          $stdout.puts "--https requires that 'server' in shakapacker.yml is set to 'https'"
           exit!
         end
       end


### PR DESCRIPTION
### Summary

`https: true` has been deprecated in favor of `server: 'https'`

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file
