### PR TITLE
Fix private method 'data' error in shakapacker:doctor task

### DIFF
--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -65,12 +65,12 @@ module Shakapacker
 
       def check_entry_points
         # Check for invalid configuration first
-        if config.data[:source_entry_path] == "/" && config.nested_entries?
+        if config.fetch(:source_entry_path) == "/" && config.nested_entries?
           @issues << "Invalid configuration: cannot use '/' as source_entry_path with nested_entries: true"
           return  # Don't try to check files when config is invalid
         end
 
-        source_entry_path = config.source_path.join(config.data[:source_entry_path] || "packs")
+        source_entry_path = config.source_path.join(config.fetch(:source_entry_path) || "packs")
 
         unless source_entry_path.exist?
           @issues << "Source entry path #{source_entry_path} does not exist"
@@ -173,7 +173,8 @@ module Shakapacker
       end
 
       def check_sri_dependencies
-        return unless config.data.dig(:integrity, :enabled)
+        integrity_config = config.integrity
+        return unless integrity_config && integrity_config[:enabled]
 
         bundler = config.assets_bundler
         if bundler == "webpack"
@@ -183,7 +184,7 @@ module Shakapacker
         end
 
         # Validate hash functions
-        hash_functions = config.data.dig(:integrity, :hash_functions) || ["sha384"]
+        hash_functions = integrity_config[:hash_functions] || ["sha384"]
         invalid_functions = hash_functions - ["sha256", "sha384", "sha512"]
         unless invalid_functions.empty?
           @issues << "Invalid SRI hash functions: #{invalid_functions.join(', ')}"

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -174,7 +174,7 @@ module Shakapacker
 
       def check_sri_dependencies
         integrity_config = config.integrity
-        return unless integrity_config && integrity_config[:enabled]
+        return unless integrity_config&.dig(:enabled)
 
         bundler = config.assets_bundler
         if bundler == "webpack"
@@ -184,7 +184,7 @@ module Shakapacker
         end
 
         # Validate hash functions
-        hash_functions = integrity_config[:hash_functions] || ["sha384"]
+        hash_functions = integrity_config.dig(:hash_functions) || ["sha384"]
         invalid_functions = hash_functions - ["sha256", "sha384", "sha512"]
         unless invalid_functions.empty?
           @issues << "Invalid SRI hash functions: #{invalid_functions.join(', ')}"

--- a/spec/shakapacker/doctor_optional_peer_spec.rb
+++ b/spec/shakapacker/doctor_optional_peer_spec.rb
@@ -33,7 +33,10 @@ describe "Shakapacker::Doctor with optional peer dependencies" do
            assets_bundler: assets_bundler,
            data: config_data,
            nested_entries?: false,
-           ensure_consistent_versioning?: false)
+           ensure_consistent_versioning?: false,
+           integrity: config_data[:integrity]).tap do |c|
+      allow(c).to receive(:fetch) { |key| config_data[key] }
+    end
   end
 
   let(:javascript_transpiler) { "babel" }

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -32,7 +32,10 @@ describe Shakapacker::Doctor do
            assets_bundler: "webpack",
            data: config_data,
            nested_entries?: false,
-           ensure_consistent_versioning?: false)
+           ensure_consistent_versioning?: false,
+           integrity: config_data[:integrity]).tap do |c|
+      allow(c).to receive(:fetch) { |key| config_data[key] }
+    end
   end
 
   let(:doctor) { described_class.new(config, root_path) }
@@ -145,7 +148,7 @@ describe Shakapacker::Doctor do
 
     context "with invalid nested_entries configuration" do
       before do
-        allow(config).to receive(:data).and_return({ source_entry_path: "/" })
+        allow(config).to receive(:fetch).with(:source_entry_path).and_return("/")
         allow(config).to receive(:nested_entries?).and_return(true)
         allow(config).to receive(:source_path).and_return(source_path)
       end
@@ -312,11 +315,9 @@ describe Shakapacker::Doctor do
   describe "SRI dependency checks" do
     context "when SRI is enabled" do
       before do
-        allow(config).to receive(:data).and_return({
-          integrity: {
-            enabled: true,
-            hash_functions: ["sha384"]
-          }
+        allow(config).to receive(:integrity).and_return({
+          enabled: true,
+          hash_functions: ["sha384"]
         })
       end
 
@@ -333,11 +334,9 @@ describe Shakapacker::Doctor do
 
       context "with invalid hash functions" do
         before do
-          allow(config).to receive(:data).and_return({
-            integrity: {
-              enabled: true,
-              hash_functions: ["md5", "sha384"]
-            }
+          allow(config).to receive(:integrity).and_return({
+            enabled: true,
+            hash_functions: ["md5", "sha384"]
           })
         end
 


### PR DESCRIPTION
## Summary
- Fixes NoMethodError when running `bin/rails shakapacker:doctor`
- Replaced private `config.data` access with public API methods
- Updated test mocks to support the new implementation

## Problem
The `shakapacker:doctor` rake task was failing with:
```
NoMethodError: private method 'data' called for an instance of Shakapacker::Configuration
```

This occurred because `lib/shakapacker/doctor.rb` was directly accessing the private `data` method of the Configuration class.

## Solution
- Replace `config.data[:source_entry_path]` with `config.fetch(:source_entry_path)`
- Replace `config.data.dig(:integrity, :enabled)` with `config.integrity[:enabled]`
- Update test mocks to support both `fetch` and `integrity` public methods

## Test Plan
- [x] All existing doctor specs pass
- [x] RuboCop passes with no offenses
- [x] Tested that the fix resolves the original error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Clearer validation for missing entry points with more informative errors.
- Bug Fixes
  - More robust handling of Subresource Integrity, honoring the enabled flag and defaulting to a sensible hash when unspecified.
- Refactor
  - Improved configuration access for greater reliability and nil-safety.
- Tests
  - Updated tests to reflect the new configuration access patterns and cover integrity-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->