### PR TITLE
Allow `webpack-cli` 6.x (non-breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
+### Added
+
+- Allow `webpack-cli` v6. [PR 533](https://github.com/shakacode/shakapacker/pull/533) by [tagliala](https://github.com/tagliala).
+
 ### Changed
 - Changed internal `require`s to `require_relative` to make code less dependent on the load path. [PR 516](https://github.com/shakacode/shakapacker/pull/516) by [tagliala](https://github.com/tagliala).
 - Allow configuring webpack from a Typescript file (`config/webpack/webpack.config.ts`). [PR 524](https://github.com/shakacode/shakapacker/pull/524) by [jdelStrother](https://github.com/jdelStrother).

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "terser-webpack-plugin": "^5.3.1",
     "webpack": "^5.72.0",
     "webpack-assets-manifest": "^5.0.6",
-    "webpack-cli": "^4.9.2 || ^5.0.0",
+    "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0",
     "webpack-dev-server": "^4.9.0 || ^5.0.0",
     "webpack-merge": "^5.8.0 || ^6.0.0"
   },


### PR DESCRIPTION
Blocked by:
- [x] #536

Close #532

### Summary

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

Please test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for `webpack-cli` v6.
	- Introduced a new configuration option: `ensure_consistent_versioning`.

- **Breaking Changes**
	- Removed methods: `verify_file_existence`, `yarn_install`, and `check_yarn`.

- **Bug Fixes**
	- Addressed errors related to the Rails environment.

- **Documentation**
	- Improved documentation for the esbuild loader and Yarn PnP usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->