### PR TITLE
Fix Ruby specs badge to reference correct workflow name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Official, actively maintained successor to [rails/webpacker](https://github.com
 - See [V7 Upgrade](./docs/v7_upgrade.md) for upgrading from the v6 release.
 - See [V6 Upgrade](./docs/v6_upgrade.md) for upgrading from v5 or prior v6 releases.
 
-[![Ruby specs](https://github.com/shakacode/shakapacker/workflows/Ruby%20specs/badge.svg)](https://github.com/shakacode/shakapacker/actions)
+[![Ruby based checks](https://github.com/shakacode/shakapacker/workflows/Ruby%20based%20checks/badge.svg)](https://github.com/shakacode/shakapacker/actions)
 [![Jest specs](https://github.com/shakacode/shakapacker/workflows/Jest%20specs/badge.svg)](https://github.com/shakacode/shakapacker/actions)
 [![Rubocop](https://github.com/shakacode/shakapacker/workflows/Rubocop/badge.svg)](https://github.com/shakacode/shakapacker/actions)
 [![JS lint](https://github.com/shakacode/shakapacker/workflows/JS%20lint/badge.svg)](https://github.com/shakacode/shakapacker/actions)


### PR DESCRIPTION
## Summary
- Fixed the Ruby specs badge in README to reference the correct workflow name "Ruby based checks"

## Details
The badge was pointing to a workflow named "Ruby specs" which no longer exists. The workflow was renamed to "Ruby based checks" at some point, causing the badge to display as red/failing even though the actual checks are passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)