### PR TITLE
fix: `hmr: false` doesn't disable Hot Module Replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Recommend `server` option instead of deprecated `https` option when `--https` is provided [PR 380](https://github.com/shakacode/shakapacker/pull/380) by [G-Rath](https://github.com/g-rath)
 - Recompile assets on asset host change [PR 364](https://github.com/shakacode/shakapacker/pull/364) by [ahangarha](https://github.com/ahangarha).
 - Add deprecation warning for `https` option in `shakapacker.yml` (use `server: 'https'` instead) [PR 382](https://github.com/shakacode/shakapacker/pull/382) by [G-Rath](https://github.com/g-rath).
+- Disable Hot Module Replacement in `webpack-dev-server` when `hmr: false` [PR 392](https://github.com/shakacode/shakapacker/pull/392) by [thedanbob](https://github.com/thedanbob).
 
 ## [v7.1.0] - September 30, 2023
 

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -86,8 +86,9 @@ module Shakapacker
         cmd += ["--config", @webpack_config]
         cmd += ["--progress", "--color"] if @pretty
 
-        cmd += ["--hot"] if @hot
-        cmd += ["only"] if @hot == "only"
+        # Default behavior of webpack-dev-server is @hot = true
+        cmd += ["--hot", "only"] if @hot == "only"
+        cmd += ["--no-hot"] if !@hot
 
         cmd += @argv
 

--- a/spec/backward_compatibility_specs/dev_server_runner_spec.rb
+++ b/spec/backward_compatibility_specs/dev_server_runner_spec.rb
@@ -54,7 +54,7 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "https",
-            hmr?: false
+            hmr?: true
           )
         )
 
@@ -70,15 +70,15 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "https",
-            hmr?: false
+            hmr?: true
           )
         )
 
         verify_command(cmd, argv: ["--https"])
       end
 
-      it "supports hot module reloading" do
-        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"])
+      it "supports disabling hot module reloading" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--no-hot"])
 
         allow(Shakapacker::DevServer).to receive(:new).and_return(
           double(
@@ -86,7 +86,7 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "http",
-            hmr?: true
+            hmr?: false
           )
         )
 
@@ -136,7 +136,7 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "https",
-          hmr?: false
+          hmr?: true
         )
       )
 
@@ -152,15 +152,15 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "https",
-          hmr?: false
+          hmr?: true
         )
       )
 
       verify_command(cmd, argv: ["--https"])
     end
 
-    it "supports hot module reloading" do
-      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"]
+    it "supports disabling hot module reloading" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--no-hot"]
 
       allow(Shakapacker::DevServer).to receive(:new).and_return(
         double(
@@ -168,7 +168,7 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "http",
-          hmr?: true
+          hmr?: false
         )
       )
 

--- a/spec/backward_compatibility_specs/webpacker_test_app/config/webpacker.yml
+++ b/spec/backward_compatibility_specs/webpacker_test_app/config/webpacker.yml
@@ -48,7 +48,7 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
-    hmr: false
+    hmr: true
     overlay: true
     disable_host_check: true
     use_local_ip: false

--- a/spec/backward_compatibility_specs/webpacker_test_app/config/webpacker_other_location.yml
+++ b/spec/backward_compatibility_specs/webpacker_test_app/config/webpacker_other_location.yml
@@ -42,7 +42,7 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
-    hmr: false
+    hmr: true
     # If HMR is on, CSS will by inlined by delivering it as part of the script payload via style-loader. Be sure
     # that you add style-loader to your project dependencies.
     #

--- a/spec/shakapacker/dev_server_runner_spec.rb
+++ b/spec/shakapacker/dev_server_runner_spec.rb
@@ -53,7 +53,7 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "https",
-            hmr?: false
+            hmr?: true
           )
         )
 
@@ -69,15 +69,15 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "https",
-            hmr?: false
+            hmr?: true
           )
         )
 
         verify_command(cmd, argv: ["--https"])
       end
 
-      it "supports hot module reloading" do
-        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"])
+      it "supports disabling hot module reloading" do
+        cmd = package_json.manager.native_exec_command("webpack", ["serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--no-hot"])
 
         allow(Shakapacker::DevServer).to receive(:new).and_return(
           double(
@@ -85,7 +85,7 @@ describe "DevServerRunner" do
             port: "3035",
             pretty?: false,
             protocol: "http",
-            hmr?: true
+            hmr?: false
           )
         )
 
@@ -134,7 +134,7 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "https",
-          hmr?: false
+          hmr?: true
         )
       )
 
@@ -150,15 +150,15 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "https",
-          hmr?: false
+          hmr?: true
         )
       )
 
       verify_command(cmd, argv: ["--https"])
     end
 
-    it "supports hot module reloading" do
-      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--hot"]
+    it "supports disabling hot module reloading" do
+      cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--no-hot"]
 
       allow(Shakapacker::DevServer).to receive(:new).and_return(
         double(
@@ -166,7 +166,7 @@ describe "DevServerRunner" do
           port: "3035",
           pretty?: false,
           protocol: "http",
-          hmr?: true
+          hmr?: false
         )
       )
 

--- a/spec/shakapacker/test_app/config/shakapacker.yml
+++ b/spec/shakapacker/test_app/config/shakapacker.yml
@@ -47,7 +47,7 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
-    hmr: false
+    hmr: true
     overlay: true
     disable_host_check: true
     use_local_ip: false

--- a/spec/shakapacker/test_app/config/shakapacker_other_location.yml
+++ b/spec/shakapacker/test_app/config/shakapacker_other_location.yml
@@ -42,7 +42,7 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
-    hmr: false
+    hmr: true
     # If HMR is on, CSS will by inlined by delivering it as part of the script payload via style-loader. Be sure
     # that you add style-loader to your project dependencies.
     #


### PR DESCRIPTION
### Summary

webpacker-dev-server >= 4 enables HMR by default, so explicitly disable when `hmr: false`. Fixes #390

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file