### PR TITLE
Fix SWC migration to use config/swc.config.js instead of .swcrc (#634)

### DIFF
--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -22,10 +22,10 @@ Set the transpiler in your `config/shakapacker.yml`:
 default: &default
   # For webpack users (babel is default, no change needed)
   javascript_transpiler: babel
-  
+
   # To opt-in to SWC for better performance
   javascript_transpiler: swc
-  
+
   # For rspack users (swc is default, no change needed)
   assets_bundler: rspack
   javascript_transpiler: swc
@@ -53,29 +53,25 @@ default: &default
 
 #### 3. Create SWC configuration (optional)
 
-If you need custom transpilation settings, create `.swcrc`:
+If you need custom transpilation settings, create `config/swc.config.js`:
 
-```json
-{
-  "$schema": "https://json.schemastore.org/swcrc",
-  "jsc": {
-    "parser": {
-      "syntax": "ecmascript",
-      "jsx": true,
-      "dynamicImport": true
-    },
-    "transform": {
-      "react": {
-        "runtime": "automatic"
+```javascript
+// config/swc.config.js
+// This file is merged with Shakapacker's default SWC configuration
+// See: https://swc.rs/docs/configuration/compilation
+
+module.exports = {
+  jsc: {
+    transform: {
+      react: {
+        runtime: "automatic"
       }
-    },
-    "target": "es2015"
-  },
-  "module": {
-    "type": "es6"
+    }
   }
 }
 ```
+
+**Important:** Use `config/swc.config.js` instead of `.swcrc`. The `.swcrc` file completely overrides Shakapacker's default SWC settings and can cause build failures. `config/swc.config.js` properly merges with Shakapacker's defaults.
 
 #### 4. Update React configuration (if using React)
 
@@ -93,11 +89,11 @@ yarn add --dev @rspack/plugin-react-refresh
 
 Typical build time improvements when migrating from Babel to SWC:
 
-| Project Size | Babel | SWC | Improvement |
-|-------------|-------|-----|-------------|
-| Small (<100 files) | 5s | 1s | 5x faster |
-| Medium (100-500 files) | 20s | 3s | 6.7x faster |
-| Large (500+ files) | 60s | 8s | 7.5x faster |
+| Project Size           | Babel | SWC | Improvement |
+| ---------------------- | ----- | --- | ----------- |
+| Small (<100 files)     | 5s    | 1s  | 5x faster   |
+| Medium (100-500 files) | 20s   | 3s  | 6.7x faster |
+| Large (500+ files)     | 60s   | 8s  | 7.5x faster |
 
 ### Compatibility Notes
 
@@ -125,7 +121,7 @@ If you encounter issues, rolling back is simple:
 ```yaml
 # config/shakapacker.yml
 default: &default
-  javascript_transpiler: babel  # Revert to babel
+  javascript_transpiler: babel # Revert to babel
 ```
 
 Then rebuild your application:
@@ -165,20 +161,21 @@ yarn add --dev @swc/core swc-loader
 # Webpack
 yarn add --dev @pmmmwh/react-refresh-webpack-plugin
 
-# Rspack  
+# Rspack
 yarn add --dev @rspack/plugin-react-refresh
 ```
 
 ### Issue: Decorators not working
 
-**Solution**: Enable decorator support in `.swcrc`:
+**Solution**: Enable decorator support in `config/swc.config.js`:
 
-```json
-{
-  "jsc": {
-    "parser": {
-      "decorators": true,
-      "decoratorsBeforeExport": true
+```javascript
+// config/swc.config.js
+module.exports = {
+  jsc: {
+    parser: {
+      decorators: true,
+      decoratorsBeforeExport: true
     }
   }
 }

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -447,6 +447,7 @@ module Shakapacker
         if swcrc_path.exist?
           @warnings << "SWC configuration: .swcrc file detected. This file completely overrides Shakapacker's default SWC settings and may cause build failures. " \
                       "Please migrate to config/swc.config.js which properly merges with Shakapacker defaults. " \
+                      "To migrate: Move your custom settings from .swcrc to config/swc.config.js (see docs for format). " \
                       "See: https://github.com/shakacode/shakapacker/blob/main/docs/using_swc_loader.md"
         end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -442,18 +442,16 @@ module Shakapacker
 
       def check_swc_config_conflicts
         swcrc_path = root_path.join(".swcrc")
-        return unless swcrc_path.exist?
+        swc_config_path = root_path.join("config/swc.config.js")
 
