### PR TITLE
Refactor nested ternary expressions to if-else statements

### DIFF
--- a/ESLINT_TECHNICAL_DEBT.md
+++ b/ESLINT_TECHNICAL_DEBT.md
@@ -6,7 +6,7 @@ This document tracks the ESLint errors currently suppressed in the codebase and 
 
 **As of 2025-10-14**: All TypeScript files in `package/` directory are temporarily excluded from linting via the ignore pattern `package/**/*.ts` in `eslint.config.js`. This allows the project to adopt ESLint configuration without requiring immediate fixes to all existing issues.
 
-**Latest Update**: Fixed all `class-methods-use-this` violations by converting FileWriter methods to static methods (4 violations resolved).
+**Latest Update**: Fixed all `no-nested-ternary` violations by refactoring to if-else statements (2 violations resolved).
 
 ## Current Linting Status
 
@@ -19,12 +19,12 @@ This document tracks the ESLint errors currently suppressed in the codebase and 
 
 **TypeScript files** (currently ignored via `package/**/*.ts`):
 
-- **Estimated suppressed errors: ~172** (from sample analysis)
-  - TypeScript type-safety issues: ~114 (66%)
-  - Style/convention issues: ~58 (34%)
+- **Estimated suppressed errors: ~170** (from sample analysis)
+  - TypeScript type-safety issues: ~114 (67%)
+  - Style/convention issues: ~56 (33%)
 
 **Target**: Reduce suppressed errors by 50% within Q1 2025
-**Last Updated**: 2025-10-14
+**Last Updated**: 2025-10-15
 
 ## Priority Matrix
 
@@ -35,7 +35,7 @@ This document tracks the ESLint errors currently suppressed in the codebase and 
 | `config.ts` type safety              | High   | Medium | P1       | 7     |
 | `no-param-reassign`                  | Medium | Low    | P2       | 7     |
 | `class-methods-use-this`             | Low    | Low    | P3       | 0     |
-| `no-nested-ternary`                  | Low    | Low    | P3       | 3     |
+| `no-nested-ternary`                  | Low    | Low    | P3       | 0     |
 | `import/prefer-default-export`       | Low    | Medium | P3       | 9     |
 | `global-require`                     | Medium | High   | P2       | 3     |
 | Other style issues                   | Low    | Low    | P3       | 31    |
@@ -80,9 +80,9 @@ This document tracks the ESLint errors currently suppressed in the codebase and 
 
 ✅ **FIXED** - All FileWriter methods that didn't use instance state have been converted to static methods
 
-#### `no-nested-ternary` (3 instances)
+#### `no-nested-ternary` (0 instances)
 
-**Fix strategy:** Refactor to if-else statements
+✅ **FIXED** - All nested ternary expressions have been refactored to if-else statements for better readability
 
 #### `no-param-reassign` (7 instances)
 
@@ -115,10 +115,10 @@ This document tracks the ESLint errors currently suppressed in the codebase and 
 - Added proper type annotations for `requireOrError` calls
 - Configured appropriate global rule disables (`no-console`, `no-restricted-syntax`)
 - ✅ **Fixed `class-methods-use-this`** - Converted FileWriter methods to static methods
+- ✅ **Fixed `no-nested-ternary`** - Refactored to if-else statements for better readability
 
 🔧 Could still fix (low risk):
 
-- `no-nested-ternary` - Refactor conditionals
 - `no-useless-escape` - Remove unnecessary escapes
 - Unused variables - Remove or prefix with underscore
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -177,8 +177,7 @@ module.exports = [
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "no-useless-escape": "off",
-      "no-continue": "off",
-      "no-nested-ternary": "off"
+      "no-continue": "off"
     }
   },
   {
@@ -195,7 +194,6 @@ module.exports = [
       "@typescript-eslint/require-await": "off",
       "no-param-reassign": "off",
       "no-await-in-loop": "off",
-      "no-nested-ternary": "off",
       "import/prefer-default-export": "off",
       "global-require": "off",
       "no-underscore-dangle": "off"
@@ -215,8 +213,7 @@ module.exports = [
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "no-useless-escape": "off",
-      "no-continue": "off",
-      "no-nested-ternary": "off"
+      "no-continue": "off"
     }
   },
   {

--- a/package/configExporter/configFile.ts
+++ b/package/configExporter/configFile.ts
@@ -124,8 +124,16 @@ export class ConfigFileLoader {
     for (const [name, build] of Object.entries(config.builds)) {
       // Guard: ensure build is a non-null plain object
       if (build == null || typeof build !== "object" || Array.isArray(build)) {
+        let buildType: string
+        if (build === null) {
+          buildType = "null"
+        } else if (Array.isArray(build)) {
+          buildType = "array"
+        } else {
+          buildType = typeof build
+        }
         throw new Error(
-          `Invalid build '${name}': must be an object, got ${build === null ? "null" : Array.isArray(build) ? "array" : typeof build}`
+          `Invalid build '${name}': must be an object, got ${buildType}`
         )
       }
 

--- a/package/configExporter/fileWriter.ts
+++ b/package/configExporter/fileWriter.ts
@@ -61,7 +61,14 @@ export class FileWriter {
     format: "yaml" | "json" | "inspect",
     buildName?: string
   ): string {
-    const ext = format === "yaml" ? "yaml" : format === "json" ? "json" : "txt"
+    let ext: string
+    if (format === "yaml") {
+      ext = "yaml"
+    } else if (format === "json") {
+      ext = "json"
+    } else {
+      ext = "txt"
+    }
     const name = buildName || env
     return `${bundler}-${name}-${configType}.${ext}`
   }


### PR DESCRIPTION
## Summary

Fixes all `no-nested-ternary` ESLint violations by refactoring nested ternary operators to if-else statements for better readability.

## Changes

- **fileWriter.ts**: Convert file extension ternary to if-else chain
- **configFile.ts**: Convert build type detection ternary to if-else chain  
- **eslint.config.js**: Remove `no-nested-ternary` suppressions from 3 override blocks
- **ESLINT_TECHNICAL_DEBT.md**: Update documentation to reflect completion

## Benefits

- Improved code readability by replacing confusing nested ternaries with clear if-else logic
- Reduced ESLint technical debt from ~172 to ~170 suppressed errors (~1% reduction)
- Non-breaking change with no impact on functionality
- Follows the Phase 1 plan outlined in ESLINT_TECHNICAL_DEBT.md

## Test Plan

- [x] All configExporter tests pass (6/6)
- [x] ESLint passes with no new errors
- [x] Pre-commit hooks pass (eslint, prettier, type-check)

## Related

- Addresses part of issue #709 (Code Style: Fix remaining ESLint style issues)
- Continues the ESLint cleanup effort started with #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESLint technical debt report, statistics, and last updated date.
* **Refactor**
  * Replaced nested ternary expressions with clearer if/else logic in configuration and file generation code; behavior unchanged.
  * Improved construction of error messages for invalid build configurations.
* **Chores**
  * Cleaned up ESLint configuration by removing overrides for nested ternary rules, aligning codebase with current linting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->