### PR TITLE
test: remove `packageManager` from dummy app

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -39,6 +39,5 @@
     "fork-ts-checker-webpack-plugin": "^6.5.2",
     "react-refresh": "^0.14.0",
     "webpack-dev-server": "^4.9.2"
-  },
-  "packageManager": "yarn@3.2.1"
+  }
 }


### PR DESCRIPTION
### Summary

Yarn v1.22.20 introduced a check [to ensure that the right version of Yarn was actually being used](https://github.com/yarnpkg/yarn/releases/tag/v1.22.20), which breaks the specs because while the dummy app specifies it should be using Yarn v3 in it's `package.json`, Yarn Berry is not properly setup so it'll never get used.

Removing `packageManager` resolves this.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
