### PR TITLE
Make RspackPlugin an alias for RspackPluginInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 Changes since the last non-beta release.
 
+### Fixed
+
+- Restore `RspackPlugin` type as an alias to `RspackPluginInstance` for backward compatibility. The type is now deprecated in favor of `RspackPluginInstance`. [#650](https://github.com/shakacode/shakapacker/issues/650)
+
 ## [v9.0.0] - October 5, 2025
 
 See the [v9 Upgrade Guide](https://github.com/shakacode/shakapacker/blob/main/docs/v9_upgrade.md) for detailed migration instructions.

--- a/docs/typescript-migration.md
+++ b/docs/typescript-migration.md
@@ -254,7 +254,8 @@ npm run type-check
 - `WebpackConfigWithDevServer` - Webpack configuration with dev server
 - `RspackConfigWithDevServer` - Rspack configuration with dev server
 - `WebpackPluginInstance` - Webpack plugin instance type
-- `RspackPlugin` - Rspack plugin interface
+- `RspackPluginInstance` - Rspack plugin instance type
+- `RspackPlugin` - **⚠️ Deprecated:** Use `RspackPluginInstance` instead
 
 ### Helper Types
 - `CompressionPluginOptions` - Compression plugin configuration

--- a/package/environments/__type-tests__/rspack-plugin-compatibility.ts
+++ b/package/environments/__type-tests__/rspack-plugin-compatibility.ts
@@ -1,0 +1,30 @@
+/**
+ * Compile-time type tests for RspackPlugin backward compatibility
+ * This file ensures that RspackPlugin is correctly aliased to RspackPluginInstance
+ * and maintains backward compatibility for existing consumers.
+ *
+ * These tests will fail at compile time if the types are not compatible.
+ */
+
+import type { RspackPlugin, RspackPluginInstance } from '../types'
+
+// Test 1: RspackPlugin should be assignable to RspackPluginInstance
+const testPluginToInstance = (plugin: RspackPlugin): RspackPluginInstance => plugin
+
+// Test 2: RspackPluginInstance should be assignable to RspackPlugin
+const testInstanceToPlugin = (instance: RspackPluginInstance): RspackPlugin => instance
+
+// Test 3: Array compatibility
+const testArrayCompatibility = (plugins: RspackPlugin[]): RspackPluginInstance[] => plugins
+const testArrayCompatibilityReverse = (
+  instances: RspackPluginInstance[]
+): RspackPlugin[] => instances
+
+// Test 4: Optional parameter compatibility
+const testOptionalParam = (plugin?: RspackPlugin): RspackPluginInstance | undefined => plugin
+const testOptionalParamReverse = (
+  instance?: RspackPluginInstance
+): RspackPlugin | undefined => instance
+
+// Export a dummy value to make this a module
+export const __typeTestsComplete = true

--- a/package/environments/types.ts
+++ b/package/environments/types.ts
@@ -19,18 +19,17 @@ export interface WebpackConfigWithDevServer extends WebpackConfiguration {
 }
 
 /**
- * Rspack plugin interface
+ * Rspack plugin instance interface
  * Uses the RspackPluginInstance type from @rspack/core
  */
 export type RspackPluginInstance = ImportedRspackPluginInstance
 
 /**
- * Rspack plugin constructor interface
- * Rspack plugins follow a similar pattern to webpack but may have different internals
+ * Rspack plugin type alias
+ * @deprecated Use RspackPluginInstance instead
+ * Retained for backward compatibility with existing code
  */
-export interface RspackPlugin {
-  new (...args: unknown[]): RspackPluginInstance
-}
+export type RspackPlugin = RspackPluginInstance
 
 /**
  * Rspack dev server configuration

--- a/package/types/README.md
+++ b/package/types/README.md
@@ -41,7 +41,8 @@ import type {
 ### Webpack/Rspack Types
 - `WebpackConfigWithDevServer` - Webpack config with dev server
 - `RspackConfigWithDevServer` - Rspack config with dev server
-- `RspackPlugin` - Rspack plugin interface
+- `RspackPluginInstance` - Rspack plugin instance type
+- `RspackPlugin` - **⚠️ Deprecated:** Use `RspackPluginInstance` instead
 - `RspackDevServerConfig` - Rspack dev server configuration
 - `CompressionPluginOptions` - Options for compression plugin
 - `CompressionPluginConstructor` - Constructor type for compression plugin

--- a/package/types/index.ts
+++ b/package/types/index.ts
@@ -40,6 +40,7 @@ export type {
 // Environment configuration types
 export type {
   WebpackConfigWithDevServer,
+  RspackPluginInstance,
   RspackPlugin,
   RspackDevServerConfig,
   RspackConfigWithDevServer,


### PR DESCRIPTION
## Summary
- Makes `RspackPlugin` a type alias for `RspackPluginInstance` to restore backward compatibility
- Marks `RspackPlugin` as deprecated to encourage migration to `RspackPluginInstance`
- Fixes issue where users depending on the exported `RspackPlugin` type experienced breaking changes

## Context
In PR #643, the `RspackPlugin` type was changed from representing a plugin instance to a constructor interface. This broke backward compatibility for users who were using the exported type.

The original `RspackPlugin` had the same shape as the current `RspackPluginInstance`. By making it an alias, we restore the original behavior while providing a migration path.

## Test Plan
- [x] TypeScript type checking passes (`yarn type-check`)
- [x] Linting passes (`yarn lint`)
- [x] Existing code using `RspackPlugin` will now work correctly
- [x] Type is marked as deprecated to guide future usage

Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * RspackPlugin is now an alias of the new RspackPluginInstance type (deprecated alias retained for compatibility).

* **Documentation**
  * Docs updated to prefer RspackPluginInstance and note RspackPlugin deprecation; examples and imports standardized.

* **Tests**
  * Added compile-time type checks to validate compatibility between the old alias and RspackPluginInstance.

* **Chores**
  * Changelog updated to record the compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->