### PR TITLE
Fix ESLint style issues in utils files

### DIFF
--- a/package/utils/errorCodes.ts
+++ b/package/utils/errorCodes.ts
@@ -165,6 +165,7 @@ export const ErrorMessages: Record<ErrorCode, string> = {
  */
 export class ShakapackerError extends Error {
   public readonly code: ErrorCode
+
   public readonly details?: Record<string, any>
 
   constructor(

--- a/package/utils/errorHelpers.ts
+++ b/package/utils/errorHelpers.ts
@@ -36,12 +36,14 @@ export function createFileOperationError(
   filePath: string,
   details?: string
 ): ShakapackerError {
-  const errorCode =
-    operation === "read"
-      ? ErrorCode.FILE_READ_ERROR
-      : operation === "write"
-        ? ErrorCode.FILE_WRITE_ERROR
-        : ErrorCode.FILE_NOT_FOUND
+  let errorCode: ErrorCode
+  if (operation === "read") {
+    errorCode = ErrorCode.FILE_READ_ERROR
+  } else if (operation === "write") {
+    errorCode = ErrorCode.FILE_WRITE_ERROR
+  } else {
+    errorCode = ErrorCode.FILE_NOT_FOUND
+  }
 
   return new ShakapackerError(errorCode, {
     path: filePath,
@@ -60,12 +62,14 @@ export function createFileOperationErrorLegacy(
 ): Error {
   const baseMessage = `Failed to ${operation} file at path '${filePath}'`
   const errorDetails = details ? ` - ${details}` : ""
-  const suggestion =
-    operation === "read"
-      ? " (check if file exists and permissions are correct)"
-      : operation === "write"
-        ? " (check write permissions and disk space)"
-        : " (check permissions)"
+  let suggestion: string
+  if (operation === "read") {
+    suggestion = " (check if file exists and permissions are correct)"
+  } else if (operation === "write") {
+    suggestion = " (check write permissions and disk space)"
+  } else {
+    suggestion = " (check permissions)"
+  }
   return new Error(`${baseMessage}${errorDetails}${suggestion}`)
 }
 


### PR DESCRIPTION
## Summary
- Add blank line between class members in `errorCodes.ts`
- Refactor nested ternary expressions to if-else statements in `errorHelpers.ts` (2 instances)

## Context
These fixes address low-hanging fruit identified in `ESLINT_TECHNICAL_DEBT.md` Phase 1 (non-breaking style fixes). This reduces the technical debt count by 3 ESLint violations.

## Changes
- **errorCodes.ts**: Added blank line between class member declarations to satisfy `lines-between-class-members` rule
- **errorHelpers.ts**: Replaced nested ternary expressions with if-else statements for better readability (fixes 2 `no-nested-ternary` violations)

## Test Plan
- [x] `yarn lint` passes
- [x] `bundle exec rubocop` passes
- [x] Verified no functional changes to error handling logic

## Related
- Part of issue #723 (Remaining TypeScript and Code Quality Improvements)
- Tracked in ESLINT_TECHNICAL_DEBT.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling code organization and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->