### PR TITLE
fix: install the latest major version of peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since the last non-beta release.
 
 ### Fixed
 
+- Install the latest major version of peer dependencies [PR 576](https://github.com/shakacode/shakapacker/pull/576) by [G-Rath](https://github.com/g-rath).
 - Remove duplicate word in comment from generated `shakapacker.yml` config [PR 572](https://github.com/shakacode/shakapacker/pull/572) by [G-Rath](https://github.com/g-rath).
 
 ## [v8.3.0] - April 25, 2025

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -136,7 +136,7 @@ Dir.chdir(Rails.root) do
   dev_dependencies_to_add = []
 
   peers.each do |(package, version)|
-    major_version = version.match(/(\d+)/)[1]
+    major_version = version.split("||").last.match(/(\d+)/)[1]
     entry = "#{package}@#{major_version}"
 
     if dev_dependency_packages.include? package


### PR DESCRIPTION
### Summary

As our peer dependency version constraints are laid out from oldest version to latest version, we currently install the oldest version major of peer dependencies which can result in security vulnerabilities and just general lagging behind - while the older versions will likely be more compatible with older versions of Node, I think it's fine to assume a recent version of Node is being used when you're install Shakapacker on a project.

<!--
  Describe the code changes in your pull request here - were there any bugs you had fixed, features you added, tradeoffs you made?
  If so, mention them. If these changes have open GitHub issues, tag them here as well to keep the conversation linked.
-->

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [ ] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->

I don't think this needs to be considered breaking given it will only apply to new runs of Shakapacker install, which is a "do once per application" thing for consumers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to include a fixed issue entry about installing the latest major version of peer dependencies.

- **Bug Fixes**
  - Improved handling of peer dependency version strings with multiple alternatives, ensuring the correct major version is extracted when alternatives are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->