### PR TITLE
Update Readme instructions for ReactRefreshWebpackPlugin 

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -61,11 +61,7 @@ const webpackConfig = generateWebpackConfig();
 
 if (isDevelopment && inliningCss) {
   webpackConfig.plugins.push(
-    new ReactRefreshWebpackPlugin({
-      overlay: {
-        sockPort: webpackConfig.devServer.port,
-      },
-    })
+    new ReactRefreshWebpackPlugin()
   );
 }
 
@@ -201,11 +197,7 @@ const webpackConfig = generateWebpackConfig();
 
 if (isDevelopment && inliningCss) {
   webpackConfig.plugins.push(
-    new ReactRefreshWebpackPlugin({
-      overlay: {
-        sockPort: webpackConfig.devServer.port,
-      },
-    })
+    new ReactRefreshWebpackPlugin()
   );
 }
 


### PR DESCRIPTION


### Summary

Current Readme suggests react-refresh-webpack-plugin usage like this:

```
new ReactRefreshWebpackPlugin({
      overlay: {
        sockPort: webpackConfig.devServer.port,
      },
})
```

In [v0.6.0](https://github.com/pmmmwh/react-refresh-webpack-plugin/releases/tag/v0.6.0) react refresh plugin has removed the overlay sockPort option.

It was released on 28 Apr 2025. From release notes:

> It is no-longer necessary as a direct integration with WDS is now possible.

New configuration should be:

```
new ReactRefreshWebpackPlugin()
```

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React setup documentation to simplify the configuration of the ReactRefreshWebpackPlugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->