### PR TITLE
Fix no-useless-escape ESLint violations

### DIFF
--- a/package/utils/pathValidation.ts
+++ b/package/utils/pathValidation.ts
@@ -14,11 +14,11 @@ export function isPathTraversalSafe(inputPath: string): boolean {
   if (inputPath.includes("\0")) return false
 
   const dangerousPatterns = [
-    /\.\.[\/\\]/, // ../ or ..\
+    /\.\.[/\\]/, // ../ or ..\
     /^\//, // POSIX absolute
-    /^[A-Za-z]:[\/\\]/, // Windows absolute (C:\ or C:/)
+    /^[A-Za-z]:[/\\]/, // Windows absolute (C:\ or C:/)
     /^\\\\/, // Windows UNC (\\server\share)
-    /~[\/\\]/, // Home directory expansion
+    /~[/\\]/, // Home directory expansion
     /%2e%2e/i // URL encoded traversal
   ]
 


### PR DESCRIPTION
## Summary
- Fixes 3 `no-useless-escape` ESLint violations in `package/utils/pathValidation.ts`
- Addresses next scheduled item from ESLint Technical Debt (Phase 1: Non-Breaking Fixes)

## Changes
Removed unnecessary escape characters for forward slashes in regex character classes:
- Line 17: `/\.\.[\/\\]/` → `/\.\.[/\\]/`
- Line 19: `/^[A-Za-z]:[\/\\]/` → `/^[A-Za-z]:[/\\]/`
- Line 21: `/~[\/\\]/` → `/~[/\\]/`

Forward slashes do not need to be escaped within character classes in JavaScript regex.

## Test Plan
- [x] Linter passes (0 errors, 3 expected warnings)
- [x] All pathValidation tests pass (11/11 tests)
- [x] Pre-commit hooks pass (lint-staged)
- [x] No functional changes - only removing unnecessary escape characters

## Related
- Part of ESLint technical debt cleanup tracked in `ESLINT_TECHNICAL_DEBT.md`
- Phase 1: Non-Breaking Fixes, low-risk item

🤖 Generated with [Claude Code](https://claude.com/claude-code)