### PR TITLE
Replace TypeScript any types with unknown and import RspackPluginInstance (#643)

### DIFF
--- a/package/environments/types.ts
+++ b/package/environments/types.ts
@@ -3,8 +3,15 @@
  * These types are exported for consumer use
  */
 
-import type { Configuration as WebpackConfiguration, WebpackPluginInstance } from "webpack"
+import type {
+  Configuration as WebpackConfiguration,
+  WebpackPluginInstance
+} from "webpack"
 import type { Configuration as DevServerConfiguration } from "webpack-dev-server"
+import type {
+  RspackPluginInstance as ImportedRspackPluginInstance,
+  Compiler
+} from "@rspack/core"
 
 /**
  * Webpack configuration extended with dev server support
@@ -16,13 +23,16 @@ export interface WebpackConfigWithDevServer extends WebpackConfiguration {
 
 /**
  * Rspack plugin interface
+ * Uses the RspackPluginInstance type from @rspack/core
+ */
+export type RspackPluginInstance = ImportedRspackPluginInstance
+
+/**
+ * Rspack plugin constructor interface
  * Rspack plugins follow a similar pattern to webpack but may have different internals
  */
 export interface RspackPlugin {
-  new(...args: any[]): {
-    apply(compiler: any): void
-    [key: string]: any
-  }
+  new (...args: unknown[]): RspackPluginInstance
 }
 
 /**
@@ -52,7 +62,7 @@ export interface RspackConfigWithDevServer {
   mode?: "development" | "production" | "none"
   devtool?: string | false
   devServer?: RspackDevServerConfig
-  plugins?: RspackPlugin[]
+  plugins?: RspackPluginInstance[]
   module?: WebpackConfiguration["module"]
   resolve?: WebpackConfiguration["resolve"]
   entry?: WebpackConfiguration["entry"]
@@ -76,15 +86,17 @@ export interface CompressionPluginOptions {
 /**
  * Compression plugin constructor type
  */
-export type CompressionPluginConstructor = new (options: CompressionPluginOptions) => WebpackPluginInstance
+export type CompressionPluginConstructor = new (
+  options: CompressionPluginOptions
+) => WebpackPluginInstance
 
 /**
  * React Refresh plugin types
  */
 export interface ReactRefreshWebpackPlugin {
-  new(options?: Record<string, unknown>): WebpackPluginInstance
+  new (options?: Record<string, unknown>): WebpackPluginInstance
 }
 
 export interface ReactRefreshRspackPlugin {
-  new(options?: Record<string, unknown>): RspackPlugin
+  new (options?: Record<string, unknown>): RspackPlugin
 }

--- a/package/index.ts
+++ b/package/index.ts
@@ -16,18 +16,21 @@ const inliningCss = require("./utils/inliningCss")
 const rulesPath = resolve(__dirname, "rules", `${config.assets_bundler}.js`)
 const rules = require(rulesPath)
 
-const generateWebpackConfig = (extraConfig: Configuration = {}, ...extraArgs: any[]): Configuration => {
+const generateWebpackConfig = (
+  extraConfig: Configuration = {},
+  ...extraArgs: unknown[]
+): Configuration => {
   if (extraArgs.length > 0) {
     throw new Error(
       `Invalid usage: generateWebpackConfig() accepts only one configuration object.\n\n` +
-      `You passed ${extraArgs.length + 1} arguments. Only one extra config may be passed here - use webpack-merge to merge configs before passing them to Shakapacker.\n\n` +
-      `Example:\n` +
-      `  const { merge } = require('webpack-merge')\n` +
-      `  const mergedConfig = merge(config1, config2, config3)\n` +
-      `  const finalConfig = generateWebpackConfig(mergedConfig)\n\n` +
-      `Or if using ES6:\n` +
-      `  import { merge } from 'webpack-merge'\n` +
-      `  const finalConfig = generateWebpackConfig(merge(config1, config2))`
+        `You passed ${extraArgs.length + 1} arguments. Only one extra config may be passed here - use webpack-merge to merge configs before passing them to Shakapacker.\n\n` +
+        `Example:\n` +
+        `  const { merge } = require('webpack-merge')\n` +
+        `  const mergedConfig = merge(config1, config2, config3)\n` +
+        `  const finalConfig = generateWebpackConfig(mergedConfig)\n\n` +
+        `Or if using ES6:\n` +
+        `  import { merge } from 'webpack-merge'\n` +
+        `  const finalConfig = generateWebpackConfig(merge(config1, config2))`
     )
   }
 

--- a/package/utils/debug.ts
+++ b/package/utils/debug.ts
@@ -16,24 +16,24 @@ const isDebugMode = (): boolean => {
   )
 }
 
-const debug = (message: string, ...args: any[]): void => {
+const debug = (message: string, ...args: unknown[]): void => {
   if (isDebugMode()) {
     // eslint-disable-next-line no-console
     console.log(`[Shakapacker] ${message}`, ...args)
   }
 }
 
-const warn = (message: string, ...args: any[]): void => {
+const warn = (message: string, ...args: unknown[]): void => {
   // eslint-disable-next-line no-console
   console.warn(`[Shakapacker] WARNING: ${message}`, ...args)
 }
 
-const error = (message: string, ...args: any[]): void => {
+const error = (message: string, ...args: unknown[]): void => {
   // eslint-disable-next-line no-console
   console.error(`[Shakapacker] ERROR: ${message}`, ...args)
 }
 
-const info = (message: string, ...args: any[]): void => {
+const info = (message: string, ...args: unknown[]): void => {
   if (isDebugMode()) {
     // eslint-disable-next-line no-console
     console.info(`[Shakapacker] INFO: ${message}`, ...args)


### PR DESCRIPTION
## Summary
- Replaced `any[]` with `unknown[]` in debug.ts logging functions (debug, warn, error, info)
- Replaced `any[]` with `unknown[]` in index.ts `generateWebpackConfig` extraArgs parameter
- Imported `RspackPluginInstance` from `@rspack/core` and use it in types.ts
- Replaced `any[]` with `unknown[]` in `RspackPlugin` constructor interface
- Updated `RspackConfigWithDevServer` to use `RspackPluginInstance[]` instead of `RspackPlugin[]`

This improves type safety by replacing overly-permissive `any` types with `unknown` where appropriate, and importing proper types from `@rspack/core` for better type checking and IDE support.

## Test plan
- Verified TypeScript compilation with `yarn build:types`
- Verified linting with `yarn lint`
- Verified type checking with `yarn tsc --noEmit`

Fixes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)