### PR TITLE
Remove unnecessary else after return statements

### DIFF
--- a/package/configExporter/buildValidator.ts
+++ b/package/configExporter/buildValidator.ts
@@ -226,9 +226,8 @@ export class BuildValidator {
 
     if (isHMR) {
       return this.validateHMRBuild(build, appRoot, bundler)
-    } else {
-      return this.validateStaticBuild(build, appRoot, bundler)
     }
+    return this.validateStaticBuild(build, appRoot, bundler)
   }
 
   /**

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1285,7 +1285,8 @@ function formatConfig(
       appRoot
     })
     return serializer.serialize(config, metadata)
-  } else if (options.format === "json") {
+  }
+  if (options.format === "json") {
     const jsonReplacer = (key: string, value: any): any => {
       if (typeof value === "function") {
         return `[Function: ${value.name || "anonymous"}]`


### PR DESCRIPTION
## Summary

- Refactor conditional logic to remove unnecessary `else` blocks after return statements
- Improves code readability and follows ESLint best practices
- Part of ongoing ESLint technical debt reduction (see ESLINT_TECHNICAL_DEBT.md)

## Changes

Fixed 2 `no-else-return` violations:
- `package/configExporter/buildValidator.ts:229` - Removed else block in build validation method
- `package/configExporter/cli.ts:1288` - Changed `else if` to `if` in config formatting function

## Test plan

- [x] `yarn lint` passes with 0 errors
- [x] `bundle exec rubocop` passes with no offenses
- [x] Pre-commit hooks ran successfully
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code structure for improved maintainability while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->