### PR TITLE
Fix assets clean lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
+### Fixed
+
+- Fixes incorrect removal of files in the assets:clean task [PR 474](https://github.com/shakacode/shakapacker/pull/474) by [tomdracz](https://github.com/tomdracz).
+
 ## [v8.0.0.rc.3] - May 9, 2024
 
 ### Fixed

--- a/lib/shakapacker/commands.rb
+++ b/lib/shakapacker/commands.rb
@@ -61,7 +61,7 @@ class Shakapacker::Commands
 
       packs = all_files - manifest_config - current_version
       packs.reject { |file| File.directory?(file) }.group_by do |path|
-        base, _, ext = File.basename(path).scan(/(.*)(-[\da-f]+)(\.\w+)/).flatten
+        base, _, ext = File.basename(path).scan(/(.*)(-[\da-f]+)((?:\.\w+)+)/).flatten
         "#{File.dirname(path)}/#{base}#{ext}"
       end.values
     end

--- a/lib/shakapacker/commands.rb
+++ b/lib/shakapacker/commands.rb
@@ -61,7 +61,7 @@ class Shakapacker::Commands
 
       packs = all_files - manifest_config - current_version
       packs.reject { |file| File.directory?(file) }.group_by do |path|
-        base, _, ext = File.basename(path).scan(/(.*)(-[\da-f]+)((?:\.\w+)+)/).flatten
+        base, _, ext = File.basename(path).scan(/(.*)(-[\da-f]+)([.\w]+)/).flatten
         "#{File.dirname(path)}/#{base}#{ext}"
       end.values
     end

--- a/spec/shakapacker/command_spec.rb
+++ b/spec/shakapacker/command_spec.rb
@@ -46,6 +46,18 @@ describe "Command" do
         "js/brandnew-0002.js" => now - 10,
         "js/brandnew-0003.js" => now - 20,
         "js/brandnew-0004.js" => now - 40,
+
+        # Compressed and map files
+        "js/application-deadbeef.js.br" => now - 4000,
+        "js/application-deadbeef.js.gz" => now - 4000,
+        "js/application-deadbeef.js.map" => now - 4000,
+        "js/application-deadbeef.js.map.br" => now - 4000,
+        "js/application-deadbeef.js.map.gz" => now - 4000,
+        "js/application-1eadbeef.js.br" => now - 4000,
+        "js/application-1eadbeef.js.gz" => now - 4000,
+        "js/application-1eadbeef.js.map" => now - 4000,
+        "js/application-1eadbeef.js.map.br" => now - 4000,
+        "js/application-1eadbeef.js.map.gz" => now - 4000,
       }.transform_keys { |path| "#{Shakapacker.config.public_output_path}/#{path}" }
     end
 
@@ -56,6 +68,12 @@ describe "Command" do
         "js/common-0eadbeee.js" => now - 9002,
         "css/common-0eadbeed.css" => now - 9004,
         "js/brandnew-0005.js" => now - 3640,
+        # Compressed and map files
+        "js/application-0eadbeef.js.br" => now - 9000,
+        "js/application-0eadbeef.js.gz" => now - 9000,
+        "js/application-0eadbeef.js.map" => now - 9000,
+        "js/application-0eadbeef.js.map.br" => now - 9000,
+        "js/application-0eadbeef.js.map.gz" => now - 9000,
       }.transform_keys { |path| "#{Shakapacker.config.public_output_path}/#{path}" }
     end
 


### PR DESCRIPTION
### Summary

Fixes lookup for assets:clean tasks

The task was trying to group files but ended up lumping map and compressed files together that ended up with incorrect deletion.

Changes the regex grouping to group file by full `.js.map.br` for example rather than just `.js` to prevent incorrect deletion.

Think this will also address https://github.com/rails/webpacker/issues/2913 issues like reported here

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved file extension recognition to handle complex formats.
- **Bug Fixes**
  - Adjusted handling of compressed and map files to ensure accurate file paths and modification times.
- **Chores**
  - Fixed incorrect file removal in the `assets:clean` task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->