### PR TITLE
refactor: use snake_case for method name

### DIFF
--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -72,7 +72,7 @@ class Shakapacker::Compiler
       config.root_path.join("tmp/shakapacker.lock")
     end
 
-    def optionalRubyRunner
+    def optional_ruby_runner
       first_line = File.readlines(bin_shakapacker_path).first.chomp
       /ruby/.match?(first_line) ? RbConfig.ruby : ""
     end
@@ -82,7 +82,7 @@ class Shakapacker::Compiler
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
-        "#{optionalRubyRunner} '#{bin_shakapacker_path}'",
+        "#{optional_ruby_runner} '#{bin_shakapacker_path}'",
         chdir: File.expand_path(config.root_path)
       )
 


### PR DESCRIPTION
### Summary

I noticed this while reviewing the codebase for other changes we might want to include in v8 - it's a private method so shouldn't be breaking at all but now's a good time to rename it either way.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

I've not included a changelog since it's such a small private change that I don't think it's worth it 🤷 