### PR TITLE
feat: allow `webpack-merge` v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since the last non-beta release.
 
 ### Changed
 - Update outdated GitHub Actions to use Node.js 20.0 versions instead [PR 497](https://github.com/shakacode/shakapacker/pull/497) by [adriangohjw](https://github.com/adriangohjw).
+- Allow `webpack-merge` v6 to be used [PR 502](https://github.com/shakacode/shakapacker/pull/502) by [G-Rath](https://github.com/g-rath).
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webpack-assets-manifest": "^5.0.6",
     "webpack-cli": "^4.9.2 || ^5.0.0",
     "webpack-dev-server": "^4.9.0 || ^5.0.0",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.8.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@types/babel__core": {


### PR DESCRIPTION
### Summary

v6 just changes the min. Node to v18, so it's fine to allow both versions to be used.

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

v6 originally changed what it used to do its cloning, but that was later reverted due to a subtle difference meaning the only impactful change is to the supported Node version



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `webpack-merge` dependency to support version 6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->