### PR TITLE
Remove dependency on glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Changes since the last non-beta release.
 - Emit warnings instead of errors when compilation is success but stderr is not empty. [PR 416](https://github.com/shakacode/shakapacker/pull/416) by [n-rodriguez](https://github.com/n-rodriguez).
 - Allow `webpack-dev-server` v5. [PR 418](https://github.com/shakacode/shakapacker/pull/418) by [G-Rath](https://github.com/g-rath)
 
+### Removed
+- Removes dependency on `glob` library. [PR 435](https://github.com/shakacode/shakapacker/pull/435) by [tomdracz](https://github.com/tomdracz).
+
 ## [v7.2.2] - January 19, 2024
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "testRegex": "(/__tests__/.*|(\\.|/))\\.jsx?$"
   },
   "dependencies": {
-    "glob": "^7.2.0",
     "js-yaml": "^4.1.0",
     "path-complete-extname": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,7 +2263,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==


### PR DESCRIPTION
### Summary

Closes #384 and supersedes #388

Ref thread here https://github.com/shakacode/shakapacker/pull/388

Removes `glob` dependency that was only used in a single place - fetching entrypoints.

Rewrites getting entrypoint files using native `fs` module functions.

Tested running through test suite and veryfing the new function results in exactly same result as previous glob call


- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file
