### PR TITLE
Add support for async script loading in javascript_pack_tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since the last non-beta release.
 
 ### Added
 
+- Support for `async` attribute in `javascript_pack_tag`, `append_javascript_pack_tag`, and `prepend_javascript_pack_tag`. [PR 554](https://github.com/shakacode/shakapacker/pull/554) by [AbanoubGhadban](https://github.com/abanoubghadban).
 - Allow `babel-loader` v10. [PR 552](https://github.com/shakacode/shakapacker/pull/552) by [shoeyn](https://github.com/shoeyn).
 
 ## [v8.1.0] - January 20, 2025

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ You can provide multiple packs and other attributes. Note, `defer` defaults to s
 ```
 
 The resulting HTML would look like this:
-```
+```html
 <script src="/packs/vendor-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
 <script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbo-track="reload" defer></script>
 <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbo-track="reload" defer"></script>
@@ -286,6 +286,26 @@ The resulting HTML would look like this:
 In this output, both the calendar and map codes might refer to other common libraries. Those get placed in something like the vendor bundle. The view helper removes any duplication.
 
 Note, the default of "defer" for the `javascript_pack_tag`. You can override that to `false`. If you expose jquery globally with `expose-loader,` by using `import $ from "expose-loader?exposes=$,jQuery!jquery"` in your `app/javascript/application.js`, pass the option `defer: false` to your `javascript_pack_tag`.
+
+The `javascript_pack_tag` also supports the `async` attribute, which you can enable by passing `async: true`:
+
+```erb
+<%= javascript_pack_tag 'application', async: true %>
+```
+
+This will generate script tags with the `async` attribute, which allows the browser to download and execute the script asynchronously without blocking HTML parsing:
+
+```html
+<script src="/packs/vendor-16838bab065ae1e314.js" async></script>
+<script src="/packs/application~runtime-16838bab065ae1e314.js" async></script>
+<script src="/packs/application-1016838bab065ae1e314.js" async></script>
+```
+
+Note that when using `async: true`, scripts may execute in any order as soon as they're downloaded, which could cause issues if your code has dependencies between files. In most cases, `defer` (the default) is preferred as it maintains execution order.
+
+> [!NOTE]
+>
+> When both `async` and `defer` attributes are specified, `async` takes precedence according to HTML5 specifications. So if you pass both `async: true` and `defer: true`, the script tag will use `async`.
 
 **Important:** Pass all your pack names as multiple arguments, not multiple calls, when using `javascript_pack_tag` and the `stylesheet_pack_tag`. Otherwise, you will get duplicated chunks on the page. 
 

--- a/spec/shakapacker/helper_spec.rb
+++ b/spec/shakapacker/helper_spec.rb
@@ -175,6 +175,53 @@ module ActionView::TestCase::Behavior
       }.to raise_error(expected_error_message)
     end
 
+    it "#javascript_pack_tag generates the correct tags when passing `async: true`" do
+      expected = <<~HTML.chomp
+        <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" async="async"></script>
+        <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" async="async"></script>
+        <script src="/packs/application-k344a6d59eef8632c9d1.js" async="async"></script>
+      HTML
+
+      expect(javascript_pack_tag("application", async: true)).to eq expected
+    end
+
+    it "#javascript_pack_tag generates the correct tags when passing both `defer: true` and `async: true`" do
+      # When both async and defer are specified, async takes precedence per HTML5 spec
+      expected = <<~HTML.chomp
+        <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" async="async"></script>
+        <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" async="async"></script>
+        <script src="/packs/application-k344a6d59eef8632c9d1.js" async="async"></script>
+      HTML
+
+      expect(javascript_pack_tag("application", defer: true, async: true)).to eq expected
+    end
+
+    it "#append_javascript_pack_tag supports the async attribute" do
+      append_javascript_pack_tag("bootstrap", async: true)
+
+      expected = <<~HTML.chomp
+        <script src="/packs/bootstrap-300631c4f0e0f9c865bc.js" async="async"></script>
+        <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
+        <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
+        <script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>
+      HTML
+
+      expect(javascript_pack_tag("application")).to eq expected
+    end
+
+    it "#prepend_javascript_pack_tag supports the async attribute" do
+      prepend_javascript_pack_tag("main", async: true)
+
+      expected = <<~HTML.chomp
+        <script src="/packs/main-e323a53c7f30f5d53cbb.js" async="async"></script>
+        <script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>
+        <script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>
+        <script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>
+      HTML
+
+      expect(javascript_pack_tag("application")).to eq expected
+    end
+
     it "#stylesheet_pack_tag generates the correct link tag with string arguments" do
       expected = (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .uniq


### PR DESCRIPTION
- Extend javascript_pack_tag to support async script loading
- Modify append_javascript_pack_tag to handle async, deferred, and sync script types
- Update script rendering order to prioritize async, then deferred, then sync scripts
- Refactor javascript_pack_tag_queue to include async script category

### Summary

<!--
  Describe the code changes in your pull request here - were there any bugs you had fixed, features you added, tradeoffs you made?
  If so, mention them. If these changes have open GitHub issues, tag them here as well to keep the conversation linked.
-->

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an `async` option in JavaScript helper methods, enabling scripts to load asynchronously. When both `async` and `defer` are specified, `async` takes precedence per HTML5 standards.
  
- **Documentation**
  - Updated guides to demonstrate how to enable asynchronous loading, including usage examples.
  
- **Tests**
  - Expanded test coverage to ensure asynchronous script loading behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->