### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/shakapacker.rb
+++ b/lib/shakapacker.rb
@@ -37,13 +37,13 @@ module Shakapacker
   delegate :bootstrap, :clean, :clobber, :compile, to: :commands
 end
 
-require "shakapacker/instance"
-require "shakapacker/env"
-require "shakapacker/configuration"
-require "shakapacker/manifest"
-require "shakapacker/compiler"
-require "shakapacker/commands"
-require "shakapacker/dev_server"
-require "shakapacker/deprecation_helper"
+require_relative "shakapacker/instance"
+require_relative "shakapacker/env"
+require_relative "shakapacker/configuration"
+require_relative "shakapacker/manifest"
+require_relative "shakapacker/compiler"
+require_relative "shakapacker/commands"
+require_relative "shakapacker/dev_server"
+require_relative "shakapacker/deprecation_helper"
 
-require "shakapacker/railtie" if defined?(Rails)
+require_relative "shakapacker/railtie" if defined?(Rails)

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -1,6 +1,7 @@
 require "open3"
-require "shakapacker/compiler_strategy"
 require "fileutils"
+
+require_relative "compiler_strategy"
 
 class Shakapacker::Compiler
   # Additional environment variables that the compiler is being run with

--- a/lib/shakapacker/compiler_strategy.rb
+++ b/lib/shakapacker/compiler_strategy.rb
@@ -1,5 +1,5 @@
-require "shakapacker/mtime_strategy"
-require "shakapacker/digest_strategy"
+require_relative "mtime_strategy"
+require_relative "digest_strategy"
 
 module Shakapacker
   class CompilerStrategy

--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -1,8 +1,9 @@
 require "shellwords"
 require "socket"
-require "shakapacker/configuration"
-require "shakapacker/dev_server"
-require "shakapacker/runner"
+
+require_relative "configuration"
+require_relative "dev_server"
+require_relative "runner"
 
 module Shakapacker
   class DevServerRunner < Shakapacker::Runner

--- a/lib/shakapacker/digest_strategy.rb
+++ b/lib/shakapacker/digest_strategy.rb
@@ -1,5 +1,6 @@
 require "digest/sha1"
-require "shakapacker/base_strategy"
+
+require_relative "base_strategy"
 
 module Shakapacker
   class DigestStrategy < BaseStrategy

--- a/lib/shakapacker/mtime_strategy.rb
+++ b/lib/shakapacker/mtime_strategy.rb
@@ -1,4 +1,4 @@
-require "shakapacker/base_strategy"
+require_relative "base_strategy"
 
 module Shakapacker
   class MtimeStrategy < BaseStrategy

--- a/lib/shakapacker/railtie.rb
+++ b/lib/shakapacker/railtie.rb
@@ -1,9 +1,9 @@
 require "rails/railtie"
 
-require "shakapacker/helper"
-require "shakapacker/dev_server_proxy"
-require "shakapacker/version_checker"
-require "shakapacker/utils/manager"
+require_relative "helper"
+require_relative "dev_server_proxy"
+require_relative "version_checker"
+require_relative "utils/manager"
 
 class Shakapacker::Engine < ::Rails::Engine
   # Allows Shakapacker config values to be set via Rails env config files

--- a/lib/shakapacker/runner.rb
+++ b/lib/shakapacker/runner.rb
@@ -1,5 +1,6 @@
-require "shakapacker/utils/misc"
-require "shakapacker/utils/manager"
+require_relative "utils/misc"
+require_relative "utils/manager"
+
 require "package_json"
 
 module Shakapacker

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "shakapacker/version"
+require_relative "version"
 
 module Shakapacker
   class VersionChecker

--- a/lib/shakapacker/webpack_runner.rb
+++ b/lib/shakapacker/webpack_runner.rb
@@ -1,5 +1,6 @@
 require "shellwords"
-require "shakapacker/runner"
+
+require_relative "runner"
 
 module Shakapacker
   class WebpackRunner < Shakapacker::Runner


### PR DESCRIPTION
### Summary

`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Refs:
- rubocop/rubocop#8748

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Don't know if this deserves an entry in the changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved dependency loading mechanism across various components for better reliability and performance.
- **Refactor**
	- Changed `require` statements to `require_relative` for several files, enhancing path resolution and maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->