### PR TITLE
Fix migrate_to_swc commands in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
    - Babel dependencies are no longer included as peer dependencies
    - Improves compilation speed by 20x
    - **Migration for existing projects:**
-     - **Option 1 (Recommended):** Switch to SWC - Run `rake shakapacker:migrate:to_swc` or manually:
+     - **Option 1 (Recommended):** Switch to SWC - Run `rake shakapacker:migrate_to_swc` or manually:
        ```yaml
        # config/shakapacker.yml
        javascript_transpiler: "swc"
@@ -59,7 +59,7 @@ See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/do
 - **Private output path** for server-side rendering bundles ([PR 592](https://github.com/shakacode/shakapacker/pull/592))
   - Configure `private_output_path` for private server bundles separate from public assets
 - **`rake shakapacker:doctor` diagnostic command** to check for configuration issues and missing dependencies ([PR 609](https://github.com/shakacode/shakapacker/pull/609))
-- **`rake shakapacker:migrate:to_swc`** migration helper to assist with switching from Babel to SWC ([PR 613](https://github.com/shakacode/shakapacker/pull/613), [PR 635](https://github.com/shakacode/shakapacker/pull/635))
+- **`rake shakapacker:migrate_to_swc`** migration helper to assist with switching from Babel to SWC ([PR 613](https://github.com/shakacode/shakapacker/pull/613), [PR 635](https://github.com/shakacode/shakapacker/pull/635))
 
 ### Security
 


### PR DESCRIPTION
### Summary
The rake command previously referenced didn't seem to be valid, and directed me to the one I've corrected it to.

It's worth nothing that this rake command didn't seem to take care of renaming `webpack_loader` → `javascript_transpiler`, only changing `webpack_loader: "babel"` → `webpack_loader: "swc"`. Maybe that's intentional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration instructions to use the renamed command: rake shakapacker:migrate_to_swc.
  * Replaced all references to the old command in the changelog and example snippets.

* **Chores**
  * Standardized the public migration command name from shakapacker:migrate:to_swc to shakapacker:migrate_to_swc across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->