### PR TITLE
Add HMR client config export in doctor mode

### DIFF
--- a/package/configExporter/fileWriter.ts
+++ b/package/configExporter/fileWriter.ts
@@ -51,11 +51,12 @@ export class FileWriter {
    *   webpack-development-client.yaml
    *   rspack-production-server.yaml
    *   webpack-test-all.json
+   *   webpack-development-client-hmr.yaml
    */
   generateFilename(
     bundler: string,
     env: string,
-    configType: "client" | "server" | "all",
+    configType: "client" | "server" | "all" | "client-hmr",
     format: "yaml" | "json" | "inspect"
   ): string {
     const ext = format === "yaml" ? "yaml" : format === "json" ? "json" : "txt"

--- a/package/configExporter/types.ts
+++ b/package/configExporter/types.ts
@@ -19,13 +19,14 @@ export interface ConfigMetadata {
   bundler: string
   environment: string
   configFile: string
-  configType: "client" | "server" | "all"
+  configType: "client" | "server" | "all" | "client-hmr"
   configCount: number
   environmentVariables: {
     NODE_ENV?: string
     RAILS_ENV?: string
     CLIENT_BUNDLE_ONLY?: string
     SERVER_BUNDLE_ONLY?: string
+    WEBPACK_SERVE?: string
   }
 }
 

--- a/test/package/configExporter.test.js
+++ b/test/package/configExporter.test.js
@@ -1,0 +1,154 @@
+const { resetEnv } = require("../helpers")
+
+// Helper function that mimics the env var restore logic from cli.ts lines 267-282
+function restoreEnvVars(saved) {
+  Object.keys(saved).forEach((key) => {
+    if (saved[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = saved[key]
+    }
+  })
+}
+
+describe("configExporter", () => {
+  beforeEach(() => jest.resetModules() && resetEnv())
+
+  describe("fileWriter", () => {
+    test("generates correct filename for client config", () => {
+      const { FileWriter } = require("../../package/configExporter/fileWriter")
+      const writer = new FileWriter()
+      const filename = writer.generateFilename(
+        "webpack",
+        "development",
+        "client",
+        "yaml"
+      )
+      expect(filename).toBe("webpack-development-client.yaml")
+    })
+
+    test("generates correct filename for server config", () => {
+      const { FileWriter } = require("../../package/configExporter/fileWriter")
+      const writer = new FileWriter()
+      const filename = writer.generateFilename(
+        "webpack",
+        "production",
+        "server",
+        "yaml"
+      )
+      expect(filename).toBe("webpack-production-server.yaml")
+    })
+
+    test("generates correct filename for client-hmr config", () => {
+      const { FileWriter } = require("../../package/configExporter/fileWriter")
+      const writer = new FileWriter()
+      const filename = writer.generateFilename(
+        "webpack",
+        "development",
+        "client-hmr",
+        "yaml"
+      )
+      expect(filename).toBe("webpack-development-client-hmr.yaml")
+    })
+
+    test("generates correct filename for json format", () => {
+      const { FileWriter } = require("../../package/configExporter/fileWriter")
+      const writer = new FileWriter()
+      const filename = writer.generateFilename(
+        "rspack",
+        "production",
+        "client",
+        "json"
+      )
+      expect(filename).toBe("rspack-production-client.json")
+    })
+  })
+
+  describe("environment variable preservation in runDoctorMode", () => {
+    let originalEnv
+
+    beforeEach(() => {
+      // Save original environment
+      originalEnv = {
+        NODE_ENV: process.env.NODE_ENV,
+        RAILS_ENV: process.env.RAILS_ENV,
+        CLIENT_BUNDLE_ONLY: process.env.CLIENT_BUNDLE_ONLY,
+        SERVER_BUNDLE_ONLY: process.env.SERVER_BUNDLE_ONLY,
+        WEBPACK_SERVE: process.env.WEBPACK_SERVE
+      }
+
+      // Set up known initial state for development mode
+      process.env.NODE_ENV = "development"
+      process.env.RAILS_ENV = "development"
+      delete process.env.WEBPACK_SERVE
+      delete process.env.SERVER_BUNDLE_ONLY
+    })
+
+    afterEach(() => {
+      // Restore original environment
+      Object.keys(originalEnv).forEach((key) => {
+        if (originalEnv[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = originalEnv[key]
+        }
+      })
+    })
+
+    test("preserves CLIENT_BUNDLE_ONLY when set before doctor mode", async () => {
+      // Set a custom value that should be preserved
+      process.env.CLIENT_BUNDLE_ONLY = "custom_value"
+
+      // The doctor mode code internally does:
+      // 1. Save original
+      const saved = {
+        CLIENT_BUNDLE_ONLY: process.env.CLIENT_BUNDLE_ONLY,
+        WEBPACK_SERVE: process.env.WEBPACK_SERVE,
+        SERVER_BUNDLE_ONLY: process.env.SERVER_BUNDLE_ONLY
+      }
+
+      // 2. Set HMR env vars
+      process.env.WEBPACK_SERVE = "true"
+      process.env.CLIENT_BUNDLE_ONLY = "yes"
+      delete process.env.SERVER_BUNDLE_ONLY
+
+      // 3. Restore using helper
+      restoreEnvVars(saved)
+
+      // Assert the original value is preserved
+      expect(process.env.CLIENT_BUNDLE_ONLY).toBe("custom_value")
+      expect(process.env.WEBPACK_SERVE).toBeUndefined()
+      expect(process.env.SERVER_BUNDLE_ONLY).toBeUndefined()
+    })
+
+    test("deletes CLIENT_BUNDLE_ONLY when not set before doctor mode", async () => {
+      // Ensure CLIENT_BUNDLE_ONLY is not set
+      delete process.env.CLIENT_BUNDLE_ONLY
+
+      // The doctor mode code internally does:
+      // 1. Save original
+      const saved = {
+        CLIENT_BUNDLE_ONLY: process.env.CLIENT_BUNDLE_ONLY,
+        WEBPACK_SERVE: process.env.WEBPACK_SERVE,
+        SERVER_BUNDLE_ONLY: process.env.SERVER_BUNDLE_ONLY
+      }
+
+      // 2. Set HMR env vars
+      process.env.WEBPACK_SERVE = "true"
+      process.env.CLIENT_BUNDLE_ONLY = "yes"
+      delete process.env.SERVER_BUNDLE_ONLY
+
+      // Verify they were set
+      expect(process.env.CLIENT_BUNDLE_ONLY).toBe("yes")
+      expect(process.env.WEBPACK_SERVE).toBe("true")
+
+      // 3. Restore using helper
+      restoreEnvVars(saved)
+
+      // Assert the variables are deleted since they were not set originally
+      expect(process.env.CLIENT_BUNDLE_ONLY).toBeUndefined()
+      expect(process.env.WEBPACK_SERVE).toBeUndefined()
+      expect(process.env.SERVER_BUNDLE_ONLY).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixed the `bin/export-bundler-config --doctor` command to generate 5 configuration files instead of 4
- Added webpack-development-client-hmr.yaml export for HMR-specific troubleshooting

## Changes
- Modified `package/configExporter/cli.ts` to generate an additional HMR client config in development mode
- Updated `package/configExporter/types.ts` to support "client-hmr" as a valid config type
- Updated `package/configExporter/fileWriter.ts` to handle the new config type
- Updated help text to reflect the 5 files that will be created

## Files Generated
The `--doctor` command now generates:
1. webpack-development-client-hmr.yaml (new)
2. webpack-development-client.yaml
3. webpack-development-server.yaml
4. webpack-production-client.yaml
5. webpack-production-server.yaml

## Test Plan
- [x] Build TypeScript successfully
- [x] Run `yarn lint` - passed
- [x] Run `bundle exec rubocop` - passed
- [ ] Manually test with `bin/export-bundler-config --doctor` in a project with webpack config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Doctor mode now produces an additional HMR client configuration during development with distinct filenames (e.g., ...-client-hmr).
  - Filename generation supports a new client-hmr variant alongside existing client/server/all outputs.
  - Exported metadata now includes WEBPACK_SERVE and recognizes a new config type value: client-hmr.
- Documentation
  - Help and examples updated to showcase the HMR client bundle and its output filenames (e.g., webpack-...-client-hmr.yaml).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->