### PR TITLE
Fix yarn.lock formatting changes in Conductor setup

### DIFF
--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -33,11 +33,7 @@ $BUNDLE_CMD install
 
 # Install JavaScript dependencies
 echo "📦 Installing JavaScript dependencies..."
-yarn install
-
-# Reset yarn.lock to avoid cosmetic formatting changes
-echo "🔄 Resetting yarn.lock formatting..."
-git restore yarn.lock 2>/dev/null || true
+yarn install --frozen-lockfile
 
 # Set up Husky git hooks
 echo "🪝 Setting up Husky git hooks..."


### PR DESCRIPTION
## Summary
- Uses `yarn install --frozen-lockfile` in Conductor setup script
- Prevents yarn.lock modifications when creating new Conductor workspaces

## Root Cause
When Conductor creates a new workspace, `yarn install` was adding optional platform-specific dependencies (like `@esbuild/android-arm64`, `@emnapi/core`, etc.) to the lockfile. Even with the same yarn version (1.22.22), yarn install without `--frozen-lockfile` can modify the lockfile by:
1. Reordering version specifiers (e.g., `"package@^1.0.0", "package@1.0.0"` → `"package@1.0.0", "package@^1.0.0"`)
2. Adding optional dependencies based on the current platform

## Solution
Use `yarn install --frozen-lockfile` which:
- Prevents any modifications to yarn.lock
- Ensures consistent installs across all environments
- Fails fast if lockfile is out of sync with package.json
- Aligns with CI/CD best practices

## Test plan
- [x] Verified `yarn install --frozen-lockfile` succeeds without modifying yarn.lock
- [x] Confirmed node_modules are properly installed
- [x] Tested that optional dependencies are correctly handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Setup now enforces installing JavaScript dependencies without modifying the lockfile, reducing incidental lockfile diffs.
  - Helps keep local environments consistent during initial setup.
  - No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->