### PR TITLE
Revert Claude model specification in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,5 +50,5 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--model claude-sonnet-4-5-20250929 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Summary
- Removes the explicit `--model claude-sonnet-4-5-20250929` flag from the Claude Code review workflow
- Allows the workflow to use the default Claude model instead of pinning to a specific version

## Rationale
This reverts the change made in #616 to use the default model configuration for Claude Code reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)