### PR TITLE
fix: update webpack-dev-server to secure versions (^4.15.2 || ^5.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-assets-manifest": "^5.0.6 || ^6.0.0",
     "webpack-subresource-integrity": "^5.1.0",
     "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0",
-    "webpack-dev-server": "^4.9.0 || ^5.0.0",
+    "webpack-dev-server": "^4.15.2 || ^5.2.2",
     "webpack-merge": "^5.8.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

Addresses critical security vulnerability CVE-2025-30359 in webpack-dev-server versions ≤5.2.0 that allows source code theft when users access malicious websites.

### Changes

- Updated `webpack-dev-server` peerDependency constraint from `^4.9.0 || ^5.0.0` to `^4.15.2 || ^5.2.2`
- Ensures new installations use secure versions by default
- Maintains compatibility with both 4.x and 5.x branches
- Installation template will still default to version 5.x (now 5.2.2+)

### Security Impact

The vulnerability (CVE-2025-30359) allows attackers to steal source code by exploiting how webpack-dev-server handles script requests. The fix in versions 4.15.2+ and 5.2.1+ addresses origin validation issues.

### Testing

- ✅ All existing tests pass
- ✅ ESLint passes
- ✅ Version extraction logic verified to work correctly with new constraints

### Migration Notes

Users can upgrade by running:
- `npm update webpack-dev-server` 
- `yarn upgrade webpack-dev-server`
- `pnpm update webpack-dev-server`

Resolves #584

🤖 Generated with [Claude Code](https://claude.ai/code)