### PR TITLE
Allow babel-loader 10 (non-breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _next_ branch is for v8 changes
 ## [Unreleased]
 Changes since the last non-beta release.
 
+### Added
+
+- Allow `babel-loader` v10. [PR 552](https://github.com/shakacode/shakapacker/pull/552) by [shoeyn](https://github.com/shoeyn).
+
 ## [v8.1.0] - January 20, 2025
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/runtime": "^7.17.9",
     "@types/babel__core": "^7.0.0",
     "@types/webpack": "^5.0.0",
-    "babel-loader": "^8.2.4 || ^9.0.0",
+    "babel-loader": "^8.2.4 || ^9.0.0 || ^10.0.0",
     "compression-webpack-plugin": "^9.0.0 || ^10.0.0|| ^11.0.0",
     "terser-webpack-plugin": "^5.3.1",
     "webpack": "^5.72.0",


### PR DESCRIPTION
### Summary

Allow babel-loader 10, there's no breaking changes, just removes old node versions
https://github.com/babel/babel-loader/releases/tag/v10.0.0

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

~- [x] Add/update test to cover these changes~
~- [x] Update documentation~
- [x] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded compatibility by adding support for babel-loader version 10.
- **Documentation**
  - Updated release notes to reflect the inclusion of the new compatibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->