### PR TITLE
Read package.json from APP_ROOT or Rails.root, not cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Changes since the last non-beta release.
 ### Changed
 - Changed internal `require`s to `require_relative` to make code less dependent on the load path. [PR 516](https://github.com/shakacode/shakapacker/pull/516) by [tagliala](https://github.com/tagliala).
 
+### Fixed
+- Fix error when rails environment is required from outside the rails root directory [PR 520](https://github.com/shakacode/shakapacker/pull/520)
+
 ## [v8.0.2] - August 28, 2024
 
 ### Fixed

--- a/lib/shakapacker/utils/manager.rb
+++ b/lib/shakapacker/utils/manager.rb
@@ -16,7 +16,7 @@ module Shakapacker
 
       # Emits a warning if it's not obvious what package manager to use
       def self.error_unless_package_manager_is_obvious!
-        return unless PackageJson.read.fetch("packageManager", nil).nil?
+        return unless PackageJson.read(rails_root).fetch("packageManager", nil).nil?
 
         guessed_binary = guess_binary
 
@@ -35,7 +35,7 @@ module Shakapacker
       #
       # @return [String]
       def self.guess_binary
-        MANAGER_LOCKS.find { |_, lock| File.exist?(lock) }&.first || "npm"
+        MANAGER_LOCKS.find { |_, lock| File.exist?(rails_root.join(lock)) }&.first || "npm"
       end
 
       # Guesses the version of the package manager to use by calling `<manager> --version`
@@ -53,6 +53,17 @@ module Shakapacker
 
         stdout.chomp
       end
+
+      private
+        def self.rails_root
+          if defined?(APP_ROOT)
+            Pathname.new(APP_ROOT)
+          elsif defined?(Rails)
+            Rails.root
+          else
+            raise "can only be called from a rails environment or with APP_ROOT defined"
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
Fixes #519.

### Summary

We have a few tools that are called from outside the rails root, require the rails environment, and then do something with the rails db.
These fail as error_unless_package_manager_is_obvious only works when called from inside Rails.root.
Other methods like `Shakapacker::VersionChecker::NodePackageVersion.package_json_path` take this into account, so my guess is that this is just a small bug.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ Bugfix, not a documented feature
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the changelog to include versioning, upgrade guides, and significant changes across multiple versions of the Shakapacker library.

- **New Features**
	- Enhanced package manager detection to operate within the correct file path context of a Rails application.

- **Bug Fixes**
	- Addressed errors related to the Rails environment being required from outside the Rails root directory.
	- Fixed documentation for the esbuild loader and improved asset compilation issues.

- **Tests**
	- Expanded test coverage for scenarios involving different working directories and package manager detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->