### PR TITLE
feat!: drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.7', '3.0']
         use_package_json_gem: ['true', 'false']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
@@ -23,13 +23,7 @@ jobs:
           # Uncomment the following line only to ensure compatibility with the
           # upcomming Rails versions, maybe before a release.
           #- gemfiles/Gemfile-rails-edge
-        exclude:
-          - ruby: 2.6
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails.7.0.x
-          - ruby: 2.6
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails-edge
+
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.7', '3.0']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
@@ -22,13 +22,6 @@ jobs:
           # Uncomment the following line only to ensure compatibility with the
           # upcomming Rails versions, maybe before a release.
           #- gemfiles/Gemfile-rails-edge
-        exclude:
-          - ruby: 2.6
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails.7.0.x
-          - ruby: 2.6
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails-edge
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require: rubocop-performance
 AllCops:
+  TargetRubyVersion: 2.7
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes since the last non-beta release.
 
   The usage of those has been deprecated in Shakapacker v7 and now fully removed in v8. See the [v7 Upgrade Guide](./docs/v7_upgrade.md) for more information if you are still yet to address this deprecation.
 
+- Drop support for Ruby 2.6 [PR 415](https://github.com/shakacode/shakapacker/pull/415) by [G-Rath](https://github.com/g-rath).
+
 ### Added
 - Emit warnings instead of errors when compilation is success but stderr is not empty. [PR 416](https://github.com/shakacode/shakapacker/pull/416) by [n-rodriguez](https://github.com/n-rodriguez).
 - Allow `webpack-dev-server` v5. [PR 418](https://github.com/shakacode/shakapacker/pull/418) by [G-Rath](https://github.com/g-rath)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Read the [full review here](https://clutch.co/profile/shakacode#reviews?sort_by=
 
 ## Prerequisites
 
-- Ruby 2.6+
+- Ruby 2.7+
 - Rails 5.2+
 - Node.js 12.13.0+ || 14+
 - Yarn

--- a/shakapacker.gemspec
+++ b/shakapacker.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/shakacode/shakapacker/tree/v#{npm_version}",
   }
 
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.add_dependency "activesupport", ">= 5.2"
   s.add_dependency "package_json"


### PR DESCRIPTION
### Summary

This isn't to say we won't drop support for other versions of Ruby, but we should definitely drop support for 2.6.

I have realised CI isn't covering newer versions of Ruby, but I'll do a dedicated PR adding those.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file
