### PR TITLE
chore: Add Husky pre-commit hook for lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged


### PR DESCRIPTION
## Summary
- Add Husky pre-commit hook configuration
- Configure hook to run lint-staged before each commit
- Ensures code quality checks run automatically

## Details
This PR adds a Husky pre-commit hook that runs lint-staged to automatically check code quality before commits are made. The hook file has been force-added since .husky is in the global gitignore.

Note: There is a deprecation warning from Husky v9 about the shebang format which will need to be updated for v10.

## Test plan
- [x] Pre-commit hook created at .husky/pre-commit
- [x] Hook is executable
- [x] Commit successfully triggered the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)