### PR TITLE
Resolve version mismatch error in spec/dummy

### DIFF
--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -4060,7 +4060,7 @@ setprototypeof@1.2.0:
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 "shakapacker@file:.yalc/shakapacker":
-  version "8.1.0"
+  version "8.2.0"
   dependencies:
     js-yaml "^4.1.0"
     path-complete-extname "^1.0.0"


### PR DESCRIPTION
CI is currently failing on master due to a version mismatch in spec/dummy. This PR is for debugging and resolving this issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process with new automation steps that clean up obsolete data and provide additional insights on dependency inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->