### PR TITLE
Consolidate dummy apps to support both webpack and rspack

### DIFF
--- a/spec/dummy/README.md
+++ b/spec/dummy/README.md
@@ -1,1 +1,76 @@
-This dummy project is based on [React on Rails Demo With SSR, HMR fast refresh, and TypeScript](https://github.com/shakacode/react_on_rails_demo_ssr_hmr) project.
+# Shakapacker Test Application
+
+This is a test Rails application used for testing Shakapacker with different asset bundlers.
+
+## Bundler Support
+
+This dummy application supports testing with both Webpack and RSpack bundlers.
+
+### Testing with Webpack (Default)
+
+```bash
+# Use webpack (default configuration)
+bin/shakapacker
+bin/shakapacker-dev-server
+```
+
+### Testing with RSpack
+
+```bash
+# Switch to RSpack configuration
+bin/test-bundler rspack
+
+# Then run shakapacker commands
+bin/shakapacker
+bin/shakapacker-dev-server
+
+# Or run directly with the test-bundler script
+bin/test-bundler rspack bin/shakapacker
+```
+
+### Switching Between Bundlers
+
+The `bin/test-bundler` script allows you to easily switch between webpack and rspack configurations:
+
+```bash
+# Switch to rspack
+bin/test-bundler rspack
+
+# Switch back to webpack
+bin/test-bundler webpack
+
+# Run a command with a specific bundler
+bin/test-bundler rspack bin/shakapacker
+bin/test-bundler webpack bin/shakapacker-dev-server
+```
+
+## Configuration Files
+
+- `config/shakapacker.yml` - Active configuration (modified by test-bundler script)
+- `config/shakapacker-webpack.yml` - Webpack-specific configuration
+- `config/shakapacker-rspack.yml` - RSpack-specific configuration
+- `config/webpack/webpack.config.js` - Webpack configuration
+- `config/rspack/rspack.config.js` - RSpack configuration
+
+## Environment Variables
+
+You can also use environment variables to override the bundler:
+
+```bash
+SHAKAPACKER_ASSET_BUNDLER=rspack bin/shakapacker
+SHAKAPACKER_ASSET_BUNDLER=webpack bin/shakapacker
+```
+
+## Running Tests
+
+To test both bundlers in CI or locally:
+
+```bash
+# Test with webpack
+bin/test-bundler webpack bin/shakapacker
+# Run your tests here
+
+# Test with rspack
+bin/test-bundler rspack bin/shakapacker
+# Run your tests here
+```

--- a/spec/dummy/bin/test-bundler
+++ b/spec/dummy/bin/test-bundler
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# Script to test Shakapacker with different bundlers (webpack or rspack)
+
+require 'fileutils'
+require 'yaml'
+
+bundler = ARGV[0] || 'webpack'
+command = ARGV[1..-1].join(' ') if ARGV.length > 1
+
+unless ['webpack', 'rspack'].include?(bundler)
+  puts "Usage: bin/test-bundler [webpack|rspack] [command]"
+  puts "Example: bin/test-bundler rspack bin/shakapacker"
+  puts "Example: bin/test-bundler webpack bin/shakapacker-dev-server"
+  exit 1
+end
+
+config_dir = File.expand_path('../config', __dir__)
+shakapacker_config = File.join(config_dir, 'shakapacker.yml')
+webpack_config = File.join(config_dir, 'shakapacker-webpack.yml')
+rspack_config = File.join(config_dir, 'shakapacker-rspack.yml')
+
+# Create backup of original webpack config if it doesn't exist
+unless File.exist?(webpack_config)
+  puts "Creating backup of original webpack config..."
+  FileUtils.cp(shakapacker_config, webpack_config)
+end
+
+# Switch configuration based on bundler
+if bundler == 'rspack'
+  if File.exist?(rspack_config)
+    puts "Switching to RSpack configuration..."
+    FileUtils.cp(rspack_config, shakapacker_config)
+    ENV['SHAKAPACKER_ASSET_BUNDLER'] = 'rspack'
+  else
+    puts "Error: RSpack config not found at #{rspack_config}"
+    exit 1
+  end
+else
+  puts "Switching to Webpack configuration..."
+  FileUtils.cp(webpack_config, shakapacker_config)
+  ENV['SHAKAPACKER_ASSET_BUNDLER'] = 'webpack'
+end
+
+puts "Using #{bundler.upcase} as the asset bundler"
+
+# Run command if provided
+if command
+  puts "Running: #{command}"
+  exec(command)
+else
+  puts "Configuration switched to #{bundler}. You can now run Shakapacker commands."
+end

--- a/spec/dummy/config/rspack/rspack.config.js
+++ b/spec/dummy/config/rspack/rspack.config.js
@@ -1,0 +1,6 @@
+// See the shakacode/shakapacker README and docs directory for advice on customizing your rspackConfig.
+const { generateRspackConfig } = require('shakapacker/rspack')
+
+const rspackConfig = generateRspackConfig()
+
+module.exports = rspackConfig

--- a/spec/dummy/config/shakapacker-rspack.yml
+++ b/spec/dummy/config/shakapacker-rspack.yml
@@ -1,0 +1,60 @@
+# Configuration for RSpack bundler
+# This file extends the base shakapacker.yml with RSpack-specific settings
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/shakapacker
+  webpack_compile_output: true
+
+  # Use RSpack as the bundler
+  assets_bundler: 'rspack'
+
+  # Additional paths webpack should lookup modules
+  # ['app/assets', 'engine/foo/app/assets']
+  additional_paths: []
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+development:
+  <<: *default
+  # This is false since we're running `bin/shakapacker -w` in Procfile.dev
+  compile: false
+
+  # Reference: https://www.rspack.dev/config/dev-server
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    # Hot Module Replacement updates modules while the application is running without a full reload
+    hot: true
+    client:
+      # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
+      overlay: true
+    compress: true
+    # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
+    allowed_hosts: [ 'localhost' ]
+    headers:
+      'Access-Control-Allow-Origin': '*'
+    static:
+      watch:
+        ignored: '**/node_modules/**'
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true

--- a/spec/dummy/config/shakapacker-webpack.yml
+++ b/spec/dummy/config/shakapacker-webpack.yml
@@ -1,0 +1,62 @@
+# Note: You must restart bin/webpacker-dev-server for changes to take effect
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/webpacker
+  webpack_compile_output: true
+
+  # Additional paths webpack should lookup modules
+  # ['app/assets', 'engine/foo/app/assets']
+  additional_paths: []
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+development:
+  <<: *default
+  # This is false since we're running `bin/webpacker -w` in Procfile.dev-setic
+  compile: false
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    # Hot Module Replacement updates modules while the application is running without a full reload
+    hmr: true
+    client:
+      # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
+      overlay: true
+      # May also be a string
+      # webSocketURL:
+      #  hostname: "0.0.0.0"
+      #  pathname: "/ws"
+      #  port: 8080
+    compress: true
+    # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
+    allowed_hosts: [ 'localhost' ]
+    pretty: true
+    headers:
+      'Access-Control-Allow-Origin': '*'
+    static:
+      watch:
+        ignored: '**/node_modules/**'
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true


### PR DESCRIPTION
## Summary
Eliminates duplication between spec/dummy and spec/dummy-rspack by configuring a single test app to support both bundlers.

## Changes
- Removed spec/dummy-rspack directory (was never in version control, only build artifacts)
- Added dual bundler support to spec/dummy with configuration switching
- Created bin/test-bundler script to easily switch between webpack and rspack
- Added separate config files for each bundler
- Added rspack.config.js alongside existing webpack.config.js
- Documented bundler testing in spec/dummy/README.md

## Benefits
- Single source of truth for test application code
- Easy testing of both bundlers without duplication
- Reduced maintenance burden

## Testing
cd spec/dummy
bin/test-bundler rspack  # Switch to rspack
bin/test-bundler webpack # Switch back to webpack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to quickly switch between Webpack and RSpack for Shakapacker, update configuration automatically, and optionally run follow-up commands with clear guidance when configs are missing.

* **Documentation**
  * Expanded README with end-to-end setup and usage for both bundlers, including how to switch bundlers, run development server and tests, and configure environment variables and output paths across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->