### PR TITLE
docs: Clean up v9 documentation for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,9 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
        ```
 
 2. **CSS Modules now use named exports by default**
-   - Configured with `namedExport: true` and `exportLocalsConvention: 'camelCaseOnly'`
    - **JavaScript:** Use named imports: `import { className } from './styles.module.css'`
    - **TypeScript:** Use namespace imports: `import * as styles from './styles.module.css'`
-   - Default imports (`import styles from '...'`) no longer work
-   - **Note:** css-loader requires `'camelCaseOnly'` or `'dashesOnly'` when `namedExport: true`. Using `'camelCase'` causes a build error.
-   - See [CSS Modules Export Mode documentation](./docs/css-modules-export-mode.md) for migration details
+   - To keep the old behavior with default imports, see [CSS Modules Export Mode documentation](./docs/css-modules-export-mode.md) for configuration instructions
 
 3. **Configuration option renamed from `webpack_loader` to `javascript_transpiler`**
    - Better reflects its purpose of configuring JavaScript transpilation
@@ -64,7 +61,9 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   - Faster Rust-based bundling with webpack-compatible APIs
   - Built-in SWC loader and CSS extraction
   - Automatic bundler detection in `bin/shakapacker`
-- **TypeScript type definitions** for improved IDE support and autocomplete. Types available via `import type { WebpackConfig, RspackConfig, EnvironmentConfig } from "shakapacker/types"`
+- **TypeScript type definitions** for improved IDE support and autocomplete
+  - Types available via `import type { WebpackConfig, RspackConfig, EnvironmentConfig } from "shakapacker/types"`
+  - See [TypeScript Documentation](./docs/typescript.md) for migration and usage instructions
 - **Optional peer dependencies** - All peer dependencies now marked as optional, preventing installation warnings while maintaining version compatibility tracking
 - **Private output path** for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592))
   - Configure `private_output_path` for private server bundles separate from public assets
@@ -85,27 +84,6 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 ### Fixed
 - Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604))
 - Updated webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585))
-
-## [v9.0.0-beta.7] - October 1, 2025
-
-### Added
-- TypeScript type definitions for improved IDE support
-- Optional peer dependencies to prevent installation warnings
-- Migration tooling improvements
-
-### Security
-- Path validation utilities
-
-### Performance
-- Validation caching improvements
-
-## [v9.0.0-beta.4] - September 15, 2025
-
-### Added
-- Rspack support as an alternative assets bundler to webpack
-- Private output path for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592))
-- Enhanced TypeScript definitions ([PR 602](https://github.com/shakacode/shakapacker/pull/602))
-- `rake shakapacker:doctor` diagnostic command ([PR 609](https://github.com/shakacode/shakapacker/pull/609))
 
 ## [v8.4.0] - September 8, 2024
 
@@ -528,9 +506,7 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
 [Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.8...main
-[v9.0.0-beta.8]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.7...v9.0.0-beta.8
-[v9.0.0-beta.7]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.4...v9.0.0-beta.7
-[v9.0.0-beta.4]: https://github.com/shakacode/shakapacker/compare/v8.4.0...v9.0.0-beta.4
+[v9.0.0-beta.8]: https://github.com/shakacode/shakapacker/compare/v8.4.0...v9.0.0-beta.8
 [v8.4.0]: https://github.com/shakacode/shakapacker/compare/v8.3.0...v8.4.0
 [v8.3.0]: https://github.com/shakacode/shakapacker/compare/v8.2.0...v8.3.0
 [v8.2.0]: https://github.com/shakacode/shakapacker/compare/v8.1.0...v8.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changes since the last non-beta release.
   - Verified strict mode is enabled in TypeScript configuration
   - Enhanced developer experience with TypeScript linting across the entire codebase
 
-## [v9.0.0-beta.7] - October 1, 2025
+## [v9.0.0-beta.8] - October 3, 2025
 
 See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/docs/v9_upgrade.md) for detailed migration instructions.
 
@@ -88,9 +88,24 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604))
 - Updated webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585))
 
+## [v9.0.0-beta.7] - October 1, 2025
+
+**Note:** See [v9.0.0-beta.8](#v900-beta8---october-3-2025) for the latest beta with additional improvements.
+
+### Added
+- TypeScript type definitions for improved IDE support
+- Optional peer dependencies to prevent installation warnings
+- Migration tooling improvements
+
+### Security
+- Path validation utilities
+
+### Performance
+- Validation caching improvements
+
 ## [v9.0.0-beta.4] - September 15, 2025
 
-**Note:** This beta release introduced breaking changes and major features. See [v9.0.0-beta.7](#v900-beta7---october-1-2025) for the complete, consolidated changelog.
+**Note:** This beta release introduced breaking changes and major features. See [v9.0.0-beta.8](#v900-beta8---october-3-2025) for the complete, consolidated changelog.
 
 ### Added
 - Rspack support as an alternative assets bundler to webpack
@@ -518,7 +533,9 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 ## v5.4.3 and prior changes from rails/webpacker
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.4...main
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.8...main
+[v9.0.0-beta.8]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.7...v9.0.0-beta.8
+[v9.0.0-beta.7]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.4...v9.0.0-beta.7
 [v9.0.0-beta.4]: https://github.com/shakacode/shakapacker/compare/v8.4.0...v9.0.0-beta.4
 [v8.4.0]: https://github.com/shakacode/shakapacker/compare/v8.3.0...v8.4.0
 [v8.3.0]: https://github.com/shakacode/shakapacker/compare/v8.2.0...v8.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,6 @@
 ## [Unreleased]
 Changes since the last non-beta release.
 
-### Added
-- **Phase 5 TypeScript Migration - Framework-Specific Modules** by [justin808](https://github.com/justin808)
-  - Converted framework-specific modules to TypeScript
-  - Migrated package/rspack/index.js to TypeScript
-  - Migrated package/swc/index.js to TypeScript
-  - Migrated package/esbuild/index.js to TypeScript
-  - Migrated package/babel/preset.js to TypeScript
-  - Added @types/babel__core for enhanced type safety
-  - All 130 tests passing
-- **Phase 6 TypeScript Migration - Final Cleanup** (by [justin808](https://github.com/justin808))
-  - Added TypeScript ESLint support with @typescript-eslint/parser and @typescript-eslint/eslint-plugin
-  - Configured TypeScript-specific linting rules for improved code quality
-  - Verified strict mode is enabled in TypeScript configuration
-  - Enhanced developer experience with TypeScript linting across the entire codebase
-
 ## [v9.0.0-beta.8] - October 3, 2025
 
 See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/docs/v9_upgrade.md) for detailed migration instructions.
@@ -77,9 +62,6 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   - Enforced strict port validation (reject strings with non-digits)
   - Added SHAKAPACKER_NPM_PACKAGE path validation (only .tgz/.tar.gz allowed)
   - Path traversal security checks now run regardless of validation mode
-
-### Changed
-- Configuration option renamed from `bundler` to `assets_bundler` (old option deprecated but still supported)
 
 ### Fixed
 - Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
    - Babel dependencies are no longer included as peer dependencies
    - Improves compilation speed by 20x
    - **Migration for existing projects:**
-     - **Option 1 (Recommended):** Switch to SWC:
+     - **Option 1 (Recommended):** Switch to SWC - Run `rake shakapacker:migrate:to_swc` or manually:
        ```yaml
        # config/shakapacker.yml
        javascript_transpiler: 'swc'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,6 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 
 ### ⚠️ Breaking Changes
 
