### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,7 +341,7 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 ## [v6.0.0.rc.6 changes from v5.4] - Forked January 16, 2022
 
 
-- `node_modules` will no longer be babel transfomed compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
+- `node_modules` will no longer be babel transformed compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
 
   ```js
   const nodeModules = require('@rails/webpacker/rules/node_modules.js')

--- a/docs/react.md
+++ b/docs/react.md
@@ -5,7 +5,7 @@ These steps describe creating a Rails/React app, using Shakapacker as the bundle
 ## Easy Setup
 If you'd like easy integration of React with Ruby on Rails, see [React on Rails](https://github.com/shakacode/react_on_rails).
 
-The below information applies to a React on Rails app, except that you need to setup some environment variables as follows:
+The below information applies to a React on Rails app, except that you need to set up some environment variables as follows:
 
 ```
 EXECJS_RUNTIME=Node

--- a/docs/react.md
+++ b/docs/react.md
@@ -3,11 +3,12 @@
 These steps describe creating a Rails/React app, using Shakapacker as the bundler.
 
 ## Easy Setup
+
 If you'd like easy integration of React with Ruby on Rails, see [React on Rails](https://github.com/shakacode/react_on_rails).
 
-The below information applies to a React on Rails app, except that you need to set up some environment variables as follows:
+The following information applies to a React on Rails app. Additionally, you need to set up some environment variables as follows:
 
-```
+```shell
 EXECJS_RUNTIME=Node
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -180,7 +180,7 @@ default: &default
 
 If you want to access any dependency without importing it everywhere or use it directly in your dev tools, please check: [https://webpack.js.org/plugins/provide-plugin/](https://webpack.js.org/plugins/provide-plugin/) and the [webpack docs on shimming globals](https://webpack.js.org/guides/shimming/#shimming-globals).
 
-Note, if you are exposing globals, like jQuery, to non-webpack dependencies (like an inline script) via the [expose-loader](https://webpack.js.org/loaders/expose-loader/), you will need to override the default of `defer: true` to be `defer:false` your call to the `javascript_pack_tag` so that the browser will load your bundle to setup the global variable before other code depends on it. However, you really should try to remove the dependendency on such globals.
+Note, if you are exposing globals, like jQuery, to non-webpack dependencies (like an inline script) via the [expose-loader](https://webpack.js.org/loaders/expose-loader/), you will need to override the default of `defer: true` to be `defer:false` your call to the `javascript_pack_tag` so that the browser will load your bundle to setup the global variable before other code depends on it. However, you really should try to remove the dependency on such globals.
 
 Thus ProvidePlugin manages build-time dependencies to global symbols whereas the expose-loader manages runtime dependencies to global symbols.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -180,7 +180,7 @@ default: &default
 
 If you want to access any dependency without importing it everywhere or use it directly in your dev tools, please check: [https://webpack.js.org/plugins/provide-plugin/](https://webpack.js.org/plugins/provide-plugin/) and the [webpack docs on shimming globals](https://webpack.js.org/guides/shimming/#shimming-globals).
 
-Note, if you are exposing globals, like jQuery, to non-webpack dependencies (like an inline script) via the [expose-loader](https://webpack.js.org/loaders/expose-loader/), you will need to override the default of `defer: true` to be `defer:false` your call to the `javascript_pack_tag` so that the browser will load your bundle to setup the global variable before other code depends on it. However, you really should try to remove the dependency on such globals.
+Note, if you are exposing globals, like jQuery, to non-webpack dependencies (like an inline script) via the [expose-loader](https://webpack.js.org/loaders/expose-loader/), you will need to override the default of `defer: true` to be `defer:false` your call to the `javascript_pack_tag` so that the browser will load your bundle to set up the global variable before other code depends on it. However, you really should try to remove the dependency on such globals.
 
 Thus ProvidePlugin manages build-time dependencies to global symbols whereas the expose-loader manages runtime dependencies to global symbols.
 

--- a/docs/v8_upgrade.md
+++ b/docs/v8_upgrade.md
@@ -33,7 +33,7 @@ Setting for example:
 __webpack_public_path__ = 'https://mycdn.url.com/packs';
 ```
 
-In your code and ensuring it is run first in the app, will allow the dynamic imports lookup path to be overriden at runtime.
+In your code and ensuring it is run first in the app, will allow the dynamic imports lookup path to be overridden at runtime.
 
 You can also try Webpack `output.publicPath` option of `'auto'` as per https://webpack.js.org/guides/public-path/#automatic-publicpath.
 

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -9,7 +9,7 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
-  # This script is a way to setup or update your development environment automatically.
+  # This script is a way to set up or update your development environment automatically.
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -363,7 +363,7 @@ describe "Shakapacker::Configuration" do
           expect(config.asset_host).to eq "domain.abc"
         end
 
-        context "without ActionController::Base.helpers.compute_asset_host returing any value" do
+        context "without ActionController::Base.helpers.compute_asset_host returning any value" do
           it "returns nil" do
             expect(ENV).to receive(:fetch).with("SHAKAPACKER_ASSET_HOST", nil).and_return(nil)
 


### PR DESCRIPTION
```
codespell **/*.md --skip="node_modules/**/*" -w
codespell **/*.rb --skip="node_modules/**/*" -L afile,filetest,noes -w
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected typos in troubleshooting, upgrade, and React documentation for better clarity and correctness.
  
- **Tests**
  - Updated a test case description for accuracy and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->