### PR TITLE
Update outdated webpack configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,8 +578,11 @@ console.log(JSON.stringify(webpackConfig, undefined, 2))
 You may want to modify the rules in the default configuration. For instance, if you are using a custom svg loader, you may want to remove `.svg` from the default file loader rules. You can search and filter the default rules like so:
 
 ```js
-const svgRule = config.module.rules.find(rule => rule.test.test('.svg'));
-svgRule.test = svgRule.test.filter(t => !t.test('.svg'))
+const fileRule = config.module.rules.find(rule => rule.test.test('.svg'));
+// removing svg from asset file rule's test RegExp
+fileRule.test = /\.(bmp|gif|jpe?g|png|tiff|ico|avif|webp|eot|otf|ttf|woff|woff2)$/
+// changing the rule type from 'asset/resource' to 'asset'. See https://webpack.js.org/guides/asset-modules/
+fileRule.type = 'asset'
 ```
 
 ### Babel configuration


### PR DESCRIPTION
The configuration change example is broken.

`const svgRule = config.module.rules.find(rule => rule.test.test('.svg'));` only works if `rule.test` is a RegExp (because of the call to `rule.test.test`).

`svgRule.test = svgRule.test.filter(t => !t.test('.svg'))` only works if `svgRule.test` is an array (because of the call to `svgRule.test.filter`).

My guess is that this error was introduced because [the same commit that created this example also changed that asset file's rule.test from arrays of RegExp to a single RegExp with conditional logic](https://github.com/shakacode/shakapacker/commit/c5257b13f1b58aa3d6a69e4ffff7ed55f3fb1f11).

This PR addresses that & also slightly expands on possible rule changes.

For even more possible configuration change logic, see #453 