### PR TITLE
fix: allow `webpack-dev-server` v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 Changes since the last non-beta release.
 
 - Emit warnings instead of errors when compilation is success but stderr is not empty. [PR 416](https://github.com/shakacode/shakapacker/pull/416) by [n-rodriguez](https://github.com/n-rodriguez).
+- Allow `webpack-dev-server` v5. [PR 418](https://github.com/shakacode/shakapacker/pull/418) by [G-Rath](https://github.com/g-rath)
 
 ## [v7.2.2] - January 19, 2024
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack": "^5.72.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-cli": "^4.9.2 || ^5.0.0",
-    "webpack-dev-server": "^4.9.0",
+    "webpack-dev-server": "^4.9.0 || ^5.0.0",
     "webpack-merge": "^5.8.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### Summary

This was released a few hours ago, and is needed to patch a vulnerability.

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file

~This looks to be working fine out of the box for me, though I'll do a look through the actual changelog later to determine if there's any followup work; would be good to get this released in the meantime though.~ looks like they just removed a bunch of previously deprecated stuff; my CSP is broken for some reason but that isn't Shakapackers problem