### PR TITLE
Fix NODE_ENV defaulting to production breaking dev server (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,7 @@ Changes since the last non-beta release.
 
 ### Fixed
 
-- Fixed NODE_ENV defaulting to production breaking dev server ([Issue 631](https://github.com/shakacode/shakapacker/issues/631))
-  - NODE_ENV now defaults to development unless RAILS_ENV is explicitly set to production
-  - Ensures dev server works out of the box without requiring NODE_ENV to be set
-  - Fixes incorrect port (8080 instead of configured port) and 404 asset errors
+- Fixed NODE_ENV defaulting to production breaking dev server ([Issue 631](https://github.com/shakacode/shakapacker/issues/631)). NODE_ENV now defaults to development unless RAILS_ENV is explicitly set to production. This ensures the dev server works out of the box without requiring NODE_ENV to be set, and fixes incorrect port and 404 asset errors.
 
 ## [v9.0.0-beta.8] - October 3, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
-* For the changelog of versions prior to v6, see the [5.x stable branch of rails/webpacker](https://github.com/rails/webpacker/tree/5-x-stable).
-* **Please see the [v9 Upgrade Guide](./docs/v9_upgrade.md) for upgrading to version 9 and accounting for breaking changes.**
-* Please see the [v8 Upgrade Guide](./docs/v8_upgrade.md) for upgrading to version 8 and accounting for breaking changes.
-* Please see the [v7 Upgrade Guide](./docs/v7_upgrade.md) for upgrading to new spelling in version 7.
-* Please see the [v6 Upgrade Guide](./docs/v6_upgrade.md) to go from versions prior to v6.
-* [ShakaCode](https://www.shakacode.com) offers support for upgrading from Webpacker or using Shakapacker. If interested, contact Justin Gordon, [justin@shakacode.com](mailto:justin@shakacode.com).
+- For the changelog of versions prior to v6, see the [5.x stable branch of rails/webpacker](https://github.com/rails/webpacker/tree/5-x-stable).
+- **Please see the [v9 Upgrade Guide](./docs/v9_upgrade.md) for upgrading to version 9 and accounting for breaking changes.**
+- Please see the [v8 Upgrade Guide](./docs/v8_upgrade.md) for upgrading to version 8 and accounting for breaking changes.
+- Please see the [v7 Upgrade Guide](./docs/v7_upgrade.md) for upgrading to new spelling in version 7.
+- Please see the [v6 Upgrade Guide](./docs/v6_upgrade.md) to go from versions prior to v6.
+- [ShakaCode](https://www.shakacode.com) offers support for upgrading from Webpacker or using Shakapacker. If interested, contact Justin Gordon, [justin@shakacode.com](mailto:justin@shakacode.com).
 
 # Versions
+
 ## [Unreleased]
+
 Changes since the last non-beta release.
+
+### Fixed
+
+- Fixed NODE_ENV defaulting to production breaking dev server ([Issue 631](https://github.com/shakacode/shakapacker/issues/631))
+  - NODE_ENV now defaults to development unless RAILS_ENV is explicitly set to production
+  - Ensures dev server works out of the box without requiring NODE_ENV to be set
+  - Fixes incorrect port (8080 instead of configured port) and 404 asset errors
 
 ## [v9.0.0-beta.8] - October 3, 2025
 
@@ -16,22 +25,24 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 ### ⚠️ Breaking Changes
 
 1. **SWC is now the default JavaScript transpiler instead of Babel** ([PR 603](https://github.com/shakacode/shakapacker/pull/603) by [justin808](https://github.com/justin808))
+
    - Babel dependencies are no longer included as peer dependencies
    - Improves compilation speed by 20x
    - **Migration for existing projects:**
      - **Option 1 (Recommended):** Switch to SWC - Run `rake shakapacker:migrate:to_swc` or manually:
        ```yaml
        # config/shakapacker.yml
-       javascript_transpiler: 'swc'
+       javascript_transpiler: "swc"
        ```
        Then install: `npm install @swc/core swc-loader`
      - **Option 2:** Keep using Babel:
        ```yaml
        # config/shakapacker.yml
-       javascript_transpiler: 'babel'
+       javascript_transpiler: "babel"
        ```
 
 2. **CSS Modules now use named exports by default**
+
    - **JavaScript:** Use named imports: `import { className } from './styles.module.css'`
    - **TypeScript:** Use namespace imports: `import * as styles from './styles.module.css'`
    - To keep the old behavior with default imports, see [CSS Modules Export Mode documentation](./docs/css-modules-export-mode.md) for configuration instructions
@@ -41,6 +52,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
    - Old `webpack_loader` option deprecated but still supported with warning
 
 ### Added
+
 - **Rspack support** as an alternative assets bundler to webpack
   - Configure `assets_bundler: 'rspack'` in `shakapacker.yml`
   - Faster Rust-based bundling with webpack-compatible APIs
@@ -56,6 +68,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - **`rake shakapacker:migrate:to_swc`** migration helper to assist with switching from Babel to SWC
 
 ### Security
+
 - **Path Validation Utilities** ([PR 614](https://github.com/shakacode/shakapacker/pull/614) by [justin808](https://github.com/justin808))
   - Added validation to prevent directory traversal attacks
   - Implemented environment variable sanitization to prevent injection
@@ -64,19 +77,22 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   - Path traversal security checks now run regardless of validation mode
 
 ### Fixed
+
 - Fixed private_output_path configuration edge cases ([PR 604](https://github.com/shakacode/shakapacker/pull/604))
 - Updated webpack-dev-server to secure versions (^4.15.2 || ^5.2.2) ([PR 585](https://github.com/shakacode/shakapacker/pull/585))
 
 ## [v8.4.0] - September 8, 2024
 
 ### Added
+
 - Support for subresource integrity. [PR 570](https://github.com/shakacode/shakapacker/pull/570) by [panagiotisplytas](https://github.com/panagiotisplytas).
 
 ### Fixed
+
 - Install the latest major version of peer dependencies [PR 576](https://github.com/shakacode/shakapacker/pull/576) by [G-Rath](https://github.com/g-rath).
 
-
 ## [v8.3.0] - April 28, 2024
+
 ### Added
 
 - Allow `webpack-assets-manifest` v6. [PR 562](https://github.com/shakacode/shakapacker/pull/562) by [tagliala](https://github.com/tagliala), [shoeyn](https://github.com/shoeyn).
@@ -91,6 +107,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - More precise types for `devServer` and `rules` in the configuration. [PR 555](https://github.com/shakacode/shakapacker/pull/555) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
 
 ## [v8.2.0] - March 12, 2025
+
 ### Added
 
 - Support for `async` attribute in `javascript_pack_tag`, `append_javascript_pack_tag`, and `prepend_javascript_pack_tag`. [PR 554](https://github.com/shakacode/shakapacker/pull/554) by [AbanoubGhadban](https://github.com/abanoubghadban).
@@ -103,21 +120,25 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - Allow `webpack-cli` v6. [PR 533](https://github.com/shakacode/shakapacker/pull/533) by [tagliala](https://github.com/tagliala).
 
 ### Changed
+
 - Changed internal `require`s to `require_relative` to make code less dependent on the load path. [PR 516](https://github.com/shakacode/shakapacker/pull/516) by [tagliala](https://github.com/tagliala).
 - Allow configuring webpack from a Typescript file (`config/webpack/webpack.config.ts`). [PR 524](https://github.com/shakacode/shakapacker/pull/524) by [jdelStrother](https://github.com/jdelStrother).
 
 ### Fixed
+
 - Fix error when rails environment is required from outside the rails root directory [PR 520](https://github.com/shakacode/shakapacker/pull/520)
 
 ## [v8.0.2] - August 28, 2024
 
 ### Fixed
+
 - Fix wrong instruction in esbuild loader documentation [PR 504](https://github.com/shakacode/shakapacker/pull/504) by [adriangohjw](https://github.com/adriangohjw).
 - Add logic to sass rule conditional on sass-loader version [PR 508](https://github.com/shakacode/shakapacker/pull/508) by [Judahmeek](https://github.com/Judahmeek).
 
 ## [v8.0.1] - July 10, 2024
 
 ### Changed
+
 - Update outdated GitHub Actions to use Node.js 20.0 versions instead [PR 497](https://github.com/shakacode/shakapacker/pull/497) by [adriangohjw](https://github.com/adriangohjw).
 - Allow `webpack-merge` v6 to be used [PR 502](https://github.com/shakacode/shakapacker/pull/502) by [G-Rath](https://github.com/g-rath).
 
@@ -178,71 +199,89 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 
 - Remove `isArray` utility (just use `Array.isArray` directly) and renamed a few files [PR 454](https://github.com/shakacode/shakapacker/pull/454) by [G-Rath](https://github.com/g-rath).
 
-- Make JavaScript test helper utilities internal (`chdirTestApp`, `chdirCwd`, `resetEnv`)  [PR 458](https://github.com/shakacode/shakapacker/pull/458) by [G-Rath](https://github.com/g-rath).
+- Make JavaScript test helper utilities internal (`chdirTestApp`, `chdirCwd`, `resetEnv`) [PR 458](https://github.com/shakacode/shakapacker/pull/458) by [G-Rath](https://github.com/g-rath).
 
 ## [v7.2.3] - March 23, 2024
 
 ### Added
+
 - Emit warnings instead of errors when compilation is success but stderr is not empty. [PR 416](https://github.com/shakacode/shakapacker/pull/416) by [n-rodriguez](https://github.com/n-rodriguez).
 - Allow `webpack-dev-server` v5. [PR 418](https://github.com/shakacode/shakapacker/pull/418) by [G-Rath](https://github.com/g-rath)
 
 ### Removed
+
 - Removes dependency on `glob` library. [PR 435](https://github.com/shakacode/shakapacker/pull/435) by [tomdracz](https://github.com/tomdracz).
 
 ### Fixed
+
 - Uses config file passed in `SHAKAPACKER_CONFIG` consistently.[PR 448](https://github.com/shakacode/shakapacker/pull/448) by [tomdracz](https://github.com/tomdracz).
 
-   Previously this could have been ignored in few code branches, especially when checking for available environments.
+  Previously this could have been ignored in few code branches, especially when checking for available environments.
 
 ## [v7.2.2] - January 19, 2024
 
 ### Added
+
 - Allow `compression-webpack-plugin` v11. [PR 406](https://github.com/shakacode/shakapacker/pull/406) by [tagliala](https://github.com/tagliala).
 
 ## [v7.2.1] - December 30, 2023
 
 ### Fixed
+
 - Show deprecation message for `relative_url_root` only if it is set. [PR 400](https://github.com/shakacode/shakapacker/pull/400) by [ahangarha](https://github.com/ahangarha).
 
 ## [v7.2.0] - December 28, 2023
 
 ### Added
+
 - Experimental support for other JS package managers using `package_json` gem [PR 349](https://github.com/shakacode/shakapacker/pull/349) by [G-Rath](https://github.com/g-rath).
 - Support `hmr: only` configuration [PR 378](https://github.com/shakacode/shakapacker/pull/378) by [SimenB](https://github.com/SimenB).
 - Use `config/shakapacker.yml` as the secondary source for `asset_host` and `relative_url_root` configurations [PR 376](https://github.com/shakacode/shakapacker/pull/376) by [ahangarha](https://github.com/ahangarha).
 
 ### Fixed
+
 - Recommend `server` option instead of the deprecated `https` option when `--https` is provided [PR 380](https://github.com/shakacode/shakapacker/pull/380) by [G-Rath](https://github.com/g-rath)
 - Recompile assets on asset host change [PR 364](https://github.com/shakacode/shakapacker/pull/364) by [ahangarha](https://github.com/ahangarha).
 - Add deprecation warning for `https` option in `shakapacker.yml` (use `server: 'https'` instead) [PR 382](https://github.com/shakacode/shakapacker/pull/382) by [G-Rath](https://github.com/g-rath).
 - Disable Hot Module Replacement in `webpack-dev-server` when `hmr: false` [PR 392](https://github.com/shakacode/shakapacker/pull/392) by [thedanbob](https://github.com/thedanbob).
 
 ### Deprecated
+
 - The usage of `relative_url_root` is deprecated in Shakapacker and will be removed in v8. [PR 376](https://github.com/shakacode/shakapacker/pull/376) by [ahangarha](https://github.com/ahangarha).
 
 ## [v7.1.0] - September 30, 2023
 
 ### Added
+
 - Support passing custom webpack config directly to `generateWebpackConfig` for merging [PR 343](https://github.com/shakacode/shakapacker/pull/343) by [G-Rath](https://github.com/g-rath).
 
 ### Fixed
+
 - Use `NODE_OPTIONS` to enable Node-specific debugging flags [PR 350](https://github.com/shakacode/shakapacker/pull/350).
 - Add the boilerplate `application.js` into `packs/` [PR 363](https://github.com/shakacode/shakapacker/pull/363).
 
 ## [v7.0.3] - July 7, 2023
+
 ### Fixed
+
 - Fixed commands execution for projects with space in the absolute path [PR 322](https://github.com/shakacode/shakapacker/pull/322) by [kukicola](https://github.com/kukicola).
 
 ## [v7.0.2] - July 3, 2023
+
 ### Fixed
+
 - Fixed creation of assets:precompile if it is missing [PR 325](https://github.com/shakacode/shakapacker/pull/325) by [ahangarha](https://github.com/ahangarha).
 
 ## [v7.0.1] - June 27, 2023
+
 ### Fixed
+
 - Fixed the condition for showing warning for setting `useContentHash` to `false` in the production environment. [PR 320](https://github.com/shakacode/shakapacker/pull/320) by [ahangarha](https://github.com/ahangarha).
 
 ## [v7.0.0] - June 23, 2023
+
 ### Breaking changes
+
 - Removes defaults passed to `@babel/preset-typescript`. [PR 273](https://github.com/shakacode/shakapacker/pull/273) by [tomdracz](https://github.com/tomdracz).
 
   `@babel/preset-typescript` has been initialised in default configuration with `{ allExtensions: true, isTSX: true }` - meaning every file in the codebase was treated as TSX leading to potential issues. This has been removed and returns to sensible default of the preset which is to figure out the file type from the extensions. This change might affect generated output however so it is marked as breaking.
@@ -252,18 +291,21 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   The `webpackConfig` property in the `shakapacker` module has been updated to be a function instead of a global mutable webpack configuration. This function now returns an immutable webpack configuration object, which ensures that any modifications made to it will not affect any other usage of the webpack configuration. If a project still requires the old mutable object, it can be accessed by replacing `webpackConfig` with `globalMutableWebpackConfig`. Check [v7-upgrade](https://github.com/shakacode/shakapacker/blob/main/docs/v7_upgrade.md) documentation for more detail.
 
 ### Added
+
 - Set CSS modules mode depending on file type. [PR 261](https://github.com/shakacode/shakapacker/pull/261) by [talyuk](https://github.com/talyuk).
 - All standard webpack entries with the camelCase format are now supported in `shakapacker.yml` in snake_case format. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha).
 - The `shakapacker:install` rake task now has an option to force overriding files using `FORCE=true` environment variable [PR311](https://github.com/shakacode/shakapacker/pull/311) by [ahangarha](https://github.com/ahangarha).
 - Allow configuration of use of contentHash for specific environment [PR 234](https://github.com/shakacode/shakapacker/pull/234) by [justin808](https://github/justin808).
 
 ### Changed
+
 - Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility.
 
   This change might be breaking for certain setups and edge cases. More information: [v7 Upgrade Guide](./docs/v7_upgrade.md) [PR157](https://github.com/shakacode/shakapacker/pull/157) by [ahangarha](https://github.com/ahangarha)
 
 - Set `source_entry_path` to `packs` and `nested_entries` to `true` in`shakapacker.yml` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
 - Dev server configuration is modified to follow [webpack recommended configurations](https://webpack.js.org/configuration/dev-server/) for dev server. [PR276](https://github.com/shakacode/shakapacker/pull/276) by [ahangarha](https://github.com/ahangarha):
+
   - Deprecated `https` entry is removed from the default configuration file, allowing to set `server` or `https` as per the project requirements. For more detail, check webpack documentation. The `https` entry can be effective only if there is no `server` entry in the config file.
   - `allowed_hosts` is now set to `auto` instead of `all` by default.
 
@@ -274,6 +316,7 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
   Going forward, the top level directory of static files will be retained so this will necessitate the update of file name references in asset helpers. In the example above, the file sourced from `app/javascript/images/image.png` will be now output to `static/images/image.png` and needs to be referenced as `image_pack_tag("images/image.jpg")` or `image_pack_tag("static/images/image.jpg")`.
 
 ### Fixed
+
 - Move compilation lock file into the working directory. [PR 272](https://github.com/shakacode/shakapacker/pull/272) by [tomdracz](https://github.com/tomdracz).
 - Process `source_entry_path` with values starting with `/` as a relative path to `source_path` [PR 284](https://github.com/shakacode/shakapacker/pull/284) by [ahangarha](https://github.com/ahangarha).
 - Removes defaults passed to `@babel/preset-typescript` to make it possible to have projects with mix of JS and TS code [PR 273](https://github.com/shakacode/shakapacker/pull/273) by [tomdracz](https://github.com/tomdracz).
@@ -282,16 +325,22 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 
 - Fixed RC version detection during installation. [PR312](https://github.com/shakacode/shakapacker/pull/312) by [ahangarha](https://github.com/ahangarha)
 - Fix addition of webpack-dev-server to devDependencies during installation. [PR310](https://github.com/shakacode/shakapacker/pull/310) by [ahangarha](https://github.com/ahangarha)
+
 ### Removed
+
 - Remove redundant enhancement for precompile task to run `yarn install` [PR 270](https://github.com/shakacode/shakapacker/pull/270) by [ahangarha](https://github.com/ahangarha).
 - Remove deprecated `check_yarn_integrity` from `Shakapacker::Configuration` [PR SP288](https://github.com/shakacode/shakapacker/pull/288) by [ahangarha](https://github.com/ahangarha).
 
 ## [v6.6.0] - March 7, 2023
+
 ### Improved
+
 - Allow configuration of webpacker.yml through env variable. [PR 254](https://github.com/shakacode/shakapacker/pull/254) by [alecslupu](https://github.com/alecslupu).
 
 ## [v6.5.6] - February 11, 2023
+
 ### Fixed
+
 - Fixed failing to update `bin/setup` file due to different formats of the file in different versions of Rails. [PR 229](https://github.com/shakacode/shakapacker/pull/229) by [ahangarha](https://github.com/ahangarha).
 
 - Upgrade several JS dependencies to fix security issues. [PR 243](https://github.com/shakacode/shakapacker/pull/243) by [ahangarha](https://github.com/ahangarha).
@@ -305,27 +354,33 @@ See the [v8 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 ## [v6.5.5] - December 28, 2022
 
 ### Improved
+
 - Describe keys different from `webpack-dev-server` in generated `webpacker.yml`. [PR 194](https://github.com/shakacode/shakapacker/pull/194) by [alexeyr](https://github.com/alexeyr).
 - Allow webpack-cli v5 [PR 216](https://github.com/shakacode/shakapacker/pull/216) by [tagliala](https://github.com/tagliala).
 - Allow babel-loader v9 [PR 215](https://github.com/shakacode/shakapacker/pull/215) by [tagliala](https://github.com/tagliala).
 
 ## [v6.5.4] - November 4, 2022
+
 ### Fixed
+
 - Fixed regression caused by 6.5.3. PR #192 introduce extra split() call. [PR 202](https://github.com/shakacode/shakapacker/pull/202) by [Eric-Guo](https://github.com/Eric-Guo).
 
 ## [v6.5.3] - November 1, 2022
 
 ### Improved
+
 - Set RAILS_ENV and BUNDLE_GEMFILE env values before requiring `bundler/setup`, `webpacker`, and `webpacker/webpack_runner`. [PR 190](https://github.com/shakacode/shakapacker/pull/190) by [betmenslido](https://github.com/betmenslido).
 - The `mini-css-extract-plugin` may cause various warnings indicating CSS order conflicts when using a [File-System-based automated bundle generation feature](https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation/).
-CSS order warnings can be disabled in projects where CSS ordering has been mitigated by consistent use of scoping or naming conventions. Added `css_extract_ignore_order_warnings` flag to webpacker configuration to disable the order warnings by [pulkitkkr](https://github.com/shakacode/shakapacker/pull/185) in [PR 192](https://github.com/shakacode/shakapacker/pull/192).
+  CSS order warnings can be disabled in projects where CSS ordering has been mitigated by consistent use of scoping or naming conventions. Added `css_extract_ignore_order_warnings` flag to webpacker configuration to disable the order warnings by [pulkitkkr](https://github.com/shakacode/shakapacker/pull/185) in [PR 192](https://github.com/shakacode/shakapacker/pull/192).
 
 ## [v6.5.2] - September 8, 2022
 
 ### Upgrade
+
 Remove the setting of the NODE_ENV in your `bin/webpacker` and `bin/webpacker-dev-server` files per [PR 185](https://github.com/shakacode/shakapacker/pull/185).
 
 ### Fixed
+
 - Changed NODE_ENV defaults to the following and moved from binstubs to the runner. [PR 185](https://github.com/shakacode/shakapacker/pull/185) by [mage1711](https://github.com/mage1711).
 
 ```
@@ -335,23 +390,30 @@ ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "develop
 ## [v6.5.1] - August 15, 2022
 
 ### Improved
+
 - Resolve exact npm package version from lockfiles for constraint checking. [PR 170](https://github.com/shakacode/shakapacker/pull/170) by [G-Rath](https://github.com/G-Rath).
 
 ### Fixed
+
 - `append_javascript_pack_tag` and `append_stylesheet_pack_tag` helpers return `nil` to prevent rendering the queue into view when using `<%= … %>` ERB syntax. [PR 167](https://github.com/shakacode/shakapacker/pull/167) by [ur5us](https://github.com/ur5us). While `<%=` should not be used, it's OK to return nil in case it's misused.
 - Fixed non-runnable test due to wrong code nesting. [PR 173](https://github.com/shakacode/shakapacker/pull/173) by [ur5us](https://github.com/ur5us).
 - Fixed default configurations not working for custom Rails environments [PR 168](https://github.com/shakacode/shakapacker/pull/168) by [ur5us](https://github.com/ur5us).
 - Added accessor method for `nested_entries` configuration. [PR 176](https://github.com/shakacode/shakapacker/pull/176) by [pulkitkkr](https://github.com/pulkitkkr).
 
 ## [v6.5.0] - July 4, 2022
+
 ### Added
+
 - `append_stylesheet_pack_tag` helper. It helps in configuring stylesheet pack names from the view for a route or partials. It is also required for filesystem-based automated Component Registry API on React on Rails gem. [PR 144](https://github.com/shakacode/shakapacker/pull/144) by [pulkitkkr](https://github.com/pulkitkkr).
 
 ### Improved
+
 - Make sure at most one compilation runs at a time [PR 139](https://github.com/shakacode/shakapacker/pull/139) by [artemave](https://github.com/artemave)
 
 ## [v6.4.1] - June 5, 2022
+
 ### Fixed
+
 - Restores automatic installation of yarn packages removed in [#131](https://github.com/shakacode/shakapacker/pull/131), with added deprecation notice. [PR 140](https://github.com/shakacode/shakapacker/pull/140) by [tomdracz](https://github.com/tomdracz).
 
   This will be again removed in Shakapacker v7 so you need to ensure you are installing yarn packages explicitly before the asset compilation, rather than relying on this behaviour through `asset:precompile` task (e.g. Capistrano deployment).
@@ -359,13 +421,17 @@ ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "develop
 - Disable Spring being used by `rails-erb-loader`. [PR 141](https://github.com/shakacode/shakapacker/pull/141) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.4.0] - June 2, 2022
+
 ### Fixed
+
 - Fixed [Issue 123: Rails 7.0.3 - Webpacker configuration file not found when running rails webpacker:install (shakapacker v6.3)](https://github.com/shakacode/shakapacker/issues/123) in [PR 136: Don't enhance precompile if no config #136](https://github.com/shakacode/shakapacker/pull/136) by [justin808](https://github.com/justin808).
 
 ### Added
+
 - Configuration boolean option `nested_entries` to use nested entries. This was the default prior to v6.0. Because entries maybe generated, it's useful to allow a `generated` subdirectory. [PR 121](https://github.com/shakacode/shakapacker/pull/121) by [justin808](https://github.com/justin808).
 
 ### Improved
+
 - Allow v10 of `compression-webpack-plugin` as a peer dependency. [PR 117](https://github.com/shakacode/shakapacker/pull/117) by [aried3r](https://github.com/aried3r).
 
 - [Remove assets:precompile task enhancement #131](https://github.com/shakacode/shakapacker/pull/131) by [James Herdman](https://github.com/jherdman): Removed the `yarn:install` Rake task, and no longer enhance `assets:precompile` with said task. These tasks were used to ensure required NPM packages were installed before asset precompilation. Going forward you will need to ensure these packages are already installed yourself. Should you wish to restore this behaviour you'll need to [reimplement the task](https://github.com/shakacode/shakapacker/blob/bee661422f2c902aa8ac9cf8fa1f7ccb8142c914/lib/tasks/yarn.rake) in your own application.
@@ -373,9 +439,11 @@ ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "develop
 ## [v6.3.0] - May 19, 2022
 
 ### Improved
+
 - Add ability to configure usage of either last modified timestamp and digest strategies when checking asset freshness. [PR 112](https://github.com/shakacode/shakapacker/pull/112) by [tomdracz](https://github.com/tomdracz).
 
 ### Fixed
+
 - On Windows CSS urls no longer contain backslashes resulting in 404 errors. [PR 115](https://github.com/shakacode/shakapacker/pull/115) by [daniel-rikowski](https://github.com/daniel-rikowski).
 
 ## [v6.3.0-rc.1] - April 24, 2022
@@ -383,6 +451,7 @@ ENV["NODE_ENV"] ||= (ENV["RAILS_ENV"] == "production") ? "production" : "develop
 Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions/6.3.0.pre.rc.1) and [NPM is 6.3.0-rc.1](https://www.npmjs.com/package/shakapacker/v/6.3.0-rc.1).
 
 ### Changed
+
 - Remove Loose mode from the default @babel-preset/env configuration. [PR 107](https://github.com/shakacode/shakapacker/pull/107) by [Jeremy Liberman](https://github.com/MrLeebo).
 
   Loose mode compiles the bundle down to be compatible with ES5, but saves space by skipping over behaviors that are considered edge cases. Loose mode can affect how your code runs in a variety of ways, but in newer versions of Babel it's better to use [Compiler Assumptions](https://babeljs.io/docs/en/assumptions) to have finer-grained control over which edge cases you're choosing to ignore.
@@ -390,10 +459,12 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
   This change may increase the file size of your bundles, and may change some behavior in your app if your code touches upon one of the edge cases where Loose mode differs from native JavaScript. There are notes in the linked PR about how to turn Loose mode back on if you need to, but consider migrating to Compiler Assumptions when you can. If you have already customized your babel config, this change probably won't affect you.
 
 ### Added
+
 - Adds `webpacker_precompile` setting to `webpacker.yml` to allow controlling precompile behaviour, similar to existing `ENV["WEBPACKER_PRECOMPILE"]` variable. [PR 102](https://github.com/shakacode/shakapacker/pull/102) by [Judahmeek](https://github.com/Judahmeek).
 - Adds `append_javascript_pack_tag` helper. Allows for easier usage and coordination of multiple javascript packs. [PR 94](https://github.com/shakacode/shakapacker/pull/94) by [tomdracz](https://github.com/tomdracz).
 
 ### Improved
+
 - Use last modified timestamps rather than file digest to determine compiler freshness. [PR 97](https://github.com/shakacode/shakapacker/pull/97) by [tomdracz](https://github.com/tomdracz).
 
   Rather than calculating SHA digest of all the files in the paths watched by the compiler, we are now comparing the modified time of the `manifest.json` file versus the latest modified timestamp of files and directories in watched paths. Unlike calculating digest, which only looked at the files, the new calculation also considers directory timestamps, including the parent ones (i.e. `config.source_path` folder timestamp will be checked together will timestamps of all files and directories inside of it).
@@ -404,18 +475,22 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 - Add `webpack-dev-server` as `peerDependency` to make its usage clear. [PR 109](https://github.com/shakacode/shakapacker/pull/109) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.2.1] - April 15, 2022
+
 ### Fixed
+
 - Put back config.public_manifest_path, removed in 6.2.0 in PR 78. [PR 104](https://github.com/shakacode/shakapacker/pull/104) by [justin808](https://github.com/justin808).
 
 ## [v6.2.0] - March 22, 2022
 
 ### Added
+
 - Make manifest_path configurable, to keep manifest.json private if desired. [PR 78](https://github.com/shakacode/shakapacker/pull/78) by [jdelStrother](https://github.com/jdelStrother).
 - Rewrite webpack module rules as regular expressions. Allows for easy iteration during config customization. [PR 60](https://github.com/shakacode/shakapacker/pull/60) by [blnoonan](https://github.com/blnoonan).
 - Initialization check to ensure shakapacker gem and NPM package version are consistent. Opt-in behaviour enabled by setting `ensure_consistent_versioning` configuration variable. [PR 51](https://github.com/shakacode/shakapacker/pull/51) by [tomdracz](https://github.com/tomdracz).
 - Add `dev_server.inline_css: bool` config option to allow for opting out of style-loader and into mini-css-extract-plugin for CSS HMR in development. [PR 69](https://github.com/shakacode/shakapacker/pull/69) by [cheald](https://github.com/cheald).
 
 ### Improved
+
 - Increase default connect timeout for dev server connections, establishing connections more reliably for busy machines. [PR 74](https://github.com/shakacode/shakapacker/pull/74) by [stevecrozz](https://github.com/stevecrozz).
 - Allow multiple invocations of stylesheet_pack_tag (eg for a regular stylesheet & a print stylesheet). [PR 82](https://github.com/shakacode/shakapacker/pull/82) by [jdelStrother](https://github.com/jdelStrother).
 - Tweak swc config for parity with Babel. [PR 79](https://github.com/shakacode/shakapacker/pull/79) by [dleavitt](https://github.com/dleavitt).
@@ -423,30 +498,38 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 ## [v6.1.1] - February 6, 2022
 
 ### Added
+
 - Support for esbuild-loader. [PR 53](https://github.com/shakacode/shakapacker/pull/53) by [tomdracz](https://github.com/tomdracz).
 
 ## [v6.1.0] - February 4, 2022
+
 ### Added
+
 - Support for SWC loader. [PR 29](https://github.com/shakacode/shakapacker/pull/29) by [tomdracz](https://github.com/tomdracz).
 
 ### Fixed
+
 - Static asset subdirectories are retained after compilation, matching Webpacker v5 behaviour. [PR 47](https://github.com/shakacode/shakapacker/pull/47) by [tomdracz](https://github.com/tomdracz). Fixes issues [rails/webpacker#2956](https://github.com/rails/webpacker/issues/2956) which broke in [rails/webpacker#2802](https://github.com/rails/webpacker/pull/2802).
 
 ## [v6.0.2] - January 25, 2022
+
 ### Improved
+
 - Fix incorrect command name in warning. [PR 33](https://github.com/shakacode/shakapacker/pull/33) by [tricknotes](https://github.com/tricknotes).
 
 ## [v6.0.1] - January 24, 2022
+
 ### Improved
+
 - PR #21 removed pnp-webpack-plugin as a dev dependency but did not remove it from the peer dependency list. [PR 30](https://github.com/shakacode/shakapacker/pull/30) by [t27duck](https://github.com/t27duck).
 
 ## [v6.0.0 changes from v6.0.0.rc.6] - January 22, 2022
 
 ### Improved
+
 - Raise on multiple invocations of javascript_pack_tag and stylesheet_pack_tag helpers. [PR 19](https://github.com/shakacode/shakapacker/pull/19) by [tomdracz](https://github.com/tomdracz).
 - Remove automatic addition of node_modules into rails asset load path. [PR 20](https://github.com/shakacode/shakapacker/pull/20) by [tomdracz](https://github.com/tomdracz).
 - Remove pnp-webpack-plugin. [PR 21](https://github.com/shakacode/shakapacker/pull/21) by [tomdracz](https://github.com/tomdracz).
-
 
 ### Merged from rails/webpacker
 
@@ -455,18 +538,18 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 - Switch to peer dependencies. [rails/webpacker #3234](https://github.com/rails/webpacker/pull/3234)
 
 ### Upgrading from rails/webpacker 6.0.0.rc.6
+
 - Single default configuration file of `config/webpack/webpack.config.js`. Previously, the config file was set
   to `config/webpack/#{NODE_ENV}.js`.
 - Changed all package.json dependencies to peerDependencies, so upgrading requires adding the dependencies, per the [UPGRADE GUIDE](./docs/v6_upgrade.md).
 
 ## [v6.0.0.rc.6 changes from v5.4] - Forked January 16, 2022
 
-
 - `node_modules` will no longer be babel transformed compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
 
   ```js
-  const nodeModules = require('@rails/webpacker/rules/node_modules.js')
-  environment.loaders.append('nodeModules', nodeModules)
+  const nodeModules = require("@rails/webpacker/rules/node_modules.js")
+  environment.loaders.append("nodeModules", nodeModules)
   ```
 
 - If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).
@@ -479,12 +562,14 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 - Deprecated configuration option `watched_paths`. Use `additional_paths` instead in `webpacker.yml`.
 
 ### Breaking changes
+
 - Renamed `/bin/webpack` to `/bin/webpacker` and `/bin/webpack-dev-server` to `bin/webpacker-dev-server` to avoid confusion with underlying webpack executables.
 - Removed integration installers
 - Splitchunks enabled by default
 - CSS extraction enabled by default, except when devServer is configured and running
 
 ## v5.4.3 and prior changes from rails/webpacker
+
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
 [Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.0.0-beta.8...main

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -9,11 +9,30 @@ This guide outlines new features, breaking changes, and migration steps for upgr
 Shakapacker v9 includes TypeScript definitions for better IDE support and type safety.
 
 - **No breaking changes** - JavaScript configs continue to work
-- **Optional** - Use TypeScript only if you want it  
+- **Optional** - Use TypeScript only if you want it
 - **Type safety** - Catch configuration errors at compile-time
 - **IDE support** - Full autocomplete for all options
 
 See the [TypeScript Documentation](./typescript.md) for usage examples.
+
+### NODE_ENV Default Behavior Fixed
+
+**What changed:** NODE_ENV now intelligently defaults based on RAILS_ENV instead of always defaulting to "production".
+
+**New behavior:**
+
+- When `RAILS_ENV=production` → `NODE_ENV` defaults to `"production"`
+- When `RAILS_ENV=development` or unset → `NODE_ENV` defaults to `"development"`
+- When `RAILS_ENV` is any other value (test, staging, etc.) → `NODE_ENV` defaults to `"development"`
+
+**Benefits:**
+
+- **Dev server "just works"** - No need to explicitly set NODE_ENV when running the development server
+- **Correct configuration loaded** - Development server now properly loads the development configuration from shakapacker.yml
+- **Fixes port issues** - Dev server uses the configured port (e.g., 3035) instead of defaulting to 8080
+- **Fixes 404 errors** - Assets load correctly without requiring manual NODE_ENV configuration
+
+**No action required** - This change improves the default behavior and requires no migration. If you were previously working around this by setting `NODE_ENV=development` manually, you can remove that workaround.
 
 ## Breaking Changes
 
@@ -25,25 +44,27 @@ See the [TypeScript Documentation](./typescript.md) for usage examples.
 
 **Quick Reference: Configuration Options**
 
-| Configuration | namedExport | exportLocalsConvention | CSS: `.my-button` | Export Available | Works With |
-|---------------|-------------|------------------------|-------------------|------------------|------------|
-| **v9 Default** | `true` | `'camelCaseOnly'` | `.my-button` | `myButton` only | ✅ Named exports |
-| **Alternative** | `true` | `'dashesOnly'` | `.my-button` | `'my-button'` only | ✅ Named exports |
-| **v8 Style** | `false` | `'camelCase'` | `.my-button` | Both `myButton` AND `'my-button'` | ✅ Default export |
-| **❌ Invalid** | `true` | `'camelCase'` | - | - | ❌ Build Error |
+| Configuration   | namedExport | exportLocalsConvention | CSS: `.my-button` | Export Available                  | Works With        |
+| --------------- | ----------- | ---------------------- | ----------------- | --------------------------------- | ----------------- |
+| **v9 Default**  | `true`      | `'camelCaseOnly'`      | `.my-button`      | `myButton` only                   | ✅ Named exports  |
+| **Alternative** | `true`      | `'dashesOnly'`         | `.my-button`      | `'my-button'` only                | ✅ Named exports  |
+| **v8 Style**    | `false`     | `'camelCase'`          | `.my-button`      | Both `myButton` AND `'my-button'` | ✅ Default export |
+| **❌ Invalid**  | `true`      | `'camelCase'`          | -                 | -                                 | ❌ Build Error    |
 
 **JavaScript Projects:**
+
 ```js
 // Before (v8)
-import styles from './Component.module.css';
-<button className={styles.button} />
+import styles from "./Component.module.css"
+;<button className={styles.button} />
 
 // After (v9)
-import { button } from './Component.module.css';
-<button className={button} />
+import { button } from "./Component.module.css"
+;<button className={button} />
 ```
 
 **TypeScript Projects:**
+
 ```typescript
 // Before (v8)
 import styles from './Component.module.css';
@@ -57,6 +78,7 @@ import * as styles from './Component.module.css';
 **Migration Options:**
 
 1. **Update your code** (Recommended):
+
    - JavaScript: Change to named imports (`import { className }`)
    - TypeScript: Change to namespace imports (`import * as styles`)
    - Kebab-case class names are automatically converted to camelCase
@@ -66,6 +88,7 @@ import * as styles from './Component.module.css';
    - This gives you time to migrate gradually
 
 **Benefits of the change:**
+
 - Eliminates webpack/TypeScript warnings
 - Better tree-shaking of unused CSS classes
 - More explicit about which classes are used
@@ -76,15 +99,17 @@ import * as styles from './Component.module.css';
 **What changed:** The configuration option has been renamed to better reflect its purpose.
 
 **Before (v8):**
+
 ```yml
 # config/shakapacker.yml
-webpack_loader: 'babel'
+webpack_loader: "babel"
 ```
 
 **After (v9):**
+
 ```yml
 # config/shakapacker.yml
-javascript_transpiler: 'babel'
+javascript_transpiler: "babel"
 ```
 
 **Note:** The old `webpack_loader` option is deprecated but still supported with a warning.
@@ -96,38 +121,48 @@ javascript_transpiler: 'babel'
 **Why:** SWC is 20x faster than Babel while maintaining compatibility with most JavaScript and TypeScript code.
 
 **Impact on existing projects:**
+
 - Your project will continue using Babel if you already have babel packages in package.json
 - To switch to SWC for better performance, see migration options below
 
 **Impact on new projects:**
+
 - New installations will use SWC by default
 - Babel dependencies won't be installed unless explicitly configured
 
 ### Migration Options
 
 #### Option 1 (Recommended): Switch to SWC
+
 ```yml
 # config/shakapacker.yml
-javascript_transpiler: 'swc'
+javascript_transpiler: "swc"
 ```
+
 Then install SWC:
+
 ```bash
 npm install @swc/core swc-loader
 ```
 
 #### Option 2: Keep using Babel
+
 ```yml
 # config/shakapacker.yml
-javascript_transpiler: 'babel'
+javascript_transpiler: "babel"
 ```
+
 No other changes needed - your existing babel packages will continue to work.
 
 #### Option 3: Use esbuild
+
 ```yml
 # config/shakapacker.yml
-javascript_transpiler: 'esbuild'
+javascript_transpiler: "esbuild"
 ```
+
 Then install esbuild:
+
 ```bash
 npm install esbuild esbuild-loader
 ```
@@ -138,7 +173,7 @@ npm install esbuild esbuild-loader
 
 ```yml
 # config/shakapacker.yml
-assets_bundler: 'rspack'  # or 'webpack' (default)
+assets_bundler: "rspack" # or 'webpack' (default)
 ```
 
 ### 5. All Peer Dependencies Now Optional
@@ -146,16 +181,19 @@ assets_bundler: 'rspack'  # or 'webpack' (default)
 **What changed:** All peer dependencies are now marked as optional via `peerDependenciesMeta`.
 
 **Benefits:**
+
 - **No installation warnings** - You won't see peer dependency warnings for packages you don't use
 - **Install only what you need** - Using webpack? Don't install rspack. Using SWC? Don't install Babel.
 - **Clear version constraints** - When you do install a package, version compatibility is still enforced
 
 **What this means for you:**
+
 - **Existing projects:** No changes needed. Your existing dependencies will continue to work.
 - **New projects:** The installer only adds the packages you actually need based on your configuration.
 - **Package manager behavior:** npm, yarn, and pnpm will no longer warn about missing peer dependencies.
 
 **Example:** If you're using SWC with webpack, you only need:
+
 ```json
 {
   "dependencies": {
@@ -168,6 +206,7 @@ assets_bundler: 'rspack'  # or 'webpack' (default)
   }
 }
 ```
+
 You won't get warnings about missing Babel, Rspack, or esbuild packages.
 
 ## Migration Steps
@@ -186,22 +225,22 @@ yarn upgrade shakapacker@^9.0.0
 
 ```js
 // Find imports like this:
-import styles from './styles.module.css';
+import styles from "./styles.module.css"
 
 // Replace with named imports:
-import { className1, className2 } from './styles.module.css';
+import { className1, className2 } from "./styles.module.css"
 ```
 
 #### Update TypeScript definitions:
 
 ```typescript
 // Update your CSS module type definitions
-declare module '*.module.css' {
+declare module "*.module.css" {
   // With namedExport: true, css-loader generates individual named exports
   // TypeScript can't know the exact names at compile time, so we declare
   // a module with any number of string exports
-  const classes: { readonly [key: string]: string };
-  export = classes;
+  const classes: { readonly [key: string]: string }
+  export = classes
   // Note: This allows 'import * as styles' but not 'import styles from'
   // because css-loader with namedExport: true doesn't generate a default export
 }
@@ -213,13 +252,15 @@ v9 automatically converts kebab-case to camelCase with `exportLocalsConvention: 
 
 ```css
 /* styles.module.css */
-.my-button { }
-.primary-color { }
+.my-button {
+}
+.primary-color {
+}
 ```
 
 ```js
 // v9 default - camelCase conversion
-import { myButton, primaryColor } from './styles.module.css';
+import { myButton, primaryColor } from "./styles.module.css"
 ```
 
 **Alternative: Keep kebab-case names with 'dashesOnly'**
@@ -256,7 +297,7 @@ If you have `webpack_loader` in your configuration:
 # webpack_loader: 'babel'
 
 # NEW:
-javascript_transpiler: 'babel'
+javascript_transpiler: "babel"
 ```
 
 ### Step 5: Run Tests
@@ -291,6 +332,7 @@ If you see warnings about CSS module exports, ensure you've updated all imports 
 ### Build Error: exportLocalsConvention Incompatible with namedExport
 
 If you see this error:
+
 ```
 "exportLocalsConvention" with "camelCase" value is incompatible with "namedExport: true" option
 ```
@@ -312,30 +354,35 @@ If you want to use `'camelCase'` (which exports both original and camelCase vers
 If you experience unexpected peer dependency warnings after upgrading to v9, you may need to clear your package manager's cache and reinstall dependencies. This ensures the new optional peer dependency configuration takes effect properly.
 
 **For npm:**
+
 ```bash
 rm -rf node_modules package-lock.json
 npm install
 ```
 
 **For Yarn:**
+
 ```bash
 rm -rf node_modules yarn.lock
 yarn install
 ```
 
 **For pnpm:**
+
 ```bash
 rm -rf node_modules pnpm-lock.yaml
 pnpm install
 ```
 
 **For Bun:**
+
 ```bash
 rm -rf node_modules bun.lockb
 bun install
 ```
 
 **When is this necessary?**
+
 - If you see peer dependency warnings for packages you don't use (e.g., warnings about Babel when using SWC)
 - If your package manager cached the old dependency resolution from v8
 - After switching transpilers or bundlers (e.g., from Babel to SWC, or webpack to rspack)

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -32,7 +32,14 @@ See the [TypeScript Documentation](./typescript.md) for usage examples.
 - **Fixes port issues** - Dev server uses the configured port (e.g., 3035) instead of defaulting to 8080
 - **Fixes 404 errors** - Assets load correctly without requiring manual NODE_ENV configuration
 
-**No action required** - This change improves the default behavior and requires no migration. If you were previously working around this by setting `NODE_ENV=development` manually, you can remove that workaround.
+**No action required** - This change improves the default behavior and requires no migration.
+
+**If you previously worked around this bug**, you can now remove these workarounds:
+
+- Remove `NODE_ENV=development` from your `.env`, `.env.development`, or `.env.local` files
+- Remove `NODE_ENV=development` from your `docker-compose.yml` or Dockerfile
+- Remove custom scripts that set NODE_ENV before running the dev server
+- Remove `NODE_ENV=development` from your `bin/dev` or Procfile.dev
 
 ## Breaking Changes
 

--- a/lib/shakapacker.rb
+++ b/lib/shakapacker.rb
@@ -6,7 +6,7 @@ require "active_support/tagged_logging"
 module Shakapacker
   extend self
 
-  DEFAULT_ENV = "production".freeze
+  DEFAULT_ENV = "development".freeze
 
   def instance=(instance)
     @instance = instance

--- a/package/env.ts
+++ b/package/env.ts
@@ -6,21 +6,30 @@ const { isFileNotFoundError } = require("./utils/errorHelpers")
 const { sanitizeEnvValue } = require("./utils/pathValidation")
 
 const NODE_ENVIRONMENTS = ["development", "production", "test"] as const
-const DEFAULT = "production"
 
 // Sanitize environment variables to prevent injection
 const initialRailsEnv = sanitizeEnvValue(process.env.RAILS_ENV)
 const rawNodeEnv = sanitizeEnvValue(process.env.NODE_ENV)
 
+// Default to development unless RAILS_ENV is explicitly production
+// This ensures the dev server works out of the box without requiring NODE_ENV to be set
+const DEFAULT = initialRailsEnv === "production" ? "production" : "development"
+
 // Validate NODE_ENV strictly
 const nodeEnv =
-  rawNodeEnv && NODE_ENVIRONMENTS.includes(rawNodeEnv as typeof NODE_ENVIRONMENTS[number]) ? rawNodeEnv : DEFAULT
+  rawNodeEnv &&
+  NODE_ENVIRONMENTS.includes(rawNodeEnv as (typeof NODE_ENVIRONMENTS)[number])
+    ? rawNodeEnv
+    : DEFAULT
 
 // Log warning if NODE_ENV was invalid
-if (rawNodeEnv && !NODE_ENVIRONMENTS.includes(rawNodeEnv as typeof NODE_ENVIRONMENTS[number])) {
+if (
+  rawNodeEnv &&
+  !NODE_ENVIRONMENTS.includes(rawNodeEnv as (typeof NODE_ENVIRONMENTS)[number])
+) {
   console.warn(
     `[SHAKAPACKER WARNING] Invalid NODE_ENV value: ${rawNodeEnv}. ` +
-    `Valid values are: ${NODE_ENVIRONMENTS.join(', ')}. Using default: ${DEFAULT}`
+      `Valid values are: ${NODE_ENVIRONMENTS.join(", ")}. Using default: ${DEFAULT}`
   )
 }
 
@@ -42,13 +51,13 @@ try {
     } catch (defaultError) {
       throw new Error(
         `Failed to load Shakapacker configuration.\n` +
-        `Neither user config (${configPath}) nor default config (${defaultConfigPath}) could be loaded.\n\n` +
-        `To fix this issue:\n` +
-        `1. Create a config/shakapacker.yml file in your project\n` +
-        `2. Or set the SHAKAPACKER_CONFIG environment variable to point to your config file\n` +
-        `3. Or reinstall Shakapacker to restore the default configuration:\n` +
-        `   npm install shakapacker --force\n` +
-        `   yarn add shakapacker --force`
+          `Neither user config (${configPath}) nor default config (${defaultConfigPath}) could be loaded.\n\n` +
+          `To fix this issue:\n` +
+          `1. Create a config/shakapacker.yml file in your project\n` +
+          `2. Or set the SHAKAPACKER_CONFIG environment variable to point to your config file\n` +
+          `3. Or reinstall Shakapacker to restore the default configuration:\n` +
+          `   npm install shakapacker --force\n` +
+          `   yarn add shakapacker --force`
       )
     }
   } else {
@@ -61,13 +70,14 @@ const regex = new RegExp(`^(${availableEnvironments})$`, "g")
 
 const runningWebpackDevServer = process.env.WEBPACK_SERVE === "true"
 
-const validatedRailsEnv = initialRailsEnv && initialRailsEnv.match(regex) ? initialRailsEnv : DEFAULT
+const validatedRailsEnv =
+  initialRailsEnv && initialRailsEnv.match(regex) ? initialRailsEnv : DEFAULT
 
 if (initialRailsEnv && validatedRailsEnv !== initialRailsEnv) {
   /* eslint no-console:0 */
   console.warn(
     `[SHAKAPACKER WARNING] Environment '${initialRailsEnv}' not found in the configuration.\n` +
-    `Using '${DEFAULT}' configuration as a fallback.`
+      `Using '${DEFAULT}' configuration as a fallback.`
   )
 }
 

--- a/package/env.ts
+++ b/package/env.ts
@@ -11,8 +11,10 @@ const NODE_ENVIRONMENTS = ["development", "production", "test"] as const
 const initialRailsEnv = sanitizeEnvValue(process.env.RAILS_ENV)
 const rawNodeEnv = sanitizeEnvValue(process.env.NODE_ENV)
 
-// Default to development unless RAILS_ENV is explicitly production
-// This ensures the dev server works out of the box without requiring NODE_ENV to be set
+// Default NODE_ENV based on RAILS_ENV to match bin/shakapacker behavior (see lib/shakapacker/runner.rb:27)
+// - RAILS_ENV=production → DEFAULT="production" (safe for production builds)
+// - RAILS_ENV=development, test, staging, or unset → DEFAULT="development" (good DX for dev server)
+// This ensures the dev server works out of the box without requiring NODE_ENV to be set explicitly
 const DEFAULT = initialRailsEnv === "production" ? "production" : "development"
 
 // Validate NODE_ENV strictly

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -429,8 +429,8 @@ describe "Shakapacker::Configuration" do
       )
     end
 
-    it "#cache_manifest? fall back to 'production' config from bundled file" do
-      expect(config.cache_manifest?).to be true
+    it "#cache_manifest? fall back to 'development' config from bundled file" do
+      expect(config.cache_manifest?).to be false
     end
 
     it "#shakapacker_precompile? use 'staging' config from custom file" do

--- a/spec/shakapacker/env_spec.rb
+++ b/spec/shakapacker/env_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Env" do
     expect(Shakapacker.env).to eq Rails.env
   end
 
-  it "uses production env without config" do
+  it "uses development env without config" do
     with_rails_env("foo") do
-      expect(Shakapacker.env).to eq "production"
+      expect(Shakapacker.env).to eq "development"
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe "Env" do
     end
   end
 
-  it "uses 'production' as default env" do
-    expect(Shakapacker::DEFAULT_ENV).to eq "production"
+  it "uses 'development' as default env" do
+    expect(Shakapacker::DEFAULT_ENV).to eq "development"
   end
 end

--- a/test/package/config.test.js
+++ b/test/package/config.test.js
@@ -71,6 +71,7 @@ describe("Config", () => {
   })
 
   test("should allow enabling integrity", () => {
+    process.env.RAILS_ENV = "production"
     process.env.SHAKAPACKER_CONFIG = "config/shakapacker_integrity.yml"
     const config = require("../../package/config")
 
@@ -78,6 +79,7 @@ describe("Config", () => {
   })
 
   test("should allow configuring hash functions", () => {
+    process.env.RAILS_ENV = "production"
     process.env.SHAKAPACKER_CONFIG = "config/shakapacker_integrity.yml"
     const config = require("../../package/config")
 
@@ -89,6 +91,7 @@ describe("Config", () => {
   })
 
   test("should allow configuring crossorigin", () => {
+    process.env.RAILS_ENV = "production"
     process.env.SHAKAPACKER_CONFIG = "config/shakapacker_integrity.yml"
     const config = require("../../package/config")
 

--- a/test/package/env.test.js
+++ b/test/package/env.test.js
@@ -54,4 +54,27 @@ describe("Env", () => {
       runningWebpackDevServer: false
     })
   })
+
+  test("rejects malicious NODE_ENV values and uses default", () => {
+    process.env.RAILS_ENV = "development"
+    process.env.NODE_ENV = "../../../etc/passwd"
+    expect(require("../../package/env")).toStrictEqual({
+      railsEnv: "development",
+      nodeEnv: "development",
+      isProduction: false,
+      isDevelopment: true,
+      runningWebpackDevServer: false
+    })
+  })
+
+  test("warns when NODE_ENV is invalid", () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation()
+    process.env.NODE_ENV = "invalid"
+    delete process.env.RAILS_ENV
+    require("../../package/env")
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid NODE_ENV value: invalid")
+    )
+    consoleSpy.mockRestore()
+  })
 })

--- a/test/package/env.test.js
+++ b/test/package/env.test.js
@@ -31,6 +31,18 @@ describe("Env", () => {
     })
   })
 
+  test("with undefined NODE_ENV and RAILS_ENV set to production", () => {
+    process.env.RAILS_ENV = "production"
+    delete process.env.NODE_ENV
+    expect(require("../../package/env")).toStrictEqual({
+      railsEnv: "production",
+      nodeEnv: "production",
+      isProduction: true,
+      isDevelopment: false,
+      runningWebpackDevServer: false
+    })
+  })
+
   test("with undefined NODE_ENV and RAILS_ENV", () => {
     delete process.env.NODE_ENV
     delete process.env.RAILS_ENV

--- a/test/package/env.test.js
+++ b/test/package/env.test.js
@@ -24,9 +24,9 @@ describe("Env", () => {
     delete process.env.NODE_ENV
     expect(require("../../package/env")).toStrictEqual({
       railsEnv: "development",
-      nodeEnv: "production",
-      isProduction: true,
-      isDevelopment: false,
+      nodeEnv: "development",
+      isProduction: false,
+      isDevelopment: true,
       runningWebpackDevServer: false
     })
   })
@@ -35,10 +35,10 @@ describe("Env", () => {
     delete process.env.NODE_ENV
     delete process.env.RAILS_ENV
     expect(require("../../package/env")).toStrictEqual({
-      railsEnv: "production",
-      nodeEnv: "production",
-      isProduction: true,
-      isDevelopment: false,
+      railsEnv: "development",
+      nodeEnv: "development",
+      isProduction: false,
+      isDevelopment: true,
       runningWebpackDevServer: false
     })
   })
@@ -48,9 +48,9 @@ describe("Env", () => {
     process.env.NODE_ENV = "staging"
     expect(require("../../package/env")).toStrictEqual({
       railsEnv: "staging",
-      nodeEnv: "production",
-      isProduction: true,
-      isDevelopment: false,
+      nodeEnv: "development",
+      isProduction: false,
+      isDevelopment: true,
       runningWebpackDevServer: false
     })
   })

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -7,6 +7,10 @@ const { chdirTestApp, resetEnv } = require("../../helpers")
 const rootPath = process.cwd()
 chdirTestApp()
 
+// Set NODE_ENV before requiring modules to ensure contenthash is enabled
+// Base config tests expect production-like behavior with contenthash
+process.env.NODE_ENV = "production"
+
 const baseConfig = require("../../../package/environments/base")
 const config = require("../../../package/config")
 

--- a/test/package/staging.test.js
+++ b/test/package/staging.test.js
@@ -19,7 +19,7 @@ describe("Custom environment", () => {
   describe("generateWebpackConfig", () => {
     beforeEach(() => jest.resetModules())
 
-    test("should use staging config and default production environment", () => {
+    test("should use staging config and default development environment", () => {
       process.env.RAILS_ENV = "staging"
       delete process.env.NODE_ENV
 
@@ -31,9 +31,10 @@ describe("Custom environment", () => {
         resolve("public", "packs-staging")
       )
       expect(webpackConfig.output.publicPath).toBe("/packs-staging/")
+      // With the NODE_ENV fix, staging now defaults to development environment
+      // instead of production, providing better DX for staging environments
       expect(webpackConfig).toMatchObject({
-        devtool: "source-map",
-        stats: "normal"
+        devtool: "cheap-module-source-map"
       })
     })
   })


### PR DESCRIPTION
## Summary

Fixes #631 - Changes NODE_ENV default behavior to intelligently default based on RAILS_ENV instead of always defaulting to production.

### New Behavior
- `RAILS_ENV=production` → `NODE_ENV` defaults to `"production"`
- `RAILS_ENV=development` or unset → `NODE_ENV` defaults to `"development"`
- `RAILS_ENV=test/staging/etc` → `NODE_ENV` defaults to `"development"`

### Fixes
- Dev server now works out of the box without requiring NODE_ENV to be set
- Correctly loads development configuration from shakapacker.yml  
- Uses configured port (e.g., 3035) instead of defaulting to 8080
- Fixes 404 asset loading errors in development

### Changes
- `package/env.ts`: Smart DEFAULT based on RAILS_ENV
- `lib/shakapacker.rb`: Update DEFAULT_ENV to "development"
- Updated all tests to match new behavior
- Updated CHANGELOG.md and docs/v9_upgrade.md

## Test Plan
- [x] JavaScript tests pass (`yarn test`)
- [x] Ruby tests pass (`bundle exec rspec`)
- [x] Linting passes (`bundle exec rubocop`)
- [x] Updated CHANGELOG.md
- [x] Updated v9 upgrade guide documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Changed
  - Default environment now favors development (not production) when NODE_ENV/RAILS_ENV are unset or non-standard; new isProduction/isDevelopment indicators added and dev-server behavior updated.
- Documentation
  - Expanded CHANGELOG with an Unreleased section; upgraded v9 upgrade guide with NODE_ENV rules, CSS Modules named-export guidance, transpiler/bundler (SWC/Rspack) migration notes, peer-dependency guidance, and troubleshooting/migration steps.
- Tests
  - Updated test expectations to reflect the development-first default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->