### PR TITLE
Emit warnings instead of errors when compilation is success but stderr is not empty

### DIFF
--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -88,7 +88,7 @@ class Shakapacker::Compiler
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"
-        logger.error "#{stderr}" unless stderr.empty?
+        logger.warn "#{stderr}" unless stderr.empty?
 
         if config.webpack_compile_output?
           logger.info stdout


### PR DESCRIPTION
By default Webpack use stderr: https://webpack.js.org/configuration/other-options/#stream so Webpack plugins messages end up with`error` severity. 

For example: https://github.com/gregnb/filemanager-webpack-plugin/blob/master/src/actions/copy.js#L25

Thank you!