### PR TITLE
ci: switch to `main` and run on `next` branch too

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -3,7 +3,8 @@ name: Dummy specs
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -3,7 +3,8 @@ name: Generator specs
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -3,7 +3,8 @@ name: Jest specs
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -3,7 +3,8 @@ name: JS lint
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,8 @@ name: Rubocop
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/ruby-backward-compatibility.yml
+++ b/.github/workflows/ruby-backward-compatibility.yml
@@ -3,7 +3,8 @@ name: Ruby specs - Backward compatibility
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,8 @@ name: Ruby specs
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
+      - 'next'
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Changes since the last non-beta release.
 
 - Export immutable webpackConfig function. [PR 293](https://github.com/shakacode/shakapacker/pull/293) by [tomdracz](https://github.com/tomdracz).
 
-  The `webpackConfig` property in the `shakapacker` module has been updated to be a function instead of a global mutable webpack configuration. This function now returns an immutable webpack configuration object, which ensures that any modifications made to it will not affect any other usage of the webpack configuration. If a project still requires the old mutable object, it can be accessed by replacing `webpackConfig` with `globalMutableWebpackConfig`. Check [v7-upgrade](https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md) documentation for more detail.
+  The `webpackConfig` property in the `shakapacker` module has been updated to be a function instead of a global mutable webpack configuration. This function now returns an immutable webpack configuration object, which ensures that any modifications made to it will not affect any other usage of the webpack configuration. If a project still requires the old mutable object, it can be accessed by replacing `webpackConfig` with `globalMutableWebpackConfig`. Check [v7-upgrade](https://github.com/shakacode/shakapacker/blob/main/docs/v7_upgrade.md) documentation for more detail.
 
 ### Added
 - Set CSS modules mode depending on file type. [PR 261](https://github.com/shakacode/shakapacker/pull/261) by [talyuk](https://github.com/talyuk).
@@ -300,7 +300,7 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 ## v5.4.3 and prior changes from rails/webpacker
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v7.2.2...master
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v7.2.2...main
 [v7.2.2]: https://github.com/shakacode/shakapacker/compare/v7.2.1...v7.2.2
 [v7.2.1]: https://github.com/shakacode/shakapacker/compare/v7.2.0...v7.2.1
 [v7.2.0]: https://github.com/shakacode/shakapacker/compare/v7.1.0...v7.2.0

--- a/docs/react.md
+++ b/docs/react.md
@@ -226,7 +226,7 @@ module.exports = webpackConfig;
 - },
 ```
 
-11. Create a `babel.config.js` file in the project root and add the following [sample code](https://github.com/shakacode/shakapacker/blob/master/docs/customizing_babel_config.md#react-configuration):
+11. Create a `babel.config.js` file in the project root and add the following [sample code](https://github.com/shakacode/shakapacker/blob/main/docs/customizing_babel_config.md#react-configuration):
 ```js
 module.exports = function (api) {
   const defaultConfigFunc = require('shakapacker/package/babel/preset.js')

--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -140,7 +140,7 @@ _If you're on webpacker v5, follow [how to upgrade to webpacker v6.0.0.rc.6 from
    ```
    See customization example the [Customizing Babel Config](./customizing_babel_config.md) for React configuration.
 
-1. `extensions` was removed from the `webpacker.yml` file. Move custom extensions to your configuration by merging an object like this. For more details, see docs for [Webpack Configuration](https://github.com/shakacode/shakapacker/blob/master/README.md#webpack-configuration)
+1. `extensions` was removed from the `webpacker.yml` file. Move custom extensions to your configuration by merging an object like this. For more details, see docs for [Webpack Configuration](https://github.com/shakacode/shakapacker/blob/main/README.md#webpack-configuration)
 
    ```js
    {

--- a/lib/shakapacker/deprecation_helper.rb
+++ b/lib/shakapacker/deprecation_helper.rb
@@ -1,7 +1,7 @@
 require "thor"
 
 module Shakapacker
-  DEPRECATION_GUIDE_URL = "https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md"
+  DEPRECATION_GUIDE_URL = "https://github.com/shakacode/shakapacker/blob/main/docs/v7_upgrade.md"
   DEPRECATION_MESSAGE = <<~MSG
     DEPRECATION NOTICE:
 

--- a/lib/shakapacker/helper.rb
+++ b/lib/shakapacker/helper.rb
@@ -98,7 +98,7 @@ module Shakapacker::Helper
   def javascript_pack_tag(*names, defer: true, **options)
     if @javascript_pack_tag_loaded
       raise "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " \
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
+      "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
     end
 
     append_javascript_pack_tag(*names, defer: defer)
@@ -169,7 +169,7 @@ module Shakapacker::Helper
   def append_stylesheet_pack_tag(*names)
     if @stylesheet_pack_tag_loaded
       raise "You can only call append_stylesheet_pack_tag before stylesheet_pack_tag helper. " \
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+      "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
     end
 
     @stylesheet_pack_tag_queue ||= []
@@ -196,7 +196,7 @@ module Shakapacker::Helper
     def update_javascript_pack_tag_queue(defer:)
       if @javascript_pack_tag_loaded
         raise "You can only call #{caller_locations(1..1).first.label} before javascript_pack_tag helper. " \
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+        "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
       end
 
       yield(defer ? :deferred : :non_deferred)

--- a/package/index.js
+++ b/package/index.js
@@ -57,7 +57,7 @@ Please use 'globalMutableWebpackConfig' instead, or use
 'generateWebpackConfig()' to avoid unwanted config mutation across the app.
 
 For more information, see version 7 upgrade documentation at:
-https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md
+https://github.com/shakacode/shakapacker/blob/main/docs/v7_upgrade.md
 `)
       return globalMutableWebpackConfig()
     }

--- a/spec/backward_compatibility_specs/helper_spec.rb
+++ b/spec/backward_compatibility_specs/helper_spec.rb
@@ -126,7 +126,7 @@ module ActionView::TestCase::Behavior
     it "#append_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+        "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag("application")
@@ -137,7 +137,7 @@ module ActionView::TestCase::Behavior
     it "#prepend_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call prepend_javascript_pack_tag before javascript_pack_tag helper. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+        "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag("application")
@@ -167,7 +167,7 @@ module ActionView::TestCase::Behavior
 
     it "#javascript_pack_tag rases error on multiple invocations" do
       expected_error_message = "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " +
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
+      "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag(:application)

--- a/spec/fixtures/github_url_package-lock.v1.json
+++ b/spec/fixtures/github_url_package-lock.v1.json
@@ -102,7 +102,7 @@
     },
     "shakapacker": {
       "version": "github:shakacode/shakapacker#31854a58be49f736f3486a946b72d7e4f334e2b2",
-      "from": "github:shakacode/shakapacker#master",
+      "from": "github:shakacode/shakapacker#main",
       "requires": {
         "glob": "^7.2.0",
         "js-yaml": "^4.1.0",

--- a/spec/fixtures/github_url_package-lock.v2.json
+++ b/spec/fixtures/github_url_package-lock.v2.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "shakapacker": "shakacode/shakapacker#master"
+        "shakapacker": "shakacode/shakapacker#main"
       },
       "devDependencies": {
         "right-pad": "^1.0.1"
@@ -9594,7 +9594,7 @@
     },
     "shakapacker": {
       "version": "git+ssh://git@github.com/shakacode/shakapacker.git#31854a58be49f736f3486a946b72d7e4f334e2b2",
-      "from": "shakapacker@shakacode/shakapacker#master",
+      "from": "shakapacker@shakacode/shakapacker#main",
       "requires": {
         "glob": "^7.2.0",
         "js-yaml": "^4.1.0",

--- a/spec/fixtures/github_url_package.json
+++ b/spec/fixtures/github_url_package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "shakapacker": "shakacode/shakapacker#master"
+    "shakapacker": "shakacode/shakapacker#main"
   },
   "devDependencies": {
     "right-pad": "^1.0.1"

--- a/spec/fixtures/github_url_pnpm-lock.v7.yaml
+++ b/spec/fixtures/github_url_pnpm-lock.v7.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   right-pad: ^1.0.1
-  shakapacker: shakacode/shakapacker#master
+  shakapacker: shakacode/shakapacker#main
 
 dependencies:
   shakapacker: github.com/shakacode/shakapacker/cdf32835d3e0949952b8b4b53063807f714f9b24

--- a/spec/fixtures/github_url_pnpm-lock.v8.yaml
+++ b/spec/fixtures/github_url_pnpm-lock.v8.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   shakapacker:
-    specifier: shakacode/shakapacker#master
+    specifier: shakacode/shakapacker#main
     version: github.com/shakacode/shakapacker/cdf32835d3e0949952b8b4b53063807f714f9b24(@babel/core@7.22.10)(@babel/plugin-transform-runtime@7.22.10)(@babel/preset-env@7.22.10)(@babel/runtime@7.22.10)(babel-loader@9.1.3)(compression-webpack-plugin@10.0.0)(terser-webpack-plugin@5.3.9)(webpack-assets-manifest@5.1.0)(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack-merge@5.9.0)(webpack@5.88.2)
 
 devDependencies:

--- a/spec/fixtures/github_url_yarn.v1.lock
+++ b/spec/fixtures/github_url_yarn.v1.lock
@@ -91,7 +91,7 @@ right-pad@^1.0.1:
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==
 
-shakapacker@shakacode/shakapacker#master:
+shakapacker@shakacode/shakapacker#main:
   version "6.5.0"
   resolved "https://codeload.github.com/shakacode/shakapacker/tar.gz/31854a58be49f736f3486a946b72d7e4f334e2b2"
   dependencies:

--- a/spec/fixtures/github_url_yarn.v2.lock
+++ b/spec/fixtures/github_url_yarn.v2.lock
@@ -124,7 +124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shakapacker@shakacode/shakapacker#master":
+"shakapacker@shakacode/shakapacker#main":
   version: 6.5.0
   resolution: "shakapacker@https://github.com/shakacode/shakapacker.git#commit=31854a58be49f736f3486a946b72d7e4f334e2b2"
   dependencies:
@@ -153,7 +153,7 @@ __metadata:
   resolution: "test_app@workspace:."
   dependencies:
     right-pad: ^1.0.1
-    shakapacker: "shakacode/shakapacker#master"
+    shakapacker: "shakacode/shakapacker#main"
   languageName: unknown
   linkType: soft
 

--- a/spec/shakapacker/helper_spec.rb
+++ b/spec/shakapacker/helper_spec.rb
@@ -126,7 +126,7 @@ module ActionView::TestCase::Behavior
     it "#append_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call append_javascript_pack_tag before javascript_pack_tag helper. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+        "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag("application")
@@ -137,7 +137,7 @@ module ActionView::TestCase::Behavior
     it "#prepend_javascript_pack_tag raises an error if called after calling #javascript_pack_tag" do
       expected_error_message = \
         "You can only call prepend_javascript_pack_tag before javascript_pack_tag helper. " +
-        "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
+        "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag("application")
@@ -167,7 +167,7 @@ module ActionView::TestCase::Behavior
 
     it "#javascript_pack_tag rases error on multiple invocations" do
       expected_error_message = "To prevent duplicated chunks on the page, you should call javascript_pack_tag only once on the page. " +
-      "Please refer to https://github.com/shakacode/shakapacker/blob/master/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
+      "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helpers-javascript_pack_tag-and-stylesheet_pack_tag for the usage guide"
 
       expect {
         javascript_pack_tag(:application)

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -233,7 +233,7 @@ describe "VersionChecker::NodePackageVersion" do
       let(:node_package_version_from_github_url) { node_package_version(fixture_version: "github_url") }
 
       it "#raw returns the GitHub repo address" do
-        expect(node_package_version_from_github_url.raw).to eq "shakacode/shakapacker#master"
+        expect(node_package_version_from_github_url.raw).to eq "shakacode/shakapacker#main"
       end
 
       it "#major_minor_patch returns nil" do


### PR DESCRIPTION
### Summary

This is the canonical default branch these days; once this is merged ideally the `master` branch should be renamed to `main` using GitHub's UI so that workflow runs and other such logs are retained.

I've also snuck in adding `next` to the list of branches to run CI on.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation~
- [x] ~Update CHANGELOG file~