### PR TITLE
chore: Clean up optional peer dependencies follow-up tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,3 +153,38 @@ To ensure that your installer works as expected, either you can run `bundle exec
 3. Run `bundle exec rails shakapacker:install` to confirm that you got the right changes.
 
  **Note:** Ensure that you use bundle exec otherwise the installed shakapacker gem will run and not the one you are working on.
+
+## CI Workflows
+
+Shakapacker uses GitHub Actions for continuous integration. The CI workflows use **Yarn** as the package manager for consistency and reliability.
+
+### Package Manager Choice
+
+The project uses Yarn in CI workflows for the following reasons:
+- Deterministic dependency resolution with `yarn.lock`
+- Faster installation with offline mirror support
+- Better workspace support for monorepo-style testing
+- Consistent behavior across different Node.js versions
+
+### Key CI Workflow Files
+
+- `.github/workflows/test-bundlers.yml` - Tests webpack, rspack, and bundler switching
+- `.github/workflows/tests.yml` - Main test suite across Ruby/Rails/Node versions
+- `.github/workflows/lint.yml` - Linting and code quality checks
+
+All workflows use:
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    cache: 'yarn'
+    cache-dependency-path: spec/dummy/yarn.lock
+```
+
+And install dependencies with:
+```bash
+yarn install
+```
+
+### Testing with Other Package Managers
+
+While CI uses Yarn, the gem supports all major package managers (npm, yarn, pnpm, bun). Generator specs test against all package managers to ensure compatibility.

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -253,6 +253,41 @@ Update your global type definitions as shown in Step 2.
 
 If you see warnings about CSS module exports, ensure you've updated all imports to use named exports or have properly configured the override.
 
+### Unexpected Peer Dependency Warnings After Upgrade
+
+If you experience unexpected peer dependency warnings after upgrading to v9, you may need to clear your package manager's cache and reinstall dependencies. This ensures the new optional peer dependency configuration takes effect properly.
+
+**For npm:**
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+**For Yarn:**
+```bash
+rm -rf node_modules yarn.lock
+yarn install
+```
+
+**For pnpm:**
+```bash
+rm -rf node_modules pnpm-lock.yaml
+pnpm install
+```
+
+**For Bun:**
+```bash
+rm -rf node_modules bun.lockb
+bun install
+```
+
+**When is this necessary?**
+- If you see peer dependency warnings for packages you don't use (e.g., warnings about Babel when using SWC)
+- If your package manager cached the old dependency resolution from v8
+- After switching transpilers or bundlers (e.g., from Babel to SWC, or webpack to rspack)
+
+**Note:** This is typically only needed once after the v8 → v9 upgrade. Subsequent installs will use the correct dependency resolution.
+
 ## Need Help?
 
 - See [CSS Modules Export Mode documentation](./css-modules-export-mode.md) for detailed configuration options

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -211,8 +211,7 @@ module Shakapacker
       def check_webpack_peer_deps(deps)
         essential_webpack = {
           "webpack" => "^5.76.0",
-          "webpack-cli" => "^4.9.2 || ^5.0.0",
-          "webpack-merge" => "^5.8.0 || ^6.0.0"
+          "webpack-cli" => "^4.9.2 || ^5.0.0"
         }
 
         essential_webpack.each do |package, version|

--- a/spec/shakapacker/doctor_optional_peer_spec.rb
+++ b/spec/shakapacker/doctor_optional_peer_spec.rb
@@ -228,15 +228,6 @@ describe "Shakapacker::Doctor with optional peer dependencies" do
         # webpack-merge is now a direct dependency of shakapacker,
         # not a peer dependency, so doctor should not check for it
 
-        # Note: The doctor might still report webpack-merge as missing
-        # if it's checking the old peer dependencies list.
-        # This is expected behavior until the doctor is updated
-        # to recognize webpack-merge as a direct dependency.
-
-        # For now, we'll skip this check since the doctor still
-        # treats webpack-merge as a peer dependency
-        skip "Doctor needs updating to recognize webpack-merge as direct dependency"
-
         doctor.send(:check_peer_dependencies)
         merge_issues = doctor.issues.select { |i| i.include?("webpack-merge") }
         expect(merge_issues).to be_empty


### PR DESCRIPTION
## Summary

This PR addresses follow-up items from PR #615 (optional peer dependencies restoration).

## Changes

### 1. Fixed Doctor Command for webpack-merge
- **Issue**: Doctor was checking for webpack-merge as a peer dependency
- **Fix**: Removed webpack-merge from `check_webpack_peer_deps` method in `lib/shakapacker/doctor.rb`
- **Reason**: webpack-merge is now a direct dependency, not a peer dependency
- **Test**: Removed skip from `spec/shakapacker/doctor_optional_peer_spec.rb:238`

### 2. Documented CI Yarn Migration
- **Added**: New "CI Workflows" section to `CONTRIBUTING.md`
- **Content**: 
  - Explains why CI uses Yarn (deterministic resolution, offline mirror, workspace support)
  - Documents key CI workflow files
  - Shows example GitHub Actions configuration
  - Clarifies that the gem supports all package managers (npm, yarn, pnpm, bun)

### 3. Documented Package Manager Cache Clearing
- **Added**: New troubleshooting section to `docs/v9_upgrade.md`
- **Content**:
  - Commands for clearing cache and reinstalling for all package managers
  - Explanation of when cache clearing is necessary
  - Guidance on peer dependency warnings after upgrade

### 4. Verified @ts-ignore Comments
- **Finding**: No @ts-ignore comments for webpack-merge were found
- **Reason**: webpack-merge is correctly imported as a regular dependency without type suppression
- **Conclusion**: No changes needed for this item

## Testing

- ✅ ESLint passes locally
- ⏳ CI will verify RuboCop (local bundle install still in progress)

## Related

- Follow-up to #615
- Addresses recommendations from PR review