### PR TITLE
Add changelog entry regarding custom bin path removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   This enables support for package managers other than `yarn`, with `npm` being the default; to continue using Yarn,
   specify it in `package.json` using the [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) property.
 
+  This also removed `@node_modules_bin_path`, `SHAKAPACKER_NODE_MODULES_BIN_PATH`, and support for installing `Shakapacker`'s javascript package in a separate directory from the Gemfile containing `Shakapacker`'s ruby gem.
+
 - Remove `yarn_install` rake task, and stop installing js packages automatically as part of `assets:precompile` [PR 412](https://github.com/shakacode/shakapacker/pull/412) by [G-Rath](https://github.com/g-rath).
 
 - Remove `check_yarn` rake task [PR 443](https://github.com/shakacode/shakapacker/pull/443) by [G-Rath](https://github.com/g-rath).


### PR DESCRIPTION
I thought it might be best to be more explicit about this breaking change, as I spent a little time confused over it.

Currently, I only know of two organizations that relied on [the removed functionality](https://github.com/shakacode/shakapacker/pull/430/files#diff-3319f61ad0f6785f99b4eeed9a14918b9932bd46934ae2cfa827bf3b3d173730L26), but there could be more.

That said, I don't think the removed functionality is necessary since the only reason I can think of for splitting Shakapacker's javascript package & ruby gem between separate directories is CI caching.

Would you agree, @G-Rath?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed support for certain variables and installation options related to `Shakapacker`.
  - Updated behavior of package installation with `npm` and `yarn`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->