-        begin
-          swcrc = JSON.parse(File.read(swcrc_path))
-          # Check for conflicting jsc.target and env settings
-          if swcrc.dig("jsc", "target") && swcrc["env"]
-            @issues << "SWC configuration conflict: .swcrc contains both 'jsc.target' and 'env' settings, which are mutually exclusive. Remove 'jsc.target' from .swcrc"
-          elsif swcrc.dig("jsc", "target")
-            @warnings << "SWC configuration: .swcrc contains 'jsc.target' which may conflict with the loader's 'env' setting. Consider removing 'jsc.target' from .swcrc to avoid build errors"
-          end
-        rescue JSON::ParserError
-          @warnings << "SWC configuration: .swcrc exists but contains invalid JSON"
+        if swcrc_path.exist?
+          @warnings << "SWC configuration: .swcrc file detected. This file completely overrides Shakapacker's default SWC settings and may cause build failures. " \
+                      "Please migrate to config/swc.config.js which properly merges with Shakapacker defaults. " \
+                      "See: https://github.com/shakacode/shakapacker/blob/main/docs/using_swc_loader.md"
+        end
+
+        if swc_config_path.exist?
+          @info << "SWC configuration: Using config/swc.config.js (recommended). This config is merged with Shakapacker's defaults."
         end
       end
 

--- a/lib/shakapacker/swc_migrator.rb
+++ b/lib/shakapacker/swc_migrator.rb
@@ -182,6 +182,11 @@ module Shakapacker
           begin
             package_json = JSON.parse(File.read(package_json_path))
             if package_json["eslintConfig"]
+              # Check parser field explicitly
+              parser = package_json["eslintConfig"]["parser"]
+              return true if parser && parser.match?(/@babel\/eslint-parser|babel-eslint/)
+
+              # Also check entire config for babel parser references (catches nested configs)
               return true if package_json["eslintConfig"].to_json.match?(/@babel\/eslint-parser|babel-eslint/)
             end
 

--- a/lib/shakapacker/swc_migrator.rb
+++ b/lib/shakapacker/swc_migrator.rb
@@ -8,8 +8,9 @@ module Shakapacker
   class SwcMigrator
     attr_reader :root_path, :logger
 
+    # Babel packages safe to remove when migrating to SWC
+    # Note: @babel/core and @babel/eslint-parser are excluded as they may be needed for ESLint
     BABEL_PACKAGES = [
-      "@babel/core",
       "@babel/plugin-proposal-class-properties",
       "@babel/plugin-proposal-object-rest-spread",
       "@babel/plugin-syntax-dynamic-import",
@@ -23,6 +24,12 @@ module Shakapacker
       "babel-loader",
       "babel-plugin-macros",
       "babel-plugin-transform-react-remove-prop-types"
+    ].freeze
+
+    # Babel packages that may be needed for ESLint - only remove if user explicitly confirms
+    ESLINT_BABEL_PACKAGES = [
+      "@babel/core",
+      "@babel/eslint-parser"
     ].freeze
 
     SWC_PACKAGES = {
@@ -39,23 +46,21 @@ module Shakapacker
       .eslintrc.json
     ].freeze
 
