### PR TITLE
feat!: remove `globalMutableWebpackConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes since the last non-beta release.
 
   The usage of those has been deprecated in Shakapacker v7 and now fully removed in v8. See the [v7 Upgrade Guide](./docs/v7_upgrade.md) for more information if you are still yet to address this deprecation.
 
+- Remove `globalMutableWebpackConfig` global [PR 439](https://github.com/shakacode/shakapacker/pull/439) by [G-Rath](https://github.com/g-rath).
+
+  Use `generateWebpackConfig` instead.
 
 - Remove `yarn_install` rake task, and stop installing js packages automatically as part of `assets:precompile` [PR 412](https://github.com/shakacode/shakapacker/pull/412) by [G-Rath](https://github.com/g-rath).
 

--- a/package/__tests__/development.js
+++ b/package/__tests__/development.js
@@ -38,29 +38,4 @@ describe('Development environment', () => {
       expect(webpackConfig.devServer).toEqual(undefined)
     })
   })
-
-  describe('globalMutableWebpackConfig', () => {
-    beforeEach(() => jest.resetModules())
-
-    test('should use development config and environment including devServer if WEBPACK_SERVE', () => {
-      process.env.RAILS_ENV = 'development'
-      process.env.NODE_ENV = 'development'
-      process.env.WEBPACK_SERVE = 'true'
-      const { globalMutableWebpackConfig: webpackConfig } = require('../index')
-
-      expect(webpackConfig.output.path).toEqual(resolve('public', 'packs'))
-      expect(webpackConfig.output.publicPath).toEqual('/packs/')
-    })
-
-    test('should use development config and environment if WEBPACK_SERVE', () => {
-      process.env.RAILS_ENV = 'development'
-      process.env.NODE_ENV = 'development'
-      process.env.WEBPACK_SERVE = undefined
-      const { globalMutableWebpackConfig: webpackConfig } = require('../index')
-
-      expect(webpackConfig.output.path).toEqual(resolve('public', 'packs'))
-      expect(webpackConfig.output.publicPath).toEqual('/packs/')
-      expect(webpackConfig.devServer).toEqual(undefined)
-    })
-  })
 })

--- a/package/__tests__/production.js
+++ b/package/__tests__/production.js
@@ -29,23 +29,4 @@ describe('Production environment', () => {
       })
     })
   })
-
-  describe('globalMutableWebpackConfig', () => {
-    beforeEach(() => jest.resetModules())
-
-    test('should use production config and environment', () => {
-      process.env.RAILS_ENV = 'production'
-      process.env.NODE_ENV = 'production'
-
-      const { globalMutableWebpackConfig: webpackConfig } = require('../index')
-
-      expect(webpackConfig.output.path).toEqual(resolve('public', 'packs'))
-      expect(webpackConfig.output.publicPath).toEqual('/packs/')
-
-      expect(webpackConfig).toMatchObject({
-        devtool: 'source-map',
-        stats: 'normal'
-      })
-    })
-  })
 })

--- a/package/__tests__/staging.js
+++ b/package/__tests__/staging.js
@@ -30,24 +30,4 @@ describe('Custom environment', () => {
       })
     })
   })
-
-  describe('globalMutableWebpackConfig', () => {
-    beforeEach(() => jest.resetModules())
-
-    test('should use staging config and default production environment', () => {
-      process.env.RAILS_ENV = 'staging'
-      delete process.env.NODE_ENV
-
-      const { globalMutableWebpackConfig: webpackConfig } = require('../index')
-
-      expect(webpackConfig.output.path).toEqual(
-        resolve('public', 'packs-staging')
-      )
-      expect(webpackConfig.output.publicPath).toEqual('/packs-staging/')
-      expect(webpackConfig).toMatchObject({
-        devtool: 'source-map',
-        stats: 'normal'
-      })
-    })
-  })
 })

--- a/package/__tests__/test.js
+++ b/package/__tests__/test.js
@@ -25,19 +25,4 @@ describe('Test environment', () => {
       expect(webpackConfig.devServer).toEqual(undefined)
     })
   })
-
-  describe('globalMutableWebpackConfig', () => {
-    beforeEach(() => jest.resetModules())
-
-    test('should use test config and production environment', () => {
-      process.env.RAILS_ENV = 'test'
-      process.env.NODE_ENV = 'test'
-
-      const { globalMutableWebpackConfig: webpackConfig } = require('../index')
-
-      expect(webpackConfig.output.path).toEqual(resolve('public', 'packs-test'))
-      expect(webpackConfig.output.publicPath).toEqual('/packs-test/')
-      expect(webpackConfig.devServer).toEqual(undefined)
-    })
-  })
 })

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -35,7 +35,6 @@ declare module 'shakapacker' {
   export const config: Config
   export const devServer: Record<string, unknown>
   export function generateWebpackConfig(extraConfig?: Configuration): Configuration
-  export const globalMutableWebpackConfig: Configuration
   export const baseConfig: Configuration
   export const env: Env
   export const rules: Record<string, unknown>

--- a/package/index.js
+++ b/package/index.js
@@ -12,13 +12,6 @@ const env = require('./env')
 const { moduleExists, canProcess } = require('./utils/helpers')
 const inliningCss = require('./utils/inliningCss')
 
-const globalMutableWebpackConfig = () => {
-  const { nodeEnv } = env
-  const path = resolve(__dirname, 'environments', `${nodeEnv}.js`)
-  const environmentConfig = existsSync(path) ? require(path) : baseConfig
-  return environmentConfig
-}
-
 const generateWebpackConfig = (extraConfig = {}, ...extraArgs) => {
   if (extraArgs.length > 0) {
     throw new Error(
@@ -26,16 +19,17 @@ const generateWebpackConfig = (extraConfig = {}, ...extraArgs) => {
     )
   }
 
-  const environmentConfig = globalMutableWebpackConfig()
-  const immutable = webpackMerge.merge({}, environmentConfig, extraConfig)
-  return immutable
+  const { nodeEnv } = env
+  const path = resolve(__dirname, 'environments', `${nodeEnv}.js`)
+  const environmentConfig = existsSync(path) ? require(path) : baseConfig
+
+  return webpackMerge.merge({}, environmentConfig, extraConfig)
 }
 
 module.exports = {
   config, // shakapacker.yml
   devServer,
   generateWebpackConfig,
-  globalMutableWebpackConfig: globalMutableWebpackConfig(),
   baseConfig,
   env,
   rules,

--- a/spec/dummy/config/webpack/commonWebpackConfig.js
+++ b/spec/dummy/config/webpack/commonWebpackConfig.js
@@ -1,6 +1,5 @@
 // Common configuration applying to client and server configuration
 
-// const { globalMutableWebpackConfig: baseClientWebpackConfig, merge } = require('shakapacker')
 const { generateWebpackConfig, merge } = require('shakapacker')
 const commonOptions = {
   resolve: {


### PR DESCRIPTION
### Summary

This was deprecated in v7 in favor of `generateWebpackConfig`, so now we can remove it

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file