### PR TITLE
feat: Complete Phase 4 TypeScript migration - Rules, Plugins, and Optimization

### DIFF
--- a/package/optimization/rspack.ts
+++ b/package/optimization/rspack.ts
@@ -5,13 +5,13 @@ const rspack = requireOrError("@rspack/core")
 
 const getOptimization = () => {
   // Use Rspack's built-in minification instead of terser-webpack-plugin
-  const result = { minimize: true }
+  const result: { minimize: boolean; minimizer?: any[] } = { minimize: true }
   try {
     result.minimizer = [
       new rspack.SwcJsMinimizerRspackPlugin(),
       new rspack.LightningCssMinimizerRspackPlugin()
     ]
-  } catch (error) {
+  } catch (error: any) {
     // Log full error with stack trace
     logError(
       `Failed to configure Rspack minimizers: ${error.message}\n${error.stack}`
@@ -24,6 +24,6 @@ const getOptimization = () => {
   return result
 }
 
-module.exports = {
+export = {
   getOptimization
 }

--- a/package/optimization/webpack.ts
+++ b/package/optimization/webpack.ts
@@ -44,6 +44,6 @@ const getOptimization = () => {
   }
 }
 
-module.exports = {
+export = {
   getOptimization
 }

--- a/package/plugins/rspack.ts
+++ b/package/plugins/rspack.ts
@@ -14,8 +14,8 @@ const getPlugins = () => {
       publicPath: config.publicPathWithoutCDN,
       writeToFileEmit: true,
       // rspack-manifest-plugin uses different option names than webpack-assets-manifest
-      generate: (seed, files, entrypoints) => {
-        const manifest = seed || {}
+      generate: (seed: any, files: any[], entrypoints: Record<string, string[]>) => {
+        const manifest: Record<string, any> = seed || {}
 
         // Add files mapping first
         files.forEach((file) => {
@@ -23,7 +23,7 @@ const getPlugins = () => {
         })
 
         // Add entrypoints information compatible with Shakapacker expectations
-        const entrypointsManifest = {}
+        const entrypointsManifest: Record<string, any> = {}
         Object.entries(entrypoints).forEach(
           ([entrypointName, entrypointFiles]) => {
             const jsFiles = entrypointFiles
@@ -83,6 +83,6 @@ const getPlugins = () => {
   return plugins
 }
 
-module.exports = {
+export = {
   getPlugins
 }

--- a/package/plugins/webpack.ts
+++ b/package/plugins/webpack.ts
@@ -57,6 +57,6 @@ const getPlugins = () => {
   return plugins
 }
 
-module.exports = {
+export = {
   getPlugins
 }

--- a/package/rules/babel.ts
+++ b/package/rules/babel.ts
@@ -3,7 +3,7 @@ const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const { isProduction } = require("../env")
 const jscommon = require("./jscommon")
 
-module.exports = loaderMatches(javascriptTranspiler, "babel", () => ({
+export = loaderMatches(javascriptTranspiler, "babel", () => ({
   test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
   ...jscommon,
   use: [

--- a/package/rules/coffee.ts
+++ b/package/rules/coffee.ts
@@ -1,6 +1,6 @@
 const { canProcess } = require("../utils/helpers")
 
-module.exports = canProcess("coffee-loader", (resolvedPath) => ({
+export = canProcess("coffee-loader", (resolvedPath: string) => ({
   test: /\.coffee(\.erb)?$/,
   use: [{ loader: resolvedPath }]
 }))

--- a/package/rules/css.ts
+++ b/package/rules/css.ts
@@ -1,3 +1,3 @@
 const { getStyleRule } = require("../utils/getStyleRule")
 
-module.exports = getStyleRule(/\.(css)$/i)
+export = getStyleRule(/\.(css)$/i)

--- a/package/rules/erb.ts
+++ b/package/rules/erb.ts
@@ -2,7 +2,7 @@ const { canProcess } = require("../utils/helpers")
 
 const runner = /^win/.test(process.platform) ? "ruby " : ""
 
-module.exports = canProcess("rails-erb-loader", (resolvedPath) => ({
+export = canProcess("rails-erb-loader", (resolvedPath: string) => ({
   test: /\.erb$/,
   enforce: "pre",
   exclude: /node_modules/,

--- a/package/rules/esbuild.ts
+++ b/package/rules/esbuild.ts
@@ -3,8 +3,8 @@ const { getEsbuildLoaderConfig } = require("../esbuild")
 const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const jscommon = require("./jscommon")
 
-module.exports = loaderMatches(javascriptTranspiler, "esbuild", () => ({
+export = loaderMatches(javascriptTranspiler, "esbuild", () => ({
   test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
   ...jscommon,
-  use: ({ resource }) => getEsbuildLoaderConfig(resource)
+  use: ({ resource }: { resource: string }) => getEsbuildLoaderConfig(resource)
 }))

--- a/package/rules/file.ts
+++ b/package/rules/file.ts
@@ -1,21 +1,21 @@
-const { dirname, sep, normalize } = require("path")
+import { dirname, sep, normalize } from "path"
 const {
   additional_paths: additionalPaths,
   source_path: sourcePath
 } = require("../config")
 
-module.exports = {
+export = {
   test: /\.(bmp|gif|jpe?g|png|tiff|ico|avif|webp|eot|otf|ttf|woff|woff2|svg)$/,
   exclude: /\.(js|mjs|jsx|ts|tsx)$/,
   type: "asset/resource",
   generator: {
-    filename: (pathData) => {
+    filename: (pathData: { filename: string }) => {
       const path = normalize(dirname(pathData.filename))
-      const stripPaths = [...additionalPaths, sourcePath].map((p) =>
+      const stripPaths = [...additionalPaths, sourcePath].map((p: string) =>
         normalize(p)
       )
 
-      const selectedStripPath = stripPaths.find((includePath) =>
+      const selectedStripPath = stripPaths.find((includePath: string) =>
         path.startsWith(includePath)
       )
 

--- a/package/rules/jscommon.ts
+++ b/package/rules/jscommon.ts
@@ -1,11 +1,11 @@
-const { resolve } = require("path")
-const { realpathSync } = require("fs")
+import { resolve } from "path"
+import { realpathSync } from "fs"
 const {
   source_path: sourcePath,
   additional_paths: additionalPaths
 } = require("../config")
 
-const inclusions = [sourcePath, ...additionalPaths].map((p) => {
+const inclusions = [sourcePath, ...additionalPaths].map((p: string) => {
   try {
     return realpathSync(p)
   } catch (e) {
@@ -13,7 +13,7 @@ const inclusions = [sourcePath, ...additionalPaths].map((p) => {
   }
 })
 
-module.exports = {
+export = {
   include: inclusions,
   exclude: [
     {

--- a/package/rules/less.ts
+++ b/package/rules/less.ts
@@ -1,4 +1,4 @@
-const path = require("path")
+import { resolve } from "path"
 const { canProcess } = require("../utils/helpers")
 const { getStyleRule } = require("../utils/getStyleRule")
 
@@ -7,13 +7,13 @@ const {
   source_path: sourcePath
 } = require("../config")
 
-module.exports = canProcess("less-loader", (resolvedPath) =>
+export = canProcess("less-loader", (resolvedPath: string) =>
   getStyleRule(/\.(less)(\.erb)?$/i, [
     {
       loader: resolvedPath,
       options: {
         lessOptions: {
-          paths: [path.resolve(__dirname, "node_modules"), sourcePath, ...paths]
+          paths: [resolve(__dirname, "node_modules"), sourcePath, ...paths]
         },
         sourceMap: true
       }

--- a/package/rules/raw.ts
+++ b/package/rules/raw.ts
@@ -11,5 +11,5 @@ const webpackRawConfig = () => ({
   type: "asset/source"
 })
 
-module.exports =
+export =
   config.assets_bundler === "rspack" ? rspackRawConfig() : webpackRawConfig()

--- a/package/rules/rspack.ts
+++ b/package/rules/rspack.ts
@@ -163,4 +163,4 @@ if (raw) {
 }
 
 debug(`Rspack rules configuration complete. Total rules: ${rules.length}`)
-module.exports = rules
+export = rules

--- a/package/rules/sass.ts
+++ b/package/rules/sass.ts
@@ -4,7 +4,7 @@ const { getStyleRule } = require("../utils/getStyleRule")
 const { canProcess, packageMajorVersion } = require("../utils/helpers")
 const { additional_paths: extraPaths } = require("../config")
 
-module.exports = canProcess("sass-loader", (resolvedPath) => {
+export = canProcess("sass-loader", (resolvedPath: string) => {
   const optionKey =
     packageMajorVersion("sass-loader") > 15 ? "loadPaths" : "includePaths"
   return getStyleRule(/\.(scss|sass)(\.erb)?$/i, [

--- a/package/rules/stylus.ts
+++ b/package/rules/stylus.ts
@@ -1,4 +1,4 @@
-const path = require("path")
+import { resolve } from "path"
 const { canProcess } = require("../utils/helpers")
 const { getStyleRule } = require("../utils/getStyleRule")
 
@@ -7,14 +7,14 @@ const {
   source_path: sourcePath
 } = require("../config")
 
-module.exports = canProcess("stylus-loader", (resolvedPath) =>
+export = canProcess("stylus-loader", (resolvedPath: string) =>
   getStyleRule(/\.(styl(us)?)(\.erb)?$/i, [
     {
       loader: resolvedPath,
       options: {
         stylusOptions: {
           include: [
-            path.resolve(__dirname, "node_modules"),
+            resolve(__dirname, "node_modules"),
             sourcePath,
             ...paths
           ]

--- a/package/rules/swc.ts
+++ b/package/rules/swc.ts
@@ -3,8 +3,8 @@ const { getSwcLoaderConfig } = require("../swc")
 const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const jscommon = require("./jscommon")
 
-module.exports = loaderMatches(javascriptTranspiler, "swc", () => ({
+export = loaderMatches(javascriptTranspiler, "swc", () => ({
   test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
   ...jscommon,
-  use: ({ resource }) => getSwcLoaderConfig(resource)
+  use: ({ resource }: { resource: string }) => getSwcLoaderConfig(resource)
 }))

--- a/package/rules/webpack.ts
+++ b/package/rules/webpack.ts
@@ -1,7 +1,7 @@
 /* eslint global-require: 0 */
 /* eslint import/no-dynamic-require: 0 */
 
-module.exports = [
+export = [
   require("./raw"),
   require("./file"),
   require("./css"),


### PR DESCRIPTION
## Summary
This PR completes **Phase 4** of the TypeScript migration by converting all loader rules, plugin configurations, and optimization settings to TypeScript.

### What was converted:
- ✅ All 14 files in `package/rules/` (babel, coffee, css, erb, esbuild, file, jscommon, less, raw, rspack, sass, stylus, swc, webpack)
- ✅ Both files in `package/plugins/` (webpack, rspack)
- ✅ Both files in `package/optimization/` (webpack, rspack)

### Changes made:
- Added proper TypeScript type annotations for loader configurations
- Added type safety for plugin options and optimization settings
- Converted all `module.exports` to `export =` for TypeScript compatibility
- Added type annotations for function parameters (e.g., `resolvedPath: string`, `resource: string`)
- Maintained full backward compatibility with existing bundler configurations

### Testing
- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ All files properly typed
- ✅ Git recognizes changes as renames (preserving history)

### Migration Progress
This completes Phase 4 of the TypeScript migration roadmap (see TODO.md).

**Next steps:** Phase 5 will convert framework-specific modules (rspack, swc, esbuild support files, babel preset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)