### PR TITLE
ci: only run Rubocop with latest Ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,19 +15,14 @@ concurrency:
 jobs:
   lint:
     name: Linting
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2']
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Ruby rubocop


### PR DESCRIPTION
### Summary

We don't need to be running Rubocop on every version of Ruby as we've got `TargetRubyVersion` set which ensures we don't use syntax that isn't supported in 2.7.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
