### PR TITLE
Fix ESLint warnings

### DIFF
--- a/scripts/remove-use-strict.js
+++ b/scripts/remove-use-strict.js
@@ -41,5 +41,4 @@ files.forEach((file) => {
   fs.writeFileSync(file, content, "utf8")
 })
 
-// eslint-disable-next-line no-console
 console.log(`Removed "use strict" from ${files.length} files`)

--- a/test/package/rules/babel.test.js
+++ b/test/package/rules/babel.test.js
@@ -19,6 +19,7 @@ const babelConfig = require("../../../package/rules/babel")
 
 // Skip tests if babel config is not available (not the active transpiler)
 if (!babelConfig) {
+  // eslint-disable-next-line jest/no-disabled-tests
   describe.skip("babel - skipped", () => {
     test.todo("skipped because babel is not the active transpiler")
   })

--- a/test/package/rules/swc.test.js
+++ b/test/package/rules/swc.test.js
@@ -19,6 +19,7 @@ const swcConfig = require("../../../package/rules/swc")
 
 // Skip tests if swc config is not available (not the active transpiler)
 if (!swcConfig) {
+  // eslint-disable-next-line jest/no-disabled-tests
   describe.skip("swc - skipped", () => {
     test.todo("skipped because swc is not the active transpiler")
   })


### PR DESCRIPTION
### Summary

This pull request addresses several ESLint warnings identified in the codebase. The specific changes are:

- **scripts/remove-use-strict.js:44**: The `eslint-disable-next-line no-console` directive was removed as it was no longer necessary.
- **test/package/rules/babel.test.js:22**: The `jest/no-disabled-tests` ESLint rule was suppressed for a deliberately skipped test case by adding `eslint-disable-next-line jest/no-disabled-tests`.
- **test/package/rules/swc.test.js:22**: Similar to the babel test file, the `jest/no-disabled-tests` rule was suppressed for a deliberately skipped test case by adding `eslint-disable-next-line jest/no-disabled-tests`.

These changes ensure that all linting checks now pass without warnings.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

All ESLint warnings have been resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint and Jest configuration directives in build and test files to ensure consistent rule compliance across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->