### PR TITLE
Show deprecation message for relative_url_root only if used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+- Show deprecation message for `relative_url_root` only if it is set. [PR 400](https://github.com/shakacode/shakapacker/pull/400) by [ahangarha](https://github.com/ahangarha).
+
 ## [v7.2.0] - December 28, 2023
 
 ### Added
@@ -23,7 +26,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Disable Hot Module Replacement in `webpack-dev-server` when `hmr: false` [PR 392](https://github.com/shakacode/shakapacker/pull/392) by [thedanbob](https://github.com/thedanbob).
 
 ### Deprecated
-- The usage of relative_url_root is deprecated in Shakapacker and will be removed in v8. [PR 376](https://github.com/shakacode/shakapacker/pull/376) by [ahangarha](https://github.com/ahangarha).
+- The usage of `relative_url_root` is deprecated in Shakapacker and will be removed in v8. [PR 376](https://github.com/shakacode/shakapacker/pull/376) by [ahangarha](https://github.com/ahangarha).
 
 ## [v7.1.0] - September 30, 2023
 

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -124,12 +124,16 @@ class Shakapacker::Configuration
   end
 
   def relative_url_root
-    Shakapacker.puts_deprecation_message "The usage of relative_url_root is deprecated in Shakapacker and will be removed in v8."
-
-    ENV.fetch(
+    result = ENV.fetch(
       "SHAKAPACKER_RELATIVE_URL_ROOT",
       fetch(:relative_url_root) || ActionController::Base.relative_url_root
     )
+
+    if result
+      Shakapacker.puts_deprecation_message("The usage of relative_url_root is deprecated in Shakapacker and will be removed in v8.")
+    end
+
+    result
   end
 
   private

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -383,14 +383,17 @@ describe "Shakapacker::Configuration" do
       )
     end
 
-    it "shows deprecation message" do
-      expect { config.relative_url_root }.to output(/deprecated/).to_stdout
-    end
+    context "with SHAKAPACKER_RELATIVE_URL_ROOT set" do
+      before do
+        expect(ENV).to receive(:fetch).with("SHAKAPACKER_RELATIVE_URL_ROOT", nil).and_return("custom_value")
+      end
+      it "shows deprecation message" do
+        expect { config.relative_url_root }.to output(/deprecated/).to_stdout
+      end
 
-    it "returns the value of SHAKAPACKER_RELATIVE_URL_ROOT if set" do
-      expect(ENV).to receive(:fetch).with("SHAKAPACKER_RELATIVE_URL_ROOT", nil).and_return("custom_value")
-
-      expect(config.relative_url_root).to eq "custom_value"
+      it "returns the value of SHAKAPACKER_RELATIVE_URL_ROOT" do
+        expect(config.relative_url_root).to eq "custom_value"
+      end
     end
 
     context "without SHAKAPACKER_RELATIVE_URL_ROOT set" do
@@ -414,6 +417,10 @@ describe "Shakapacker::Configuration" do
             expect(ENV).to receive(:fetch).with("SHAKAPACKER_RELATIVE_URL_ROOT", nil).and_return(nil)
 
             expect(config.relative_url_root).to be nil
+          end
+
+          it "doesn't shows deprecation message" do
+            expect { config.relative_url_root }.to_not output(/deprecated/).to_stdout
           end
         end
       end


### PR DESCRIPTION
### Summary

Show deprecation message for `relative_url_root` only if it is used.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

Fixes #399