### PR TITLE
Improve upgrade documentation to clarify dual Gemfile and package.json updates

### DIFF
--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -84,12 +84,14 @@ Note that pre-release versions use different formats:
 
 ### Major Version Upgrades
 
-For major version upgrades, always check the version-specific upgrade guides:
+For major version upgrades, always consult the version-specific upgrade guides for breaking changes and new features:
 
-- [V9 Upgrade Guide](./v9_upgrade.md) - Upgrading from v8 to v9
+- [V9 Upgrade Guide](./v9_upgrade.md) - Upgrading from v8 to v9 (includes CSS Modules changes, SWC defaults, and more)
 - [V8 Upgrade Guide](./v8_upgrade.md) - Upgrading from v7 to v8
 - [V7 Upgrade Guide](./v7_upgrade.md) - Upgrading from v6 to v7
 - [V6 Upgrade Guide](./v6_upgrade.md) - Upgrading from v5 to v6
+
+> **💡 Note:** Major version upgrades may include breaking changes. The steps above cover the basic gem/package updates that apply to all versions, but you should always review the version-specific guide for additional migration steps.
 
 ---
 

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -6,12 +6,12 @@ This guide outlines new features, breaking changes, and migration steps for upgr
 
 > **⚠️ Important:** Shakapacker is both a Ruby gem AND an npm package. **You must update BOTH**:
 >
-> 1. Update the version in `Gemfile`
-> 2. Update the version in `package.json`
-> 3. Run `bundle update shakapacker`
-> 4. Run your package manager install command (`yarn install`, `npm install`, or `pnpm install`)
+> - Update the version in `Gemfile`
+> - Update the version in `package.json`
+> - Run `bundle update shakapacker`
+> - Run your package manager install command (`yarn install`, `npm install`, or `pnpm install`)
 >
-> See the [Migration Steps](#migration-steps) section below for complete instructions.
+> See [Migration Steps](#migration-steps) below for detailed instructions including version format differences and testing.
 
 > **⚠️ Important for v9.1.0 Users:** If you're upgrading to v9.1.0 or later, please note the [SWC Configuration Breaking Change](#swc-loose-mode-breaking-change-v910) below. This affects users who previously configured SWC in v9.0.0.
 
@@ -273,6 +273,8 @@ You won't get warnings about missing Babel, Rspack, or esbuild packages.
 
 ## Migration Steps
 
+> **💡 Tip:** For general upgrade instructions applicable to all Shakapacker versions, see [Upgrading Shakapacker](./common-upgrades.md#upgrading-shakapacker) in the Common Upgrades guide.
+
 ### Step 1: Update Gemfile
 
 Update the shakapacker version in your `Gemfile`:
@@ -424,12 +426,22 @@ gem "shakapacker", "9.3.0"         # stable
 gem "shakapacker", "9.3.0.beta.1"  # pre-release
 ```
 
+Stable version in package.json:
+
 ```json
-// package.json - uses hyphens for pre-release versions
 {
   "dependencies": {
-    "shakapacker": "9.3.0"         // stable
-    "shakapacker": "9.3.0-beta.1"  // pre-release
+    "shakapacker": "9.3.0"
+  }
+}
+```
+
+Pre-release version in package.json:
+
+```json
+{
+  "dependencies": {
+    "shakapacker": "9.3.0-beta.1"
   }
 }
 ```


### PR DESCRIPTION
## Summary

Improves upgrade documentation to make it crystal clear that Shakapacker requires updating both the Ruby gem (in Gemfile) and npm package (in package.json) when upgrading.

- Adds prominent callout at the top of v9_upgrade.md emphasizing both updates are required
- Adds complete upgrade steps showing both Gemfile and package.json updates
- Adds new "Upgrading Shakapacker" section to common-upgrades.md with detailed instructions
- Documents version format differences between Ruby gems (dot notation: `9.3.0.beta.1`) and npm (hyphen notation: `9.3.0-beta.1`)
- Explains why both must be updated together (compatibility, features, bug fixes)

## What Changed

### docs/v9_upgrade.md
- Added prominent warning callout at top of document
- Rewrote "Migration Steps" section to explicitly show both Gemfile and package.json updates
- Added "Version Format Differences" section explaining dot vs hyphen notation
- Renumbered steps to accommodate the new structure

### docs/common-upgrades.md
- Added new "Upgrading Shakapacker" section at the top of the table of contents
- Provides complete upgrade instructions applicable to all versions
- Documents the dual nature of Shakapacker (Ruby gem + npm package)
- Links to version-specific upgrade guides

## Why This Matters

As noted in #730, AI tools and developers can easily miss that both Gemfile and package.json need updating. This can lead to:
- Incomplete upgrades with mismatched versions
- Build failures and cryptic errors
- Confusion about which version to use
- Time wasted troubleshooting preventable issues

## Test Plan

- [x] Verified existing tests pass (1 pre-existing failure unrelated to docs)
- [x] Ran `yarn lint` - passing (3 pre-existing warnings)
- [x] Ran `bundle exec rubocop` - passing
- [x] Reviewed documentation formatting and links
- [x] Confirmed all code examples are correct

Fixes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive “Upgrading Shakapacker” guide and TOC entry.
  * Introduced a clear, step-by-step dual upgrade flow covering both the Ruby gem and npm package with explicit commands and verification checklist.
  * Explained version-format differences and pre-release conventions with examples and guidance for finding versions.
  * Expanded v9 upgrade guidance (CSS Modules, kebab-case, config updates, TypeScript, NODE_ENV, SWC) and troubleshooting for peer deps, cache, build, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->