### PR TITLE
[TEST] Add backward-compatible alias for RspackPlugin type

### DIFF
--- a/package/environments/types.ts
+++ b/package/environments/types.ts
@@ -19,16 +19,23 @@ export interface WebpackConfigWithDevServer extends WebpackConfiguration {
 }
 
 /**
- * Rspack plugin interface
+ * Rspack plugin instance interface
  * Uses the RspackPluginInstance type from @rspack/core
  */
 export type RspackPluginInstance = ImportedRspackPluginInstance
 
 /**
+ * @deprecated Use RspackPluginInstance instead. This alias is provided for backward compatibility.
+ * In versions prior to the introduction of RspackPluginInstance, RspackPlugin represented
+ * the plugin instance shape. It now aliases to RspackPluginInstance.
+ */
+export type RspackPlugin = RspackPluginInstance
+
+/**
  * Rspack plugin constructor interface
  * Rspack plugins follow a similar pattern to webpack but may have different internals
  */
-export interface RspackPlugin {
+export interface RspackPluginConstructor {
   new (...args: unknown[]): RspackPluginInstance
 }
 

--- a/package/types/index.ts
+++ b/package/types/index.ts
@@ -17,7 +17,7 @@ export type {
   LegacyConfig,
   Env,
   DevServerConfig
-} from '../types'
+} from "../types"
 
 // Loader types
 export type {
@@ -25,7 +25,7 @@ export type {
   ShakapackerLoaderOptions,
   LoaderResolver,
   LoaderConfig
-} from '../loaders'
+} from "../loaders"
 
 // Webpack-specific types
 export type {
@@ -35,19 +35,21 @@ export type {
   ShakapackerLoader as WebpackLoader,
   LoaderType,
   LoaderUtils
-} from '../webpack-types'
+} from "../webpack-types"
 
 // Environment configuration types
 export type {
   WebpackConfigWithDevServer,
+  RspackPluginInstance,
   RspackPlugin,
+  RspackPluginConstructor,
   RspackDevServerConfig,
   RspackConfigWithDevServer,
   CompressionPluginOptions,
   CompressionPluginConstructor,
   ReactRefreshWebpackPlugin,
   ReactRefreshRspackPlugin
-} from '../environments/types'
+} from "../environments/types"
 
 // Node.js error type (re-exported for convenience)
 export type NodeJSError = NodeJS.ErrnoException
@@ -57,4 +59,4 @@ export type {
   Configuration as WebpackConfiguration,
   WebpackPluginInstance,
   RuleSetRule
-} from 'webpack'
+} from "webpack"


### PR DESCRIPTION
Restore backward compatibility for users depending on the RspackPlugin type by aliasing it to RspackPluginInstance. The constructor interface is now exported as RspackPluginConstructor.

Fixes #650

### Summary

<!--
  Describe the code changes in your pull request here - were there any bugs you had fixed, features you added, tradeoffs you made?
  If so, mention them. If these changes have open GitHub issues, tag them here as well to keep the conversation linked.
-->

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->
