### PR TITLE
Fix yarn.lock version in the dummy spec directory

### DIFF
--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -4060,7 +4060,7 @@ setprototypeof@1.2.0:
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 "shakapacker@file:.yalc/shakapacker":
-  version "7.2.3"
+  version "8.0.0-rc.2"
   dependencies:
     js-yaml "^4.1.0"
     path-complete-extname "^1.0.0"


### PR DESCRIPTION
### Summary

Fixes dummy specs fail because of Shakapacker version mismatch https://github.com/shakacode/shakapacker/actions/runs/8995105572/job/24709542960#step:6:186