-    DEFAULT_SWCRC_CONFIG = {
-      "jsc" => {
-        "parser" => {
-          "syntax" => "ecmascript",
-          "jsx" => true,
-          "dynamicImport" => true
-        },
-        "transform" => {
-          "react" => {
-            "runtime" => "automatic"
+    DEFAULT_SWC_CONFIG = <<~JS.freeze
+      // config/swc.config.js
+      // This file is merged with Shakapacker's default SWC configuration
+      // See: https://swc.rs/docs/configuration/compilation
+
+      module.exports = {
+        jsc: {
+          transform: {
+            react: {
+              runtime: "automatic"
+            }
           }
         }
-      },
-      "module" => {
-        "type" => "es6"
       }
-    }.freeze
+    JS
 
     def initialize(root_path, logger: nil)
       @root_path = Pathname.new(root_path)
@@ -68,7 +73,7 @@ module Shakapacker
       results = {
         config_updated: update_shakapacker_config,
         packages_installed: install_swc_packages,
-        swcrc_created: create_swcrc,
+        swc_config_created: create_swc_config,
         babel_packages_found: find_babel_packages
       }
 
@@ -76,9 +81,9 @@ module Shakapacker
       logger.info "   Note: SWC is approximately 20x faster than Babel for transpilation."
       logger.info "   Please test your application thoroughly after migration."
       logger.info "\n📝 Configuration Info:"
-      logger.info "   - .swcrc provides base configuration for all environments"
-      logger.info "   - The SWC loader adds automatic environment targeting (via 'env' setting)"
-      logger.info "   - You can customize .swcrc, but avoid setting 'jsc.target' as it conflicts with 'env'"
+      logger.info "   - config/swc.config.js is merged with Shakapacker's default SWC configuration"
+      logger.info "   - You can customize config/swc.config.js to add additional options"
+      logger.info "   - Avoid using .swcrc as it overrides Shakapacker defaults completely"
 
       # Show cleanup recommendations if babel packages found
       if results[:babel_packages_found].any?
@@ -108,20 +113,21 @@ module Shakapacker
       package_json_path = root_path.join("package.json")
       unless package_json_path.exist?
         logger.error "❌ No package.json found"
-        return { removed_packages: [], config_files_deleted: [] }
+        return { removed_packages: [], config_files_deleted: [], preserved_packages: [] }
       end
 
       # Check if ESLint uses Babel parser
+      preserved_for_eslint = []
       if eslint_uses_babel?
-        logger.info "\n⚠️  WARNING: ESLint configuration detected that may use Babel"
-        logger.info "   If you use @babel/eslint-parser or babel-eslint, you may need to:"
-        logger.info "   1. Keep @babel/core and related Babel packages for ESLint"
-        logger.info "   2. Or switch to @typescript-eslint/parser for TypeScript files"
-        logger.info "   3. Or use espree (ESLint's default parser) for JavaScript files"
-        logger.info "\n   Proceeding with Babel package removal. Check your ESLint config after."
+        logger.info "\n⚠️  ESLint configuration detected that uses Babel parser"
+        logger.info "   Preserving @babel/core and @babel/eslint-parser for ESLint compatibility"
+        logger.info "   To switch ESLint parser:"
+        logger.info "   1. For TypeScript: use @typescript-eslint/parser"
+        logger.info "   2. For JavaScript: use espree (ESLint's default parser)"
+        preserved_for_eslint = ESLINT_BABEL_PACKAGES
       end
 
-      removed_packages = remove_babel_from_package_json(package_json_path)
+      removed_packages = remove_babel_from_package_json(package_json_path, preserve: preserved_for_eslint)
       deleted_files = delete_babel_config_files
 
       if removed_packages.any?
@@ -131,7 +137,7 @@ module Shakapacker
         logger.info "ℹ️  No Babel packages found to remove"
       end
 
-      { removed_packages: removed_packages, config_files_deleted: deleted_files }
+      { removed_packages: removed_packages, config_files_deleted: deleted_files, preserved_packages: preserved_for_eslint }
     end
 
     def find_babel_packages
@@ -144,7 +150,9 @@ module Shakapacker
         dev_dependencies = package_json["devDependencies"] || {}
         all_deps = dependencies.merge(dev_dependencies)
 
-        found_packages = BABEL_PACKAGES.select { |pkg| all_deps.key?(pkg) }
+        # Find all babel packages (including ESLint-related ones for display)
+        all_babel_packages = BABEL_PACKAGES + ESLINT_BABEL_PACKAGES
+        found_packages = all_babel_packages.select { |pkg| all_deps.key?(pkg) }
         found_packages
       rescue JSON::ParserError => e
         logger.error "Failed to parse package.json: #{e.message}"
@@ -254,29 +262,35 @@ module Shakapacker
         {}
       end
 
-      def create_swcrc
-        swcrc_path = root_path.join(".swcrc")
-        if swcrc_path.exist?
-          logger.info "ℹ️  .swcrc already exists"
+      def create_swc_config
+        config_dir = root_path.join("config")
+        swc_config_path = config_dir.join("swc.config.js")
+
+        if swc_config_path.exist?
+          logger.info "ℹ️  config/swc.config.js already exists"
           return false
         end
 
-        logger.info "📄 Creating .swcrc configuration..."
-        File.write(swcrc_path, JSON.pretty_generate(DEFAULT_SWCRC_CONFIG) + "\n")
-        logger.info "✅ .swcrc created"
+        FileUtils.mkdir_p(config_dir) unless config_dir.exist?
+
+        logger.info "📄 Creating config/swc.config.js..."
+        File.write(swc_config_path, DEFAULT_SWC_CONFIG)
+        logger.info "✅ config/swc.config.js created"
         true
       rescue StandardError => e
-        logger.error "Failed to create .swcrc: #{e.message}"
+        logger.error "Failed to create config/swc.config.js: #{e.message}"
         false
       end
 
-      def remove_babel_from_package_json(package_json_path)
+      def remove_babel_from_package_json(package_json_path, preserve: [])
         package_json = JSON.parse(File.read(package_json_path))
         dependencies = package_json["dependencies"] || {}
         dev_dependencies = package_json["devDependencies"] || {}
         removed_packages = []
 
         BABEL_PACKAGES.each do |package|
+          next if preserve.include?(package)
+
           if dependencies.delete(package)
             removed_packages << package
             logger.info "  - Removed #{package} from dependencies"
@@ -284,6 +298,13 @@ module Shakapacker
           if dev_dependencies.delete(package)
             removed_packages << package
             logger.info "  - Removed #{package} from devDependencies"
+          end
+        end
+
+        # Log preserved packages
+        preserve.each do |package|
+          if dependencies[package] || dev_dependencies[package]
+            logger.info "  - Preserved #{package} (needed for ESLint)"
           end
         end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -854,7 +854,7 @@ describe Shakapacker::Doctor do
         end
       end
 
-      context "with SWC config containing jsc.target" do
+      context "with .swcrc file (deprecated)" do
         before do
           package_json = {
             "devDependencies" => {
@@ -873,13 +873,13 @@ describe Shakapacker::Doctor do
           }))
         end
 
-        it "warns about potential config conflict" do
+        it "warns about .swcrc anti-pattern" do
           doctor.send(:check_javascript_transpiler_dependencies)
-          expect(doctor.warnings).to include(match(/SWC configuration.*jsc\.target.*may conflict/))
+          expect(doctor.warnings).to include(match(/\.swcrc file detected.*overrides Shakapacker's default.*migrate to config\/swc\.config\.js/))
         end
       end
 
-      context "with SWC config containing both jsc.target and env" do
+      context "with config/swc.config.js file (recommended)" do
         before do
           package_json = {
             "devDependencies" => {
@@ -888,19 +888,13 @@ describe Shakapacker::Doctor do
             }
           }
           File.write(package_json_path, JSON.generate(package_json))
-          File.write(root_path.join(".swcrc"), JSON.generate({
-            "jsc" => {
-              "target" => "es2015"
-            },
-            "env" => {
-              "targets" => "defaults"
-            }
-          }))
+          FileUtils.mkdir_p(root_path.join("config"))
+          File.write(root_path.join("config/swc.config.js"), "module.exports = {}")
         end
 
-        it "reports a configuration error" do
+        it "shows info about using recommended config" do
           doctor.send(:check_javascript_transpiler_dependencies)
-          expect(doctor.issues).to include(match(/SWC configuration conflict.*both 'jsc\.target' and 'env'/))
+          expect(doctor.info).to include(match(/Using config\/swc\.config\.js \(recommended\)/))
         end
       end
     end


### PR DESCRIPTION
## Summary

Fixes #634 - The `rake shakapacker:migrate_to_swc` task now creates `config/swc.config.js` instead of `.swcrc`, fixing three critical issues that made the migration task broken for most users.

## Changes Made

### 1. Configuration File Change
- **Changed**: Migration now creates `config/swc.config.js` instead of `.swcrc`
- **Why**: `.swcrc` completely overrides Shakapacker's default SWC settings, bypassing webpack-merge
- **Benefit**: `config/swc.config.js` properly merges with Shakapacker's defaults, preserving important settings like `loose: true`, `env.coreJs: 3`, source maps, and dynamic parser configuration

### 2. ESLint Dependencies Preserved
- **Split**: `BABEL_PACKAGES` into safe-to-remove packages and ESLint-related packages (`ESLINT_BABEL_PACKAGES`)
- **Preserved**: `@babel/core` and `@babel/eslint-parser` when ESLint uses them
- **Why**: Many projects (like those using `eslint-config-shakacode`) require these packages for ESLint to work
- **Improved**: Warning messages now explain how to migrate ESLint parser if desired

### 3. Doctor Check Updates
- **Added**: Warning when `.swcrc` file is detected (anti-pattern)
- **Removed**: Obsolete `jsc.target`/`env` conflict checks (no longer generated)
- **Added**: Info message when using recommended `config/swc.config.js`

### 4. Documentation Updates
- **Updated**: `transpiler-migration.md` to show `config/swc.config.js` instead of `.swcrc`
- **Added**: Important note explaining `.swcrc` vs `config/swc.config.js` difference
- **Fixed**: Decorator example to use recommended config file format

## Testing

- ✅ All RSpec tests updated and passing
- ✅ RuboCop clean
- ✅ JavaScript linting clean
- ✅ Both SwcMigrator and Doctor specs updated

## Breaking Changes

None - this is a bug fix that makes the migration task actually work correctly.

## Migration Path

Existing users with `.swcrc` files will:
1. Get a warning from `shakapacker:doctor` to migrate to `config/swc.config.js`
2. Can manually migrate by moving their custom settings to `config/swc.config.js`
3. New migrations will automatically use the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)