### PR TITLE
Add assets_bundler_config_path configuration option

### DIFF
--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -49,6 +49,11 @@ default: &default
   # Available options: 'webpack' (default) or 'rspack'
   assets_bundler: "webpack"
 
+  # Path to the directory containing webpack/rspack config files
+  # Defaults to 'config/webpack' for webpack or 'config/rspack' for rspack
+  # Use '.' to specify the root directory of your project
+  # assets_bundler_config_path: config/webpack
+
   # Hook to run before webpack compilation (e.g., for generating dynamic entry points)
   # SECURITY: Only reference trusted scripts within your project. The hook command will be
   # validated to ensure it points to a file within the project root.

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -148,6 +148,14 @@ class Shakapacker::Configuration
     javascript_transpiler
   end
 
+  def assets_bundler_config_path
+    custom_path = fetch(:assets_bundler_config_path)
+    return custom_path if custom_path
+
+    # Default paths based on bundler type
+    rspack? ? "config/rspack" : "config/webpack"
+  end
+
   private
 
     def default_javascript_transpiler


### PR DESCRIPTION
## Summary
- Adds `assets_bundler_config_path` configuration option to shakapacker.yml
- Enables custom location for webpack/rspack config files
- Defaults to `config/webpack` for webpack and `config/rspack` for rspack
- Users can specify any directory, including `.` for project root

## Changes
- Added `assets_bundler_config_path` option to default shakapacker.yml template
- Added `Configuration#assets_bundler_config_path` method with bundler-specific defaults
- Updated `Runner#find_webpack_config` and `Runner#find_rspack_config_with_fallback` to use configurable path
- Updated help text to reflect new configuration option
- Added comprehensive test coverage for the new feature

## Test Plan
- [x] Added tests for default behavior (config/webpack, config/rspack)
- [x] Added tests for custom config paths
- [x] Added tests for root directory specification (.)
- [x] All existing tests pass
- [x] RuboCop passes

## Example Usage

```yaml
# In config/shakapacker.yml
default: &default
  assets_bundler: "webpack"
  assets_bundler_config_path: "build_configs"  # Custom directory
```

Or for root directory:
```yaml
  assets_bundler_config_path: "."  # Config files in project root
```

## Breaking Changes
None - defaults to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to set a custom assets bundler config directory, with sensible defaults for different bundlers.
  * Tooling now dynamically locates rspack/webpack config files in the chosen directory, supporting .ts and .js.
  * Help and deprecation messages updated to reflect the dynamic path.

* **Documentation**
  * Expanded configuration guidance with comments explaining the new setting, defaults, and usage.

* **Tests**
  * Added tests covering default and custom config paths, including edge cases (e.g., root directory).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->