### PR TITLE
fix: only strip paths that start with source path

### DIFF
--- a/package/rules/__tests__/file.js
+++ b/package/rules/__tests__/file.js
@@ -76,5 +76,12 @@ describe('file', () => {
     expect(file.generator.filename(pathData)).toEqual(
       'static/images/[name]-[hash][ext][query]'
     );
+
+    const pathData2 = {
+      filename: 'app/javascript/app/assets/image.svg',
+    };
+    expect(file.generator.filename(pathData2)).toEqual(
+      'static/app/assets/[name]-[hash][ext][query]'
+    );
   });
 })

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -13,7 +13,7 @@ module.exports = {
       const path = dirname(pathData.filename)
       const stripPaths = [...additionalPaths, sourcePath]
 
-      const selectedStripPath = stripPaths.find((includePath) => path.includes(includePath))
+      const selectedStripPath = stripPaths.find((includePath) => path.startsWith(includePath))
 
       const folders = path
         .replace(`${selectedStripPath}`, '')


### PR DESCRIPTION
### Summary

Follow up to #403

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

This test seems a little silly, but I don't think it's entirely unreasonable in the real world