### PR TITLE
Missing `merge` import in V8 upgrade docs

### DIFF
--- a/docs/v8_upgrade.md
+++ b/docs/v8_upgrade.md
@@ -152,7 +152,7 @@ module.exports = merge(globalMutableWebpackConfig, customConfig);
 
 ```js
 // after
-const { generateWebpackConfig } = require('shakapacker');
+const { generateWebpackConfig, merge } = require('shakapacker');
 
 const customConfig = {
   module: {


### PR DESCRIPTION
### Summary

Simple documentation fix because I was seeing `ReferenceError: merge is not defined` 

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Update documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated v8 upgrade guide to include the `merge` function from `shakapacker`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->