### PR TITLE
upgrade actions/setup-node to v4

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: yarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
+#### Changed
+- Update outdated GitHub Actions to use Node.js 20.0 versions instead [PR 497](https://github.com/shakacode/shakapacker/pull/497) by [adriangohjw](https://github.com/adriangohjw).
+
 ### Fixed
 
 - Improve documentation for using Yarn PnP [PR 484](https://github.com/shakacode/shakapacker/pull/484) by [G-Rath](https://github.com/g-rath).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changes since the last non-beta release.
 
 ### Fixed
 
+- Fixes failing tests for Ruby 2.7 due to `Rack::Handler::Puma.respond_to?(:config)` [PR 501](https://github.com/shakacode/shakapacker/pull/501) by [adriangohjw](https://github.com/adriangohjw)
+
 - Improve documentation for using Yarn PnP [PR 484](https://github.com/shakacode/shakapacker/pull/484) by [G-Rath](https://github.com/g-rath).
 
 - Remove old `yarn` bin script [PR 483](https://github.com/shakacode/shakapacker/pull/483) by [G-Rath](https://github.com/g-rath).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
-#### Changed
+### Changed
 - Update outdated GitHub Actions to use Node.js 20.0 versions instead [PR 497](https://github.com/shakacode/shakapacker/pull/497) by [adriangohjw](https://github.com/adriangohjw).
 
 ### Fixed

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -19,10 +19,23 @@ describe "Generator" do
     ))
 
     Bundler.with_unbundled_env do
-      sh_in_dir({}, BASE_RAILS_APP_PATH, %(
-        gem update bundler
-        bundle add shakapacker --path "#{GEM_ROOT}"
-      ))
+      if RUBY_VERSION.start_with?("2.")
+        # Bundler's version compatible with Ruby 2 does not support "--path" switch
+        # Overwriting "rack" version due to unless Rack::Handler::Puma.respond_to?(:config) in Capybara gem v3.39.2 or earlier.
+        # Issue resolved in Capybara v3.40.0, but Ruby 2.7 support dropped; last compatible version is v3.39.2.
+        # Ref: https://github.com/shakacode/shakapacker/issues/498
+        sh_in_dir({}, BASE_RAILS_APP_PATH, %(
+          gem update bundler
+          echo 'gem "shakapacker", :path => "#{GEM_ROOT}"' >> Gemfile
+          echo 'gem "rack", "< 3.0.0"' >> Gemfile
+          bundle install
+        ))
+      else
+        sh_in_dir({}, BASE_RAILS_APP_PATH, %(
+          gem update bundler
+          bundle add shakapacker --path "#{GEM_ROOT}"
+        ))
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

Node.js 16 actions are deprecated and we want to update them to use the latest actions

- Updated `actions/setup-node@v3` to `actions/setup-node@v4`

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

~- [ ] Add/update test to cover these changes~
~- [ ] Update documentation~
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions to use `actions/setup-node@v4` for improved Node.js compatibility and support.
  
- **Documentation**
  - Updated `CHANGELOG.md` to reflect the changes in GitHub Actions, ensuring they use Node.js 20.0 for better compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->