### PR TITLE
Show plugin names in YAML config export

### DIFF
--- a/package/configExporter/yamlSerializer.ts
+++ b/package/configExporter/yamlSerializer.ts
@@ -150,7 +150,7 @@ export class YamlSerializer {
 
       // Check if this is a plugin object and add its name as a comment
       const pluginName = this.getConstructorName(item)
-      const isPlugin = pluginName && /(^|\.)plugins\[\d+\]/.test(keyPath)
+      const isPlugin = pluginName && /(^|\.)plugins\[\d+\]/.test(itemPath)
       const isEmpty =
         typeof item === "object" &&
         item !== null &&


### PR DESCRIPTION
## Summary

Fixes #749

This PR enhances the `--doctor` command output by displaying plugin names in the YAML export, making it much easier to identify which plugins are being used.

## Changes

- **Added plugin name detection**: Extract constructor names from plugin objects
- **Plugin comments**: Non-empty plugins show their name as a comment above the plugin configuration
- **Inline names for empty plugins**: Empty plugins (like `{}`) now show as `{} # PluginName` 
- **General improvement**: Any object with a custom constructor name now shows that name for empty objects

## Before

```yaml
plugins:
  -
    {}
  -
    options:
      enabled: true
      output: ./public/packs/manifest.json
```

## After

```yaml
plugins:
    # MiniCssExtractPlugin
    -
      {} # MiniCssExtractPlugin
    # WebpackAssetsManifest
    -
      options:
        enabled: true
        output: ./public/packs/manifest.json
```

## Test Plan

- [x] Built TypeScript and verified output format
- [x] Tested with mock plugins including empty and non-empty configurations
- [x] Verified linting passes
- [x] Confirmed plugin names appear correctly in YAML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * YAML configuration exports now annotate object and array items with constructor names: empty values show the constructor inline, while non-empty items get a preceding comment. Formatting, indentation and multi-line value layout are preserved for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->