### PR TITLE
Fix tests uninitialized constant rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes since the last non-beta release.
 
 ### Fixed
 
+- Fixes failing tests for Ruby 2.7 due to `Rack::Handler::Puma.respond_to?(:config)` [PR 501](https://github.com/shakacode/shakapacker/pull/501) by [adriangohjw](https://github.com/adriangohjw)
+
 - Improve documentation for using Yarn PnP [PR 484](https://github.com/shakacode/shakapacker/pull/484) by [G-Rath](https://github.com/g-rath).
 
 - Remove old `yarn` bin script [PR 483](https://github.com/shakacode/shakapacker/pull/483) by [G-Rath](https://github.com/g-rath).

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -21,9 +21,13 @@ describe "Generator" do
     Bundler.with_unbundled_env do
       if RUBY_VERSION.start_with?("2.")
         # Bundler's version compatible with Ruby 2 does not support "--path" switch
+        # Overwriting "rack" version due to unless Rack::Handler::Puma.respond_to?(:config) in Capybara gem v3.39.2 or earlier.
+        # Issue resolved in Capybara v3.40.0, but Ruby 2.7 support dropped; last compatible version is v3.39.2.
+        # Ref: https://github.com/shakacode/shakapacker/issues/498
         sh_in_dir({}, BASE_RAILS_APP_PATH, %(
           gem update bundler
           echo 'gem "shakapacker", :path => "#{GEM_ROOT}"' >> Gemfile
+          echo 'gem "rack", "< 3.0.0"' >> Gemfile
           bundle install
         ))
       else

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -19,10 +19,19 @@ describe "Generator" do
     ))
 
     Bundler.with_unbundled_env do
-      sh_in_dir({}, BASE_RAILS_APP_PATH, %(
-        gem update bundler
-        bundle add shakapacker --path "#{GEM_ROOT}"
-      ))
+      if RUBY_VERSION.start_with?("2.")
+        # Bundler's version compatible with Ruby 2 does not support "--path" switch
+        sh_in_dir({}, BASE_RAILS_APP_PATH, %(
+          gem update bundler
+          echo 'gem "shakapacker", :path => "#{GEM_ROOT}"' >> Gemfile
+          bundle install
+        ))
+      else
+        sh_in_dir({}, BASE_RAILS_APP_PATH, %(
+          gem update bundler
+          bundle add shakapacker --path "#{GEM_ROOT}"
+        ))
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

Closes https://github.com/shakacode/shakapacker/issues/498

Tests for ruby 2.7 were failing due to unless `Rack::Handler::Puma.respond_to?(:config)` in Capybara gem v3.39.2 or earlier.

This is caused by [`Rack` moving to a separate gem `Rackup` in Rack 3](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#binrackup-rackserver-rackhandlerand--racklobster-were-moved-to-a-separate-gem)

Issue resolved in Capybara v3.40.0, but Ruby 2.7 support dropped; last compatible version is v3.39.2. 

Hardcoding `rack` to be version 2 fixes it

### Pull Request checklist

~- [ ] Add/update test to cover these changes~
- Since this issue is relating to `capybara` which only happens in test environment, do you think we need to write a test for it? (@justin808)

~- [ ] Update documentation~
- [x] Update CHANGELOG file

### Other Information

Unsure if this is the best fix, but it's the easiest one I could come up with that does not require huge changes - especially when Ruby 2.7 has already passed EOL 2023-03-31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved failing tests for Ruby 2.7 related to `Rack::Handler::Puma.respond_to?(:config)`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->