### PR TITLE
Don't update Bundler in generator specs

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
+          rubygems: latest
       - name: Install dependencies
         run: |
           bundle install

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -52,5 +52,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler-cache: true
       - run: bundle exec rake run_spec:generator

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+          rubygems: latest
           bundler-cache: true
 
       - name: Ruby rubocop
@@ -69,6 +70,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Ruby specs

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -25,14 +25,12 @@ describe "Generator" do
         # Issue resolved in Capybara v3.40.0, but Ruby 2.7 support dropped; last compatible version is v3.39.2.
         # Ref: https://github.com/shakacode/shakapacker/issues/498
         sh_in_dir({}, BASE_RAILS_APP_PATH, %(
-          gem update bundler
           echo 'gem "shakapacker", :path => "#{GEM_ROOT}"' >> Gemfile
           echo 'gem "rack", "< 3.0.0"' >> Gemfile
           bundle install
         ))
       else
         sh_in_dir({}, BASE_RAILS_APP_PATH, %(
-          gem update bundler
           bundle add shakapacker --path "#{GEM_ROOT}"
         ))
       end


### PR DESCRIPTION
### Summary

- Skip manual update of Bundler when running generator specs
- Use bundler and rubygems version shipped by ruby/setup-ruby action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to use the latest RubyGems version across multiple workflow files
	- Simplified test suite setup by removing Bundler update command in generator specs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->