### PR TITLE
Fix config export to respect outputs array

### DIFF
--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1468,7 +1468,16 @@ function loadShakapackerConfig(
 ): { bundler: "webpack" | "rspack"; configPath: string } {
   // Return cached result if same environment
   if (shakapackerConfigCache && shakapackerConfigCache.env === env) {
+    if (process.env.VERBOSE) {
+      console.log(
+        `[Config Exporter] Using cached bundler config for env: ${env}`
+      )
+    }
     return shakapackerConfigCache.result
+  }
+
+  if (process.env.VERBOSE) {
+    console.log(`[Config Exporter] Loading shakapacker config for env: ${env}`)
   }
 
   try {
@@ -1500,11 +1509,14 @@ function loadShakapackerConfig(
         customConfigPath ||
         (bundler === "rspack" ? "config/rspack" : "config/webpack")
 
+      const result = { bundler, configPath }
+      shakapackerConfigCache = { env, result }
+
+      // Only log on first call (when cache was empty)
       console.log(
         `[Config Exporter] Auto-detected bundler: ${bundler}, config path: ${configPath}`
       )
-      const result = { bundler, configPath }
-      shakapackerConfigCache = { env, result }
+
       return result
     }
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Fixes multiple UX issues with `--doctor` mode and config export:
1. Unwanted config files being created despite `outputs` specification
2. Duplicate "Auto-detected bundler" log messages
3. Requirement to manually set `CLIENT_BUNDLE_ONLY` for non-SSR projects
4. Unclear error messages from webpack config loading

## Problems Fixed

### 1. Extra config files created (Main Issue)

When a build specifies `outputs: ["client"]`, the exporter was processing ALL configs returned by webpack/rspack:

```yaml
dev-hmr:
  outputs:
    - client
```

Despite specifying only `client`, the exporter would create BOTH:
- `webpack-dev-hmr-client.yaml` ✅
- `webpack-dev-hmr-server.yaml` ❌ (should not exist)

**Root cause**: Code validated `index < buildOutputs.length` but still processed all configs in forEach loop.

### 2. Duplicate log messages

`[Config Exporter] Auto-detected bundler: webpack, config path: config/webpack` appeared twice per build.

**Root cause**: `loadShakapackerConfig()` called by both `autoDetectBundler()` and `findConfigFile()`.

### 3. Required CLIENT_BUNDLE_ONLY for non-SSR projects

Users had to manually add `CLIENT_BUNDLE_ONLY: "yes"` to prevent webpack from returning unwanted server configs.

### 4. Unclear webpack config errors

Old error:
```
❌ Config file found but invalid: Create a pack with the file name 'server-bundle.js'...
```

Hard to understand what went wrong or which build failed.

## Solutions

### 1. Skip configs beyond outputs array

```typescript
if (buildOutputs.length > 0) {
  // Skip configs beyond the outputs array
  if (index >= buildOutputs.length) {
    return // Skip this config
  }
  // ...
}
```

### 2. Cache shakapacker config loading

```typescript
let shakapackerConfigCache: {
  env: string
  result: { bundler, configPath }
} | null = null
```

Prevents duplicate loading and logging. Cache cleared between builds.

### 3. Auto-set CLIENT_BUNDLE_ONLY/SERVER_BUNDLE_ONLY from outputs

```typescript
if (!resolvedBuild.environment.CLIENT_BUNDLE_ONLY && 
    !resolvedBuild.environment.SERVER_BUNDLE_ONLY) {
  if (buildOutputs.length === 1) {
    if (buildOutputs[0] === "client") {
      process.env.CLIENT_BUNDLE_ONLY = "yes"
    }
  }
}
```

Only auto-set if not already in build environment config.

### 4. Improve error messages

New structured error:
```
Failed to load webpack/rspack config file.

Config file: config/webpack/webpack.config.js
Build: dev
Error: Create a pack with the file name 'server-bundle.js'...

Tip: Check that the config file is valid and doesn't have syntax errors.
```

## Test Plan

- [x] Built TypeScript successfully
- [x] Linting passes
- [x] Logic verified for all scenarios:
  - `outputs: ["client"]` with 2 webpack configs → only exports config[0]
  - No duplicate log messages
  - CLIENT_BUNDLE_ONLY auto-set when needed
  - Clear error messages with context

## Results

For users with SSR configs like:
```yaml
dev:
  description: Development client bundle for SSR (no HMR)
  environment:
    NODE_ENV: development
    RAILS_ENV: development
  outputs:
    - client
```

**Before**: Had to manually add `CLIENT_BUNDLE_ONLY: "yes"` or webpack would fail
**After**: Works automatically - CLIENT_BUNDLE_ONLY is inferred from outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip invalid or null build outputs and correctly handle single-output builds by auto-selecting client/server mode.
  * Clearer, more descriptive errors and tips when configuration files fail to load or execute.

* **Refactor**
  * Memoization with explicit cache invalidation so repeated operations are faster while keeping configs fresh between runs.
  * Safer normalization of configs, including unwrapping module defaults and supporting function-based configs.

* **Enhancement**
  * Added verbose debug logging and explicit environment emission for more transparent build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->