### PR TITLE
Pass in shakapacker config consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Changes since the last non-beta release.
 ### Removed
 - Removes dependency on `glob` library. [PR 435](https://github.com/shakacode/shakapacker/pull/435) by [tomdracz](https://github.com/tomdracz).
 
+### Fixed
+- Uses config file passed in `SHAKAPACKER_CONFIG` consistently.[PR 448](https://github.com/shakacode/shakapacker/pull/448) by [tomdracz](https://github.com/tomdracz).
+
+   Previously this could have been ignored in few code branches, especially when checking for available environments.
+
 ## [v7.2.2] - January 19, 2024
 
 ### Added

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -106,7 +106,7 @@ class Shakapacker::Compiler
 
       env.merge(
         "SHAKAPACKER_ASSET_HOST" => instance.config.asset_host,
-        "SHAKAPACKER_CONFIG"     => instance.config_path.to_s
+        "SHAKAPACKER_CONFIG"     => instance.config.config_path.to_s
       )
     end
 

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -12,7 +12,7 @@ class Shakapacker::Configuration
   def initialize(root_path:, config_path:, env:)
     @root_path = root_path
     @env = env
-    @config_path = config_path
+    @config_path = Pathname.new(ENV["SHAKAPACKER_CONFIG"] || config_path)
   end
 
   def dev_server

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -12,7 +12,7 @@ class Shakapacker::Configuration
   def initialize(root_path:, config_path:, env:)
     @root_path = root_path
     @env = env
-    @config_path = Pathname.new(ENV["SHAKAPACKER_CONFIG"] || config_path)
+    @config_path = config_path
   end
 
   def dev_server

--- a/lib/shakapacker/env.rb
+++ b/lib/shakapacker/env.rb
@@ -20,7 +20,7 @@ class Shakapacker::Env
     end
 
     def fallback_env_warning
-      logger.info "RAILS_ENV=#{Rails.env} environment is not defined in config/shakapacker.yml, falling back to #{Shakapacker::DEFAULT_ENV} environment"
+      logger.info "RAILS_ENV=#{Rails.env} environment is not defined in #{config_path}, falling back to #{Shakapacker::DEFAULT_ENV} environment"
     end
 
     def available_environments

--- a/lib/shakapacker/env.rb
+++ b/lib/shakapacker/env.rb
@@ -1,5 +1,6 @@
 class Shakapacker::Env
-  delegate :config_path, :logger, to: :@instance
+  delegate :config, :logger, to: :@instance
+  delegate :config_path, to: :config
 
   def self.inquire(instance)
     new(instance).inquire

--- a/lib/shakapacker/env.rb
+++ b/lib/shakapacker/env.rb
@@ -1,6 +1,5 @@
 class Shakapacker::Env
-  delegate :config, :logger, to: :@instance
-  delegate :config_path, to: :config
+  delegate :config_path, :logger, to: :@instance
 
   def self.inquire(instance)
     new(instance).inquire

--- a/lib/shakapacker/instance.rb
+++ b/lib/shakapacker/instance.rb
@@ -7,7 +7,7 @@ class Shakapacker::Instance
 
   def initialize(root_path: Rails.root, config_path: Rails.root.join("config/shakapacker.yml"))
     @root_path = root_path
-    @config_path = config_path
+    @config_path = Pathname.new(ENV["SHAKAPACKER_CONFIG"] || config_path)
   end
 
   def env

--- a/lib/shakapacker/instance.rb
+++ b/lib/shakapacker/instance.rb
@@ -7,7 +7,7 @@ class Shakapacker::Instance
 
   def initialize(root_path: Rails.root, config_path: Rails.root.join("config/shakapacker.yml"))
     @root_path = root_path
-    @config_path = Pathname.new(ENV["SHAKAPACKER_CONFIG"] || config_path)
+    @config_path = config_path
   end
 
   def env

--- a/spec/shakapacker/instance_spec.rb
+++ b/spec/shakapacker/instance_spec.rb
@@ -3,6 +3,7 @@ require_relative "spec_helper_initializer"
 describe "Shakapacker::Instance" do
   before :each do
     ENV.delete("SHAKAPACKER_CONFIG")
+    Shakapacker.instance = Shakapacker::Instance.new
   end
 
   after :each do
@@ -19,7 +20,6 @@ describe "Shakapacker::Instance" do
 
   it "uses the SHAKAPACKER_CONFIG env variable for the config file path" do
     ENV["SHAKAPACKER_CONFIG"] = "/some/random/path.yml"
-    Shakapacker.instance = Shakapacker::Instance.new
 
     actual_config_path = "/some/random/path.yml"
     expected_config_path = Shakapacker.config.config_path.to_s

--- a/spec/shakapacker/instance_spec.rb
+++ b/spec/shakapacker/instance_spec.rb
@@ -3,7 +3,6 @@ require_relative "spec_helper_initializer"
 describe "Shakapacker::Instance" do
   before :each do
     ENV.delete("SHAKAPACKER_CONFIG")
-    Shakapacker.instance = Shakapacker::Instance.new
   end
 
   after :each do
@@ -20,6 +19,7 @@ describe "Shakapacker::Instance" do
 
   it "uses the SHAKAPACKER_CONFIG env variable for the config file path" do
     ENV["SHAKAPACKER_CONFIG"] = "/some/random/path.yml"
+    Shakapacker.instance = Shakapacker::Instance.new
 
     actual_config_path = "/some/random/path.yml"
     expected_config_path = Shakapacker.config.config_path.to_s


### PR DESCRIPTION
### Summary

Whilst investigating https://github.com/shakacode/shakapacker/issues/408 I couldn't quite replicate the issues but did notice there a few places in the code where we were not respecting `SHAKAPACKER_CONFIG` env variable. This moves it up one level to main `Shakapacker::Instance` so it should be used consistently.

There are places like runners where we were using configuration object directly but they were already accounting for path set by env variable.

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file
