### PR TITLE
ci: use caching

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -23,9 +23,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: yarn
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
+          bundler-cache: true
       - name: Install dependencies
         run: |
           bundle install

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -52,6 +52,32 @@ jobs:
           bundle config --local path vendor/bundle
       - name: Install dependencies
         run: bundle install
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v3
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: generator-${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            generator-${{ runner.os }}-npm-
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: generator-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            generator-${{ runner.os }}-yarn-
+
       - run: bundle exec rake run_spec:generator
         env:
           SHAKAPACKER_USE_PACKAGE_JSON_GEM: ${{ matrix.use_package_json_gem }}


### PR DESCRIPTION
### Summary

This attempts to use caching to speed up the dummy and generator workflows - it's hard to completely cache everything since we're testing against so many package managers within the specs themselves, but it should be easy to at least try caching `npm` and `yarn`  downloads which'll hopefully give some speed up.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