-**Note:** These breaking changes were introduced in beta.4 and remain in effect.
-
 1. **SWC is now the default JavaScript transpiler instead of Babel** ([PR 603](https://github.com/shakacode/shakapacker/pull/603) by [justin808](https://github.com/justin808))
    - Babel dependencies are no longer included as peer dependencies
    - Improves compilation speed by 20x
@@ -90,8 +88,6 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 
 ## [v9.0.0-beta.7] - October 1, 2025
 
-**Note:** See [v9.0.0-beta.8](#v900-beta8---october-3-2025) for the latest beta with additional improvements.
-
 ### Added
 - TypeScript type definitions for improved IDE support
 - Optional peer dependencies to prevent installation warnings
@@ -104,8 +100,6 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - Validation caching improvements
 
 ## [v9.0.0-beta.4] - September 15, 2025
-
-**Note:** This beta release introduced breaking changes and major features. See [v9.0.0-beta.8](#v900-beta8---october-3-2025) for the complete, consolidated changelog.
 
 ### Added
 - Rspack support as an alternative assets bundler to webpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,55 +26,11 @@ Changes since the last non-beta release.
 
 ## [v9.0.0-beta.7] - October 1, 2025
 
-### Added
-- **Phase 2 TypeScript Migration - Core Modules** ([PR 608](https://github.com/shakacode/shakapacker/pull/608) by [justin808](https://github.com/justin808))
-  - Converted core modules to TypeScript: config.ts, env.ts, and utilities
-  - Enhanced type safety across the codebase
-  - Better IDE support and autocomplete
-- **Phase 3 TypeScript Migration - Environment Files** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Converted all environment configuration files to TypeScript (development, production, test)
-  - Added centralized type exports for consumer use (import from "shakapacker/types")
-  - Created shared TypeScript interfaces for environment configurations
-  - Introduced structured error codes for programmatic error handling
-  - Exported shared types: WebpackConfig, RspackConfig, EnvironmentConfig
-- **Optional Peer Dependencies** ([PR 615](https://github.com/shakacode/shakapacker/pull/615) by [justin808](https://github.com/justin808))
-  - Restored peer dependencies as optional to improve package version tracking
-  - Added peerDependenciesMeta marking all peers as optional
-  - Moved webpack-merge to direct dependencies (required at runtime)
-  - Prevents installation warnings while maintaining upgrade visibility
-- **Migration Tooling Improvements** ([PR 613](https://github.com/shakacode/shakapacker/pull/613) by [justin808](https://github.com/justin808))
-  - Added SWC migration helper: rake shakapacker:migrate:to_swc
-  - Enhanced error messages for missing dependencies
-  - Improved doctor command output
-
-### Security
-- **Path Validation Utilities** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Added validation to prevent directory traversal attacks
-  - Implemented environment variable sanitization to prevent injection
-  - Enforced strict port validation (reject strings with non-digits)
-  - Added SHAKAPACKER_NPM_PACKAGE path validation (only .tgz/.tar.gz allowed)
-  - Path traversal security checks now run regardless of validation mode
-
-### Changed
-- **Build Process Improvements** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Environment JS files now generated during npm publish (not committed to git)
-  - Prevents TypeScript source and compiled JS from getting out of sync
-  - Auto-format compiled JavaScript during build process
-  - Enhanced .npmignore to exclude TypeScript sources, include compiled JS
-
-### Performance
-- **Validation Caching** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Implemented TTL-based validation caching (5s watch, 1min dev, infinite prod)
-  - Made cache TTL configurable via SHAKAPACKER_CACHE_TTL environment variable
-  - Lazy-loaded and cached watch mode detection
-
-### Fixed
-- Fixed clearValidationCache() to actually clear the cache ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-- Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604) by [justin808](https://github.com/justin808))
-
-## [v9.0.0-beta.4] - September 15, 2025
+See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/docs/v9_upgrade.md) for detailed migration instructions.
 
 ### ⚠️ Breaking Changes
+
+**Note:** These breaking changes were introduced in beta.4 and remain in effect.
 
 1. **SWC is now the default JavaScript transpiler instead of Babel** ([PR 603](https://github.com/shakacode/shakapacker/pull/603) by [justin808](https://github.com/justin808))
    - Babel dependencies are no longer included as peer dependencies
@@ -110,23 +66,75 @@ Changes since the last non-beta release.
   - Faster Rust-based bundling with webpack-compatible APIs
   - Built-in SWC loader and CSS extraction
   - Automatic bundler detection in `bin/shakapacker`
+- **TypeScript Support** ([PR 608](https://github.com/shakacode/shakapacker/pull/608), [PR 614](https://github.com/shakacode/shakapacker/pull/614), [PR 602](https://github.com/shakacode/shakapacker/pull/602) by [justin808](https://github.com/justin808))
+  - Converted core modules to TypeScript: config.ts, env.ts, and utilities
+  - Converted all environment configuration files to TypeScript (development, production, test)
+  - Added centralized type exports for consumer use (import from "shakapacker/types")
+  - Created shared TypeScript interfaces for environment configurations
+  - Introduced structured error codes for programmatic error handling
+  - Exported shared types: WebpackConfig, RspackConfig, EnvironmentConfig
+  - Enhanced type safety across the codebase
+  - Better IDE support and autocomplete
+- **Optional Peer Dependencies** ([PR 615](https://github.com/shakacode/shakapacker/pull/615) by [justin808](https://github.com/justin808))
+  - Restored peer dependencies as optional to improve package version tracking
+  - Added peerDependenciesMeta marking all peers as optional
+  - Moved webpack-merge to direct dependencies (required at runtime)
+  - Prevents installation warnings while maintaining upgrade visibility
 - **Private output path** for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592) by [justin808](https://github.com/justin808))
   - Configure `private_output_path` for private server bundles
-- **Enhanced TypeScript definitions** ([PR 602](https://github.com/shakacode/shakapacker/pull/602) by [justin808](https://github.com/justin808))
-  - Better IDE support and type safety
 - **`rake shakapacker:doctor` diagnostic command** ([PR 609](https://github.com/shakacode/shakapacker/pull/609) by [justin808](https://github.com/justin808))
   - Check for configuration issues and missing dependencies
   - Identify missing loaders that cause build errors
   - Particularly useful when migrating to v9 where peer dependencies are removed
   - Detects transpiler-specific issues based on v9 changes
+- **Migration Tooling Improvements** ([PR 613](https://github.com/shakacode/shakapacker/pull/613) by [justin808](https://github.com/justin808))
+  - Added SWC migration helper: rake shakapacker:migrate:to_swc
+  - Enhanced error messages for missing dependencies
+  - Improved doctor command output
+
+### Security
+- **Path Validation Utilities** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
+  - Added validation to prevent directory traversal attacks
+  - Implemented environment variable sanitization to prevent injection
+  - Enforced strict port validation (reject strings with non-digits)
+  - Added SHAKAPACKER_NPM_PACKAGE path validation (only .tgz/.tar.gz allowed)
+  - Path traversal security checks now run regardless of validation mode
 
 ### Changed
 - Configuration option renamed from `bundler` to `assets_bundler` (deprecated but supported)
 - **Babel dependencies are now optional** instead of peer dependencies ([PR 603](https://github.com/shakacode/shakapacker/pull/603) by [justin808](https://github.com/justin808))
   - Installed automatically only when `javascript_transpiler` is set to 'babel'
+- **Build Process Improvements** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
+  - Environment JS files now generated during npm publish (not committed to git)
+  - Prevents TypeScript source and compiled JS from getting out of sync
+  - Auto-format compiled JavaScript during build process
+  - Enhanced .npmignore to exclude TypeScript sources, include compiled JS
+
+### Performance
+- **Validation Caching** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
+  - Implemented TTL-based validation caching (5s watch, 1min dev, infinite prod)
+  - Made cache TTL configurable via SHAKAPACKER_CACHE_TTL environment variable
+  - Lazy-loaded and cached watch mode detection
 
 ### Fixed
+- Fixed clearValidationCache() to actually clear the cache ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
+- Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604) by [justin808](https://github.com/justin808))
 - Update webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585) by [justin808](https://github.com/justin808))
+
+## [v9.0.0-beta.4] - September 15, 2025
+
+**Note:** This beta release introduced breaking changes and major features. See [v9.0.0-beta.7](#v900-beta7---october-1-2025) for the complete, consolidated changelog.
+
+### ⚠️ Breaking Changes
+- SWC is now the default JavaScript transpiler instead of Babel ([PR 603](https://github.com/shakacode/shakapacker/pull/603))
+- CSS Modules now use named exports by default
+- Configuration option renamed from `webpack_loader` to `javascript_transpiler`
+
+### Added
+- Rspack support as an alternative assets bundler to webpack
+- Private output path for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592))
+- Enhanced TypeScript definitions ([PR 602](https://github.com/shakacode/shakapacker/pull/602))
+- `rake shakapacker:doctor` diagnostic command ([PR 609](https://github.com/shakacode/shakapacker/pull/609))
 
 ## [v8.4.0] - September 8, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,31 +66,12 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   - Faster Rust-based bundling with webpack-compatible APIs
   - Built-in SWC loader and CSS extraction
   - Automatic bundler detection in `bin/shakapacker`
-- **TypeScript Support** ([PR 608](https://github.com/shakacode/shakapacker/pull/608), [PR 614](https://github.com/shakacode/shakapacker/pull/614), [PR 602](https://github.com/shakacode/shakapacker/pull/602) by [justin808](https://github.com/justin808))
-  - Converted core modules to TypeScript: config.ts, env.ts, and utilities
-  - Converted all environment configuration files to TypeScript (development, production, test)
-  - Added centralized type exports for consumer use (import from "shakapacker/types")
-  - Created shared TypeScript interfaces for environment configurations
-  - Introduced structured error codes for programmatic error handling
-  - Exported shared types: WebpackConfig, RspackConfig, EnvironmentConfig
-  - Enhanced type safety across the codebase
-  - Better IDE support and autocomplete
-- **Optional Peer Dependencies** ([PR 615](https://github.com/shakacode/shakapacker/pull/615) by [justin808](https://github.com/justin808))
-  - Restored peer dependencies as optional to improve package version tracking
-  - Added peerDependenciesMeta marking all peers as optional
-  - Moved webpack-merge to direct dependencies (required at runtime)
-  - Prevents installation warnings while maintaining upgrade visibility
-- **Private output path** for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592) by [justin808](https://github.com/justin808))
-  - Configure `private_output_path` for private server bundles
-- **`rake shakapacker:doctor` diagnostic command** ([PR 609](https://github.com/shakacode/shakapacker/pull/609) by [justin808](https://github.com/justin808))
-  - Check for configuration issues and missing dependencies
-  - Identify missing loaders that cause build errors
-  - Particularly useful when migrating to v9 where peer dependencies are removed
-  - Detects transpiler-specific issues based on v9 changes
-- **Migration Tooling Improvements** ([PR 613](https://github.com/shakacode/shakapacker/pull/613) by [justin808](https://github.com/justin808))
-  - Added SWC migration helper: rake shakapacker:migrate:to_swc
-  - Enhanced error messages for missing dependencies
-  - Improved doctor command output
+- **TypeScript type definitions** for improved IDE support and autocomplete. Types available via `import type { WebpackConfig, RspackConfig, EnvironmentConfig } from "shakapacker/types"`
+- **Optional peer dependencies** - All peer dependencies now marked as optional, preventing installation warnings while maintaining version compatibility tracking
+- **Private output path** for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592))
+  - Configure `private_output_path` for private server bundles separate from public assets
+- **`rake shakapacker:doctor` diagnostic command** to check for configuration issues and missing dependencies
+- **`rake shakapacker:migrate:to_swc`** migration helper to assist with switching from Babel to SWC
 
 ### Security
 - **Path Validation Utilities** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
@@ -101,34 +82,15 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   - Path traversal security checks now run regardless of validation mode
 
 ### Changed
-- Configuration option renamed from `bundler` to `assets_bundler` (deprecated but supported)
-- **Babel dependencies are now optional** instead of peer dependencies ([PR 603](https://github.com/shakacode/shakapacker/pull/603) by [justin808](https://github.com/justin808))
-  - Installed automatically only when `javascript_transpiler` is set to 'babel'
-- **Build Process Improvements** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Environment JS files now generated during npm publish (not committed to git)
-  - Prevents TypeScript source and compiled JS from getting out of sync
-  - Auto-format compiled JavaScript during build process
-  - Enhanced .npmignore to exclude TypeScript sources, include compiled JS
-
-### Performance
-- **Validation Caching** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-  - Implemented TTL-based validation caching (5s watch, 1min dev, infinite prod)
-  - Made cache TTL configurable via SHAKAPACKER_CACHE_TTL environment variable
-  - Lazy-loaded and cached watch mode detection
+- Configuration option renamed from `bundler` to `assets_bundler` (old option deprecated but still supported)
 
 ### Fixed
-- Fixed clearValidationCache() to actually clear the cache ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
-- Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604) by [justin808](https://github.com/justin808))
-- Update webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585) by [justin808](https://github.com/justin808))
+- Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604))
+- Updated webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585))
 
 ## [v9.0.0-beta.4] - September 15, 2025
 
 **Note:** This beta release introduced breaking changes and major features. See [v9.0.0-beta.7](#v900-beta7---october-1-2025) for the complete, consolidated changelog.
-
-### ⚠️ Breaking Changes
-- SWC is now the default JavaScript transpiler instead of Babel ([PR 603](https://github.com/shakacode/shakapacker/pull/603))
-- CSS Modules now use named exports by default
-- Configuration option renamed from `webpack_loader` to `javascript_transpiler`
 
 ### Added
 - Rspack support as an alternative assets bundler to webpack

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Shakapacker (v8)
+# Shakapacker (v9)
 ---
 
-_🚀 Shakapacker 9.0.0.beta.2 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
+_🚀 Shakapacker 9.0.0-beta.7 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shakapacker (v9)
 ---
 
-_🚀 Shakapacker 9.0.0-beta.7 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
+_🚀 Shakapacker 9 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ _🚀 Shakapacker 9.0.0-beta.7 supports [Rspack](https://rspack.rs/)! 10x faster
 _Official, actively maintained successor to [rails/webpacker](https://github.com/rails/webpacker). ShakaCode stands behind the long-term maintenance and development of this project for the Rails community._
 
 * ⚠️ See the [6-stable](https://github.com/shakacode/shakapacker/tree/6-stable) branch for Shakapacker v6.x code and documentation. :warning:
+* **See [V9 Upgrade](./docs/v9_upgrade.md) for upgrading from the v8 release.**
 * See [V8 Upgrade](./docs/v8_upgrade.md) for upgrading from the v7 release.
 * See [V7 Upgrade](./docs/v7_upgrade.md) for upgrading from the v6 release.
 * See [V6 Upgrade](./docs/v6_upgrade.md) for upgrading from v5 or prior v6 releases.


### PR DESCRIPTION
## Summary
- Updates README to reflect v9 status and adds V9 Upgrade Guide link
- Cleans up CHANGELOG.md for v9.0.0-beta.8 release:
  - Removes internal implementation details
  - Removes duplicate beta.7 and beta.4 sections
  - Adds clear migration guidance for SWC, CSS Modules, and TypeScript
  - Mentions rake task for SWC migration
  - Provides configuration options to maintain old CSS Modules behavior

## Changes
- README.md: Updated header to "Shakapacker (v9)" and added V9 Upgrade Guide link
- CHANGELOG.md: Comprehensive cleanup focusing on user-facing changes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG to consolidate Unreleased items and link to the v9 Upgrade Guide.
  * Documented v9.0.0-beta.8 highlights: exposed TypeScript types, optional peer dependencies, doctor command enhancements, migration helper to_swc, and guidance on private_output_path.
  * Revised messaging: SWC as default, CSS Modules guidance, and configuration option renames; refreshed upgrade/compare links.
  * Added note on security-related Path Validation Utilities.
  * Updated README to Shakapacker v9, refreshed beta/version note, and added link to V9 Upgrade instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->