### PR TITLE
Fix SwcMigrator to use javascript_transpiler config instead of unused swc flag

### DIFF
--- a/lib/shakapacker/swc_migrator.rb
+++ b/lib/shakapacker/swc_migrator.rb
@@ -230,8 +230,8 @@ module Shakapacker
             settings.delete("babel")
           end
 
-          settings["swc"] = true
-          logger.info "  - Enabled SWC for #{env} environment"
+          settings["javascript_transpiler"] = "swc"
+          logger.info "  - Set javascript_transpiler to 'swc' for #{env} environment"
         end
 
         File.write(config_path, config.to_yaml)

--- a/spec/shakapacker/swc_migrator_spec.rb
+++ b/spec/shakapacker/swc_migrator_spec.rb
@@ -59,12 +59,12 @@ describe Shakapacker::SwcMigrator do
         rescue ArgumentError
           YAML.load_file(root_path.join("config/shakapacker.yml"))
         end
-        expect(config["default"]["swc"]).to eq(true)
+        expect(config["default"]["javascript_transpiler"]).to eq("swc")
         expect(config["default"]["babel"]).to be_nil
         expect(config["development"]["babel"]).to be_nil
-        expect(config["development"]["swc"]).to eq(true)
+        expect(config["development"]["javascript_transpiler"]).to eq("swc")
         expect(config["production"]["babel"]).to be_nil
-        expect(config["production"]["swc"]).to eq(true)
+        expect(config["production"]["javascript_transpiler"]).to eq("swc")
       end
 
       it "installs SWC packages" do


### PR DESCRIPTION
## Summary
- Fixed SwcMigrator to set `javascript_transpiler: "swc"` instead of the unused `swc: true` flag
- Updated test expectations to verify the correct configuration is set

## Problem
The `swc: true` setting added by SwcMigrator was not used anywhere in the codebase. The transpiler is actually determined by the `javascript_transpiler` configuration option (as seen in `lib/shakapacker/configuration.rb:120-133` and `package/config.ts:141-165`).

This meant that running `rails shakapacker:migrate_to_swc` would:
1. Install SWC packages ✅
2. Create swc.config.js ✅
3. Remove babel config ✅
4. Add `swc: true` to shakapacker.yml ❌ (unused)
5. BUT NOT actually configure SWC as the transpiler ❌

## Solution
Changed SwcMigrator to set `javascript_transpiler: "swc"` which is the actual configuration option that determines which transpiler to use.

## Test plan
- [x] Run `bundle exec rspec spec/shakapacker/swc_migrator_spec.rb` - all tests pass
- [x] Run `bundle exec rubocop` - no violations

Fixes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)