### PR TITLE
Add full Ruby 3.4 compatibility (non-breaking)

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
@@ -41,6 +41,12 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.3'
             gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.7.0.x
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
         run: rm -f Gemfile.lock
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           rubygems: latest
           bundler-cache: true
 
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile:
           - gemfiles/Gemfile-rails.6.0.x
           - gemfiles/Gemfile-rails.6.1.x
@@ -59,6 +59,12 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: '3.3'
             gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.6.0.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: '3.4'
+            gemfile: gemfiles/Gemfile-rails.7.0.x
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/lib/shakapacker/helper.rb
+++ b/lib/shakapacker/helper.rb
@@ -195,7 +195,7 @@ module Shakapacker::Helper
 
     def update_javascript_pack_tag_queue(defer:)
       if @javascript_pack_tag_loaded
-        raise "You can only call #{caller_locations(1..1).first.label} before javascript_pack_tag helper. " \
+        raise "You can only call #{caller_locations(1..1).first.base_label} before javascript_pack_tag helper. " \
         "Please refer to https://github.com/shakacode/shakapacker/blob/main/README.md#view-helper-append_javascript_pack_tag-prepend_javascript_pack_tag-and-append_stylesheet_pack_tag for the usage guide"
       end
 


### PR DESCRIPTION
Blocked by
- [x] #536

Caller location with `label` is being decorated with
`Shakapacker::Helper#` in Ruby 3.4

This commit changes `label` to `base_label`

Close #535

Ref:
- https://ruby-doc.org/core-2.7.0/Thread/Backtrace/Location.html#method-i-base_label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **CI/CD Updates**
  - Added support for Ruby 3.4 in GitHub Actions workflows
  - Updated testing matrix to include Ruby 3.4
  - Added specific exclusion rules for Ruby 3.4 with certain Rails gemfiles

- **Code Improvements**
  - Minor refinement to error message generation in helper method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->