### PR TITLE
Allow loading webpack.config.ts if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since the last non-beta release.
 
 ### Changed
 - Changed internal `require`s to `require_relative` to make code less dependent on the load path. [PR 516](https://github.com/shakacode/shakapacker/pull/516) by [tagliala](https://github.com/tagliala).
+- Allow configuring webpack from a Typescript file (`config/webpack/webpack.config.ts`). [PR 524](https://github.com/shakacode/shakapacker/pull/524) by [jdelStrother](https://github.com/jdelStrother).
 
 ### Fixed
 - Fix error when rails environment is required from outside the rails root directory [PR 520](https://github.com/shakacode/shakapacker/pull/520)

--- a/README.md
+++ b/README.md
@@ -675,6 +675,24 @@ module.exports = generateWebpackConfig({
 });
 ```
 
+Optionally, your webpack config file itself can be written in Typescript:
+
+``` bash
+npm install ts-node @types/node @types/webpack
+```
+
+```ts
+// config/webpack/webpack.config.ts
+import { generateWebpackConfig } from "shakapacker";
+import ForkTSCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
+
+const config = generateWebpackConfig({
+  plugins: [new ForkTSCheckerWebpackPlugin()],
+});
+
+export default config;
+```
+
 #### CSS
 
 To enable CSS support in your application, add the following packages:

--- a/lib/shakapacker/runner.rb
+++ b/lib/shakapacker/runner.rb
@@ -15,13 +15,8 @@ module Shakapacker
       @argv = argv
 
       @app_path              = File.expand_path(".", Dir.pwd)
-      @webpack_config        = File.join(@app_path, "config/webpack/webpack.config.js")
       @shakapacker_config    = ENV["SHAKAPACKER_CONFIG"] || File.join(@app_path, "config/shakapacker.yml")
-
-      unless File.exist?(@webpack_config)
-        $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails shakapacker:install' to install Shakapacker with default configs or add the missing config file for your custom environment."
-        exit!
-      end
+      @webpack_config        = find_webpack_config
 
       Shakapacker::Utils::Manager.error_unless_package_manager_is_obvious!
     end
@@ -29,5 +24,18 @@ module Shakapacker
     def package_json
       @package_json ||= PackageJson.read(@app_path)
     end
+
+    private
+      def find_webpack_config
+        possible_paths = %w[ts js].map do |ext|
+          File.join(@app_path, "config/webpack/webpack.config.#{ext}")
+        end
+        path = possible_paths.find { |f| File.exist?(f) }
+        unless path
+          $stderr.puts "webpack config #{possible_paths.last} not found, please run 'bundle exec rails shakapacker:install' to install Shakapacker with default configs or add the missing config file for your custom environment."
+          exit!
+        end
+        path
+      end
   end
 end

--- a/spec/shakapacker/webpack_runner_spec.rb
+++ b/spec/shakapacker/webpack_runner_spec.rb
@@ -54,6 +54,17 @@ describe "WebpackRunner" do
 
         verify_command(cmd, argv: (["--watch"]))
       end
+
+      it "loads webpack.config.ts if present" do
+        ts_config = "#{test_app_path}/config/webpack/webpack.config.ts"
+        FileUtils.touch(ts_config)
+
+        cmd = package_json.manager.native_exec_command("webpack", ["--config", ts_config])
+
+        verify_command(cmd)
+      ensure
+        FileUtils.rm(ts_config)
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

This allows configuring webpack from Typescript in `config/webpack/webpack.config.ts` if it's present.

Further instructions on configuring webpack with typescript are [here](https://webpack.js.org/configuration/configuration-languages/), but if you've added ts-node & typescript to your package.json that should be all that's needed for webpack.config.ts to just work.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a TypeScript-based configuration option for webpack (`webpack.config.ts`).
  
- **Bug Fixes**
  - Improved error handling for Rails environment loading.
  
- **Documentation**
  - Updated README with installation instructions and upgrade paths for version 8.
  - Enhanced clarity on dependency management and configuration structure.

- **Tests**
  - Added a test case to verify loading of TypeScript webpack configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->