### PR TITLE
ci: don't run on pushes to `next`

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
   pull_request:
 
 concurrency:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
   pull_request:
 
 concurrency:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
### Summary

This should halve the number of jobs being run on `next` without losing anything so long as we continue to have a PR to `main` as that will trigger the workflows due to being a `pull_request`.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~