### PR TITLE
Fix install commands for different yarn versions

### DIFF
--- a/docs/v8_upgrade.md
+++ b/docs/v8_upgrade.md
@@ -21,9 +21,7 @@ If your host might differ, between various environments for example, you will ei
 - Ensure the assets are specifically rebuilt for each environment (Heroku pipeline promote feature for example does not do that by default).
 - Make sure the assets are compiled with `SHAKAPACKER_ASSET_HOST=''` ENV variable to avoid hardcording URLs in packs output.
 
-Second option has got a certain gotcha - dynamic imports and static asset references (like image paths in CSS) will end up without host reference and the app will try and fetch them from your app host rather than defined `config.asset_host`.
-
-Make sure the assets are compiled with `SHAKAPACKER_ASSET_HOST=''` ENV variable to avoid hardcoding URLs in packs output.
+The second option has got a certain gotcha - dynamic imports and static asset references (like image paths in CSS) will end up without a host reference and the app will try and fetch them from your app host rather than defined `config.asset_host`.
 
 To get around that, you can use dynamic override as outlined by [Webpack documentation](https://webpack.js.org/guides/asset-modules/#on-the-fly-override).
 
@@ -102,10 +100,10 @@ namespace :assets do
     raise if File.exist?("package.json") && !(system "npm ci")
 
     # yarn v1.x (classic)
-    raise if File.exist?("package.json") && !(system "yarn install --immutable")
+    raise if File.exist?("package.json") && !(system "yarn install --frozen-lockfile")
 
     # yarn v2+ (berry)
-    raise if File.exist?("package.json") && !(system "yarn install --frozen-lockfile")
+    raise if File.exist?("package.json") && !(system "yarn install --immutable")
 
     # bun v1+
     raise if File.exist?("package.json") && !(system "bun install --frozen-lockfile")


### PR DESCRIPTION
### Summary

The install command given for Yarn Classic only works for Yarn Berry. The command given for Yarn Berry works, but only due to backward compatibility. See https://yarnpkg.com/cli/install:

> If the `--immutable` option is set (defaults to true on CI), Yarn will abort with an error exit code if the lockfile was to be modified (other paths can be added using the [immutablePatterns](https://yarnpkg.com/configuration/yarnrc#immutablePatterns) configuration setting). For backward compatibility we offer an alias under the name of `--frozen-lockfile`, but it will be removed in a later release.

Separately, removed a duplicate sentence.

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- ~[ ] Add/update test to cover these changes~
- [x] Update documentation
- ~[ ] Update CHANGELOG file~

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated upgrade guide for Shakapacker from v7 to v8, detailing significant changes and best practices.
	- Emphasized the importance of setting the `SHAKAPACKER_ASSET_HOST` environment variable.
	- Clarified the necessity of the `packageManager` property in `package.json`.
	- Noted the renaming of the `check_yarn` rake task to `check_manager`.
	- Highlighted the requirement for manual installation of JavaScript dependencies prior to asset compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->