### PR TITLE
Fix ESLint warnings

### DIFF
--- a/scripts/remove-use-strict.js
+++ b/scripts/remove-use-strict.js
@@ -41,5 +41,4 @@ files.forEach((file) => {
   fs.writeFileSync(file, content, "utf8")
 })
 
-// eslint-disable-next-line no-console
 console.log(`Removed "use strict" from ${files.length} files`)

--- a/test/package/rules/babel.test.js
+++ b/test/package/rules/babel.test.js
@@ -19,6 +19,7 @@ const babelConfig = require("../../../package/rules/babel")
 
 // Skip tests if babel config is not available (not the active transpiler)
 if (!babelConfig) {
+  // eslint-disable-next-line jest/no-disabled-tests
   describe.skip("babel - skipped", () => {
     test.todo("skipped because babel is not the active transpiler")
   })

--- a/test/package/rules/swc.test.js
+++ b/test/package/rules/swc.test.js
@@ -19,6 +19,7 @@ const swcConfig = require("../../../package/rules/swc")
 
 // Skip tests if swc config is not available (not the active transpiler)
 if (!swcConfig) {
+  // eslint-disable-next-line jest/no-disabled-tests
   describe.skip("swc - skipped", () => {
     test.todo("skipped because swc is not the active transpiler")
   })


### PR DESCRIPTION
## Summary
- Remove unused eslint-disable directive for console.log in remove-use-strict.js script
- Add eslint-disable comments for intentionally skipped tests in babel and swc test files

## Test plan
- [x] `yarn lint` passes with no warnings
- [x] `bundle exec rubocop` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)