### PR TITLE
Fix generator specs (non-breaking, no changes to production code)

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: '16'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.2'
+          ruby-version: '3.1.6'
       - name: Install dependencies
         run: |
           bundle install

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -25,16 +25,23 @@ jobs:
           - gemfiles/Gemfile-rails.7.0.x
           - gemfiles/Gemfile-rails.7.1.x
           - gemfiles/Gemfile-rails.7.2.x
+          - gemfiles/Gemfile-rails.8.0.x
           # Uncomment the following line only to ensure compatibility with the
           # upcomming Rails versions, maybe before a release.
           #- gemfiles/Gemfile-rails-edge
         exclude:
           - ruby: '2.7'
             gemfile: gemfiles/Gemfile-rails.7.2.x
+          - ruby: '2.7'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails.7.2.x
+          - ruby: '3.0'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.1'
             gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.1'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.2'
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.3'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: yarn
 
       - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 16.x, 18.x, 20.x]
+        node: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,16 +42,23 @@ jobs:
           - gemfiles/Gemfile-rails.7.0.x
           - gemfiles/Gemfile-rails.7.1.x
           - gemfiles/Gemfile-rails.7.2.x
+          - gemfiles/Gemfile-rails.8.0.x
           # Uncomment the following line only to ensure compatibility with the
           # upcomming Rails versions, maybe before a release.
           #- gemfiles/Gemfile-rails-edge
         exclude:
           - ruby: '2.7'
             gemfile: gemfiles/Gemfile-rails.7.2.x
+          - ruby: '2.7'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails.7.2.x
+          - ruby: '3.0'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.1'
             gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.1'
+            gemfile: gemfiles/Gemfile-rails.8.0.x
           - ruby: '3.2'
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.3'

--- a/gemfiles/Gemfile-rails.6.0.x
+++ b/gemfiles/Gemfile-rails.6.0.x
@@ -5,5 +5,5 @@ gemspec path: "../"
 gem "rails", "~> 6.0.0"
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
-gem "rspec-rails", "~> 5.0.0"
+gem "rspec-rails", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -7,5 +7,5 @@ gemspec path: "../"
 gem "rails", '~>6.1.0'
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
-gem "rspec-rails", "~> 6.0.0"
+gem "rspec-rails", "~> 6.1"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.7.0.x
+++ b/gemfiles/Gemfile-rails.7.0.x
@@ -7,5 +7,5 @@ gemspec path: "../"
 gem "rails", '~>7.0.0'
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
-gem "rspec-rails", "~> 6.0.0"
+gem "rspec-rails", "~> 7.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.7.2.x
+++ b/gemfiles/Gemfile-rails.7.2.x
@@ -7,5 +7,5 @@ gemspec path: "../"
 gem "rails", '~>7.2.0'
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
-gem "rspec-rails", "~> 6.0.0"
+gem "rspec-rails", "~> 7.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.8.0.x
+++ b/gemfiles/Gemfile-rails.8.0.x
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec path: "../"
 
-gem "rails", '~>7.1.0'
+gem "rails", '~>8.0.0'
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
 gem "rspec-rails", "~> 7.0"

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -31,8 +31,17 @@ describe "Generator" do
           bundle install
         ))
       else
+        # TODO: remove when Ruby < 3.1 support will be dropped
+        # Ref: https://github.com/shakacode/shakapacker/issues/534
+        bundler_update_command =
+          if RUBY_VERSION.start_with?("3.1")
+            "gem update bundler"
+          else
+            "gem install bundler --version '< 2.6'"
+          end
+
         sh_in_dir({}, BASE_RAILS_APP_PATH, %(
-          gem update bundler
+          #{bundler_update_command}
           bundle add shakapacker --path "#{GEM_ROOT}"
         ))
       end


### PR DESCRIPTION
Allow bundler installation on Ruby 3.0

Additionally:
- Test against Node 22
- Test against Rails 8.0
- Use latest Ruby 3.1 for dummy specs
- Use proper rspec-rails versions

Close #534

---

Non breaking, no changes to production code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Gemfile for Rails version 8.0.x.
	- Expanded Node.js version support in CI jobs to include 22.x.
	- Updated Ruby version in workflows to 3.1.6.
- **Bug Fixes**
	- Adjusted version constraints for `rspec-rails` across multiple Gemfiles to ensure compatibility.
- **Chores**
	- Updated commands for Bundler based on Ruby version in the generator specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->