### PR TITLE
Fix: esbuild loader documentation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
+### Changed
+
+- Fix wrong instruction in esbuild loader documentation [PR 504](https://github.com/shakacode/shakapacker/pull/504) by [adriangohjw](https://github.com/adriangohjw)
+
 ## [v8.0.1] - July 10, 2024
 
 ### Changed

--- a/docs/using_esbuild_loader.md
+++ b/docs/using_esbuild_loader.md
@@ -27,7 +27,7 @@ To use esbuild as your transpiler today. You need to do two things:
 npm install esbuild esbuild-loader
 ```
 
-2. Add or change `shakapacker_loader` value in your default `shakapacker.yml` config to `esbuild`
+2. Add or change `webpack_loader` value in your default `shakapacker.yml` config to `esbuild`
 The default configuration of babel is done by using `package.json` to use the file within the `shakapacker` package.
 
 ```yml


### PR DESCRIPTION
should be `webpack_loader` instead, similar to https://github.com/shakacode/shakapacker/blob/main/docs/using_swc_loader.md

### Summary

<!--
  Describe the code changes in your pull request here - were there any bugs you had fixed, features you added, tradeoffs you made?
  If so, mention them. If these changes have open GitHub issues, tag them here as well to keep the conversation linked.
-->

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

~- [ ] Add/update test to cover these changes~
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->

N.A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected esbuild loader documentation to update configuration value from `shakapacker_loader` to `webpack_loader`.
  - Fixed an incorrect instruction in the esbuild loader documentation in the `CHANGELOG.md` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->