### PR TITLE
docs: Add webpack-cli/webpack-dev-server version compatibility gotcha

### DIFF
--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -101,9 +101,13 @@ _If you're on webpacker v5, follow [how to upgrade to webpacker v6.0.0.rc.6 from
 
 1. Update `webpack-dev-server` to the current version, greater than 4.2, updating `package.json`.
 
-   **Important:** Ensure version compatibility between webpack-cli and webpack-dev-server. If you encounter the error `[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema` with an unknown property `_assetEmittingPreviousFiles`, this typically indicates version incompatibility. webpack-cli v4 is not compatible with webpack-dev-server v5. Ensure you're using compatible versions, such as:
-   - webpack-cli 4.x with webpack-dev-server 4.x 
-   - webpack-cli 5.x with webpack-dev-server 5.x
+   **Important:** If you encounter the error `[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema` with an unknown property `_assetEmittingPreviousFiles`, this indicates your webpack-dev-server configuration contains deprecated options. 
+   
+   To resolve this issue:
+   - Ensure you're using webpack-cli >= 4.7.0 with webpack-dev-server 5.x (webpack-cli 4.7+ is compatible with webpack-dev-server v5)
+   - Check your current versions: `npm list webpack-cli webpack-dev-server`
+   - Remove any legacy options like `_assetEmittingPreviousFiles` from your dev-server configuration
+   - Review the [webpack-dev-server migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md) for proper v4 to v5 migration steps
    
    See [issue #526](https://github.com/shakacode/shakapacker/issues/526) for more details.
 

--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -101,6 +101,12 @@ _If you're on webpacker v5, follow [how to upgrade to webpacker v6.0.0.rc.6 from
 
 1. Update `webpack-dev-server` to the current version, greater than 4.2, updating `package.json`.
 
+   **Important:** Ensure version compatibility between webpack-cli and webpack-dev-server. If you encounter the error `[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema` with an unknown property `_assetEmittingPreviousFiles`, this typically indicates version incompatibility. webpack-cli v4 is not compatible with webpack-dev-server v5. Ensure you're using compatible versions, such as:
+   - webpack-cli 4.x with webpack-dev-server 4.x 
+   - webpack-cli 5.x with webpack-dev-server 5.x
+   
+   See [issue #526](https://github.com/shakacode/shakapacker/issues/526) for more details.
+
 1. Update API usage of the view helpers by changing `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag` to `javascript_pack_tag` and `stylesheet_pack_tag`. Ensure that your layouts and views will only have **at most one call** to `javascript_pack_tag` and **at most one call** to `stylesheet_pack_tag`. You can now pass multiple bundles to these view helper methods. If you fail to changes this, you may experience performance issues, and other bugs related to multiple copies of React, like [issue 2932](https://github.com/rails/webpacker/issues/2932).  If you expose jquery globally with `expose-loader` by using `import $ from "expose-loader?exposes=$,jQuery!jquery"` in your `app/javascript/application.js`, pass the option `defer: false` to your `javascript_pack_tag`.
 
 1. If you are using any integrations like `css`, `postcss`, `React` or `TypeScript`. Please see https://github.com/shakacode/shakapacker#integrations section on how they work in v6.


### PR DESCRIPTION
## Summary
- Documents the V6 upgrade error where webpack-cli v4 is incompatible with webpack-dev-server v5
- Adds clear guidance on version compatibility requirements
- References issue #526 for users encountering the `_assetEmittingPreviousFiles` error

## Context
Users upgrading from Webpacker v5 to v6 may encounter the error:
```
[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
```

This occurs when webpack-cli v4 is used with webpack-dev-server v5, which are incompatible.

## Test plan
- [x] Documentation clearly explains the issue
- [x] Provides solution for version compatibility
- [x] Links to original issue for reference

Fixes #526

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v6 upgrade guide with an “Important” remediation block for deprecated option errors (assetEmittingPreviousFiles), including verification steps and cleanup instructions.
  * Recommends compatible webpack-cli and webpack-dev-server pairings (noting webpack-cli >=4.7.0 with webpack-dev-server 5.x).
  * Links to the related issue for context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->