### PR TITLE
Add a Regex Equality Test Function

### DIFF
--- a/package/utils/helpers.js
+++ b/package/utils/helpers.js
@@ -55,6 +55,13 @@ const loaderMatches = (configLoader, loaderToCheck, fn) => {
   return fn()
 }
 
+function regexEqualityCheck(r1, r2) {
+  return r1 instanceof RegExp && 
+         r2 instanceof RegExp &&
+         r1.source === r2.source &&
+         r1.flags.split("").sort().join("") === r2.flags.split("").sort().join("");
+}
+
 module.exports = {
   chdirTestApp,
   chdirCwd,
@@ -64,5 +71,6 @@ module.exports = {
   canProcess,
   moduleExists,
   resetEnv,
-  loaderMatches
+  loaderMatches,
+  regexEqualityCheck
 }


### PR DESCRIPTION
In recent client work, I've been using this function (which I borrowed from StackOverflow [here](https://stackoverflow.com/a/10776682)) to isolate rules for a specific module type (like CSS or SVG files) by using it like so:
```javascript
webpackConfig.module.rules.forEach((rule) => {
  if (regexAreTheSame(rule.test, /\.(scss|sass)(\.erb)?$/i)) {
    const sassDefaultLoaders = rule.use
    // resolve-url-loader needs sourcemaps from sass-loader
    rule.use.forEach((item) => {
      if (item.loader?.includes('sass-loader')) {
        item.options = {
          sourceMap: true,
        }
      }
      if (item.loader?.includes('/css-loader')) {
        item.options = {
          sourceMap: true,
          importLoaders: 2,
          modules: true
        }
      }
    })
  }
})
```
While creating a function to find & apply options to a specific loader would be possible, it has proven complicated, would require several parameters, & wouldn't resolve use cases such as users seeking to remove or add loaders.

That said, I think that the regex equality test function itself would be useful to enough users to make it worthwhile to include into Shakapacker's utils (I've used it for multiple clients).