### PR TITLE
test: require `ostruct` explicitly

### DIFF
--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -1,4 +1,5 @@
 require_relative "spec_helper_initializer"
+require "ostruct"
 
 describe "Shakapacker::Compiler" do
   it "accepts custom environment variables" do


### PR DESCRIPTION
### Summary

I'm not sure why CI has suddenly started failing but hopefully this'll fix it - I assume some dependency was requiring `ostruct` for us which has now changed.

### Pull Request checklist
_Remove this line after checking all the items here. If the item does not apply to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~