### PR TITLE
fix: Restore optional peer dependencies with proper configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,114 @@
     "webpack-merge": "^5.8.0",
     "webpack-subresource-integrity": "^5.1.0"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.17.9",
+    "@babel/plugin-transform-runtime": "^7.17.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/runtime": "^7.17.9",
+    "@rspack/core": "^1.0.0",
+    "@rspack/cli": "^1.0.0",
+    "@rspack/plugin-react-refresh": "^1.0.0",
+    "@types/babel__core": "^7.0.0",
+    "@types/webpack": "^5.0.0",
+    "babel-loader": "^8.2.4 || ^9.0.0 || ^10.0.0",
+    "compression-webpack-plugin": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "css-loader": "^6.8.1 || ^7.0.0",
+    "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
+    "esbuild-loader": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "mini-css-extract-plugin": "^2.0.0",
+    "rspack-manifest-plugin": "^5.0.0",
+    "sass": "^1.0.0",
+    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "swc-loader": "^0.1.15 || ^0.2.0",
+    "terser-webpack-plugin": "^5.3.1",
+    "webpack": "^5.76.0",
+    "webpack-assets-manifest": "^5.0.6 || ^6.0.0",
+    "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0",
+    "webpack-dev-server": "^4.15.2 || ^5.2.2",
+    "webpack-merge": "^5.8.0 || ^6.0.0",
+    "webpack-subresource-integrity": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "@babel/plugin-transform-runtime": {
+      "optional": true
+    },
+    "@babel/preset-env": {
+      "optional": true
+    },
+    "@babel/runtime": {
+      "optional": true
+    },
+    "@rspack/core": {
+      "optional": true
+    },
+    "@rspack/cli": {
+      "optional": true
+    },
+    "@rspack/plugin-react-refresh": {
+      "optional": true
+    },
+    "@types/babel__core": {
+      "optional": true
+    },
+    "@types/webpack": {
+      "optional": true
+    },
+    "babel-loader": {
+      "optional": true
+    },
+    "compression-webpack-plugin": {
+      "optional": true
+    },
+    "css-loader": {
+      "optional": true
+    },
+    "esbuild": {
+      "optional": true
+    },
+    "esbuild-loader": {
+      "optional": true
+    },
+    "mini-css-extract-plugin": {
+      "optional": true
+    },
+    "rspack-manifest-plugin": {
+      "optional": true
+    },
+    "sass": {
+      "optional": true
+    },
+    "sass-loader": {
+      "optional": true
+    },
+    "swc-loader": {
+      "optional": true
+    },
+    "terser-webpack-plugin": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    },
+    "webpack-assets-manifest": {
+      "optional": true
+    },
+    "webpack-cli": {
+      "optional": true
+    },
+    "webpack-dev-server": {
+      "optional": true
+    },
+    "webpack-merge": {
+      "optional": true
+    },
+    "webpack-subresource-integrity": {
+      "optional": true
+    }
+  },
   "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">= 14",

--- a/package/config.ts
+++ b/package/config.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path"
 import { load } from "js-yaml"
 import { existsSync, readFileSync } from "fs"
+// @ts-ignore - webpack-merge is an optional peer dependency
 import { merge } from "webpack-merge"
 const { ensureTrailingSlash } = require("./utils/helpers")
 const { railsEnv } = require("./env")

--- a/package/environments/base.ts
+++ b/package/environments/base.ts
@@ -5,6 +5,7 @@ const { basename, dirname, join, relative, resolve } = require("path")
 const { existsSync, readdirSync } = require("fs")
 import { Dirent } from "fs"
 const extname = require("path-complete-extname")
+// @ts-ignore - webpack is an optional peer dependency
 import { Configuration, Entry } from "webpack"
 const config = require("../config")
 const { isProduction } = require("../env")

--- a/package/index.ts
+++ b/package/index.ts
@@ -4,6 +4,7 @@
 const webpackMerge = require("webpack-merge")
 import { resolve } from "path"
 import { existsSync } from "fs"
+// @ts-ignore - webpack is an optional peer dependency
 import { Configuration } from "webpack"
 const config = require("./config")
 const baseConfig = require("./environments/base")

--- a/package/loaders.d.ts
+++ b/package/loaders.d.ts
@@ -1,3 +1,4 @@
+// @ts-ignore - webpack is an optional peer dependency
 import type { LoaderDefinitionFunction } from 'webpack'
 
 export interface ShakapackerLoaderOptions {

--- a/package/webpack-types.d.ts
+++ b/package/webpack-types.d.ts
@@ -1,3 +1,4 @@
+// @ts-ignore - webpack is an optional peer dependency
 import type { Configuration, RuleSetRule, RuleSetUseItem } from 'webpack'
 
 export interface ShakapackerWebpackConfig extends Configuration {


### PR DESCRIPTION
## Summary
- Restored peer dependencies that were previously removed to avoid installation warnings
- Properly configured them as optional using `peerDependenciesMeta`
- Added TypeScript ignore comments for optional package imports

## Context
Based on discussion in Discord, peer dependencies were removed to avoid warnings during package installation. However, this made it difficult to track what packages are required and supported versions during upgrades. The proper solution is to use `peerDependenciesMeta` to mark dependencies as optional.

## Changes
1. Re-added all peer dependencies to package.json including:
   - Babel packages (@babel/core, babel-loader, etc.)
   - Webpack packages (webpack, webpack-cli, webpack-dev-server, etc.)
   - Rspack packages (@rspack/core, @rspack/cli, rspack-manifest-plugin)
   - Type definitions (@types/webpack, @types/babel__core)
   - Loaders (css-loader, sass-loader, esbuild-loader, swc-loader)
   - Other build tools (compression-webpack-plugin, terser-webpack-plugin, etc.)

2. Marked ALL peer dependencies as optional via `peerDependenciesMeta`
   - This prevents installation warnings when packages are not installed
   - Constraints are only enforced if the user actually installs the dependency

3. Fixed TypeScript imports with `@ts-ignore` comments for optional packages
   - Added comments to webpack and webpack-merge imports
   - Ensures TypeScript doesn't error when optional packages aren't installed

## Testing
- ✅ Tested with npm install - no warnings
- ✅ Tested with yarn install - no warnings  
- ✅ TypeScript builds successfully
- ✅ RSpec tests pass
- ✅ RuboCop passes with no offenses

## Fixes
Resolves #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)