### PR TITLE
docs: Fix incorrect workflow file references in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,8 +169,9 @@ The project uses Yarn in CI workflows for the following reasons:
 ### Key CI Workflow Files
 
 - `.github/workflows/test-bundlers.yml` - Tests webpack, rspack, and bundler switching
-- `.github/workflows/tests.yml` - Main test suite across Ruby/Rails/Node versions
-- `.github/workflows/lint.yml` - Linting and code quality checks
+- `.github/workflows/ruby.yml` - Ruby test suite across Ruby/Rails versions
+- `.github/workflows/node.yml` - Node.js test suite across Node versions
+- `.github/workflows/generator.yml` - Generator installation tests
 
 All workflows use:
 ```yaml


### PR DESCRIPTION
## Summary

Quick fix for incorrect CI workflow file references in the CONTRIBUTING.md documentation.

## Changes

### Corrected Workflow File References

**Before:**
- `.github/workflows/tests.yml` ❌ (doesn't exist)
- `.github/workflows/lint.yml` ❌ (doesn't exist)

**After:**
- `.github/workflows/ruby.yml` ✅ (Ruby test suite)
- `.github/workflows/node.yml` ✅ (Node.js test suite)
- `.github/workflows/generator.yml` ✅ (Generator tests)

All referenced files now actually exist in the repository.

### Trailing Newline

✅ Verified CONTRIBUTING.md has the required trailing newline character per CLAUDE.md requirements.

## Related

- Follow-up to PR #617
- Addresses minor documentation issues flagged in review