### PR TITLE
Replace require with import in package/index.ts

### DIFF
--- a/package/index.ts
+++ b/package/index.ts
@@ -1,17 +1,17 @@
 /* eslint global-require: 0 */
 /* eslint import/no-dynamic-require: 0 */
 
-const webpackMerge = require("webpack-merge")
+import * as webpackMerge from "webpack-merge"
 import { resolve } from "path"
 import { existsSync } from "fs"
 // @ts-ignore: webpack is an optional peer dependency (using type-only import)
 import type { Configuration } from "webpack"
-const config = require("./config")
-const baseConfig = require("./environments/base")
-const devServer = require("./dev_server")
-const env = require("./env")
-const { moduleExists, canProcess } = require("./utils/helpers")
-const inliningCss = require("./utils/inliningCss")
+import config from "./config"
+import baseConfig from "./environments/base"
+import devServer from "./dev_server"
+import env from "./env"
+import { moduleExists, canProcess } from "./utils/helpers"
+import inliningCss from "./utils/inliningCss"
 
 const rulesPath = resolve(__dirname, "rules", `${config.assets_bundler}.js`)
 const rules = require(rulesPath)


### PR DESCRIPTION
## Summary
- Converts static `require` statements to ES6 `import` statements in `package/index.ts`
- Lines 4, 9-14 converted from `require()` to `import`
- Dynamic `require()` calls on lines 17 and 39 intentionally left unchanged as they depend on runtime configuration

## Changes
- `const webpackMerge = require("webpack-merge")` → `import * as webpackMerge from "webpack-merge"`
- `const config = require("./config")` → `import config from "./config"`
- Similar conversions for baseConfig, devServer, env, helpers, and inliningCss modules

## Test plan
- [x] Run `yarn lint` - passes
- [x] Run `bundle exec rubocop` - passes
- [x] Run `bundle exec rspec` - 772/773 tests pass (1 unrelated failure in optional_dependencies_spec)

Fixes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated internal modules to ES module import style; public interface and runtime behavior are unchanged.
* **Chores**
  * Updated internal module resolution to align with modern standards for maintainability.

No user action required; functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->