### PR TITLE
fix: emit a deprecation warning for `https` and don't mention it in generated config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Fixed
 - Recommend `server` option instead of deprecated `https` option when `--https` is provided [PR 380](https://github.com/shakacode/shakapacker/pull/380) by [G-Rath](https://github.com/g-rath)
 - Recompile assets on asset host change [PR 364](https://github.com/shakacode/shakapacker/pull/364) by [ahangarha](https://github.com/ahangarha).
+- Add deprecation warning for `https` option in `shakapacker.yml` (use `server: 'https'` instead) [PR 382](https://github.com/shakacode/shakapacker/pull/382) by [G-Rath](https://github.com/g-rath).
 
 ## [v7.1.0] - September 30, 2023
 

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -59,8 +59,6 @@ development:
   # Keys not described there are documented inline and in https://github.com/shakacode/shakapacker/
   dev_server:
     # For running dev server with https, set `server: https`.
-    # You may use `https: true` instead but notice that it is deprecated in favor of `server: https`
-    # Ensure only one of these entries is set.
     # server: https
 
     host: localhost

--- a/lib/shakapacker/dev_server.rb
+++ b/lib/shakapacker/dev_server.rb
@@ -31,7 +31,13 @@ class Shakapacker::DevServer
   end
 
   def https?
-    case fetch(:https)
+    value = fetch(:https)
+
+    unless value.nil?
+      puts "WARNING: `https: true` has been deprecated in favor of `server: 'https'`"
+    end
+
+    case value
     when true, "true", Hash
       true
     else


### PR DESCRIPTION
### Summary

If this flag is deprecated then it shouldn't be mentioned in the generated config because that just encourages its usage; we should also be omitting a deprecation warning so people know to move off it

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] Update CHANGELOG file