### PR TITLE
Test against Ruby 3.3

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
@@ -32,6 +32,10 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.2'
             gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.3'
+            gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.3'
+            gemfile: gemfiles/Gemfile-rails.6.1.x
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Ruby rubocop
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
@@ -47,6 +47,10 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.2'
             gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.3'
+            gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.3'
+            gemfile: gemfiles/Gemfile-rails.6.1.x
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
Ruby 3.3 is the latest stable version of Ruby


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflows to support Ruby version 3.3, ensuring compatibility with the latest Ruby features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->