### PR TITLE
test: remove `webdrivers` gem from dummy app

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -46,8 +46,6 @@ group :test do
   gem "capybara", "~> 3.39.1"
   # gem 'capybara-webkit'
   gem "selenium-webdriver", ">= 4.9"
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem "webdrivers"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
### Summary

This functionality is now built into `selenium-webdriver` and the two can conflict

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
