### PR TITLE
Fix rspack native bindings installation issue

### DIFF
--- a/lib/shakapacker/bundler_switcher.rb
+++ b/lib/shakapacker/bundler_switcher.rb
@@ -241,6 +241,13 @@ module Shakapacker
             raise "Failed to install prod dependencies"
           end
         end
+
+        # Run a full install to ensure optional dependencies (like native bindings) are properly resolved
+        # This is especially important for packages like @rspack/core that use platform-specific native modules
+        unless package_json.manager.install
+          puts "❌ Failed to run full install to resolve optional dependencies"
+          raise "Failed to run full install"
+        end
       end
 
       def get_package_json


### PR DESCRIPTION
## Summary

- Fixed rspack native bindings not being installed when switching bundlers with `--install-deps`
- Added full `npm install` step after adding packages to resolve optional dependencies
- Added test coverage for install failure scenarios

## Problem

When switching from webpack to rspack using `bin/rake shakapacker:switch_bundler rspack -- --install-deps`, the native bindings for @rspack/core were not being installed correctly, resulting in this error:

```
Error: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). 
Please try `npm i` again after removing both package-lock.json and node_modules directory.

Cannot find module './rspack.darwin-universal.node'
Cannot find module '@rspack/binding-darwin-universal'
Cannot find module './rspack.darwin-arm64.node'
Cannot find module '@rspack/binding-darwin-arm64'
```

## Root Cause

The `package_json` gem's `add` method uses `npm install <package>` which doesn't properly resolve optional dependencies for packages like @rspack/core that use platform-specific native bindings.

## Solution

Run a full `npm install` after adding new packages to ensure optional dependencies are properly resolved. This is especially important for packages like @rspack/core that use platform-specific native modules (e.g., @rspack/binding-darwin-arm64).

## Changes

- `lib/shakapacker/bundler_switcher.rb`: Added full install step after adding dependencies
- `spec/shakapacker/bundler_switcher_spec.rb`: Updated specs to expect install call and added test for install failure

## Test Plan

- [x] All existing tests pass
- [x] Added new test for install failure scenario
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)