### PR TITLE
Fix verbose flag and change export extension to .yml

### DIFF
--- a/package/configExporter/fileWriter.ts
+++ b/package/configExporter/fileWriter.ts
@@ -56,12 +56,12 @@ export class FileWriter {
    * @example
    * // Built-in types
    * generateFilename("webpack", "development", "client", "yaml")
-   * // => "webpack-development-client.yaml"
+   * // => "webpack-development-client.yml"
    *
    * @example
    * // Custom output names
    * generateFilename("webpack", "development", "client-modern", "yaml", "dev-hmr")
-   * // => "webpack-dev-hmr-client-modern.yaml"
+   * // => "webpack-dev-hmr-client-modern.yml"
    */
   static generateFilename(
     bundler: string,
@@ -72,7 +72,7 @@ export class FileWriter {
   ): string {
     let ext: string
     if (format === "yaml") {
-      ext = "yaml"
+      ext = "yml"
     } else if (format === "json") {
       ext = "json"
     } else {

--- a/test/configExporter/integration.test.js
+++ b/test/configExporter/integration.test.js
@@ -127,21 +127,21 @@ builds:
 
       // Should have 3 files (one per build)
       expect(files).toHaveLength(3)
-      expect(files).toContain("webpack-dev-hmr-client.yaml")
-      expect(files).toContain("webpack-dev-client.yaml")
-      expect(files).toContain("webpack-prod-client.yaml")
+      expect(files).toContain("webpack-dev-hmr-client.yml")
+      expect(files).toContain("webpack-dev-client.yml")
+      expect(files).toContain("webpack-prod-client.yml")
 
       // Verify files have different content (proving environment isolation)
       const devHmrContent = require("fs").readFileSync(
-        join(outputDir, "webpack-dev-hmr-client.yaml"),
+        join(outputDir, "webpack-dev-hmr-client.yml"),
         "utf8"
       )
       const devContent = require("fs").readFileSync(
-        join(outputDir, "webpack-dev-client.yaml"),
+        join(outputDir, "webpack-dev-client.yml"),
         "utf8"
       )
       const prodContent = require("fs").readFileSync(
-        join(outputDir, "webpack-prod-client.yaml"),
+        join(outputDir, "webpack-prod-client.yml"),
         "utf8"
       )
 
@@ -195,8 +195,8 @@ builds:
       // Verify files
       expect(existsSync(outputDir)).toBe(true)
       const files = readdirSync(outputDir)
-      expect(files).toContain("webpack-custom-dev-client.yaml")
-      expect(files).toContain("webpack-custom-prod-client.yaml")
+      expect(files).toContain("webpack-custom-dev-client.yml")
+      expect(files).toContain("webpack-custom-prod-client.yml")
     })
 
     it("should use fallback builds when no config file exists", () => {

--- a/test/package/configExporter.test.js
+++ b/test/package/configExporter.test.js
@@ -23,7 +23,7 @@ describe("configExporter", () => {
         "client",
         "yaml"
       )
-      expect(filename).toBe("webpack-development-client.yaml")
+      expect(filename).toBe("webpack-development-client.yml")
     })
 
     test("generates correct filename for server config", () => {
@@ -34,7 +34,7 @@ describe("configExporter", () => {
         "server",
         "yaml"
       )
-      expect(filename).toBe("webpack-production-server.yaml")
+      expect(filename).toBe("webpack-production-server.yml")
     })
 
     test("generates correct filename for client-hmr config", () => {
@@ -45,7 +45,7 @@ describe("configExporter", () => {
         "client-hmr",
         "yaml"
       )
-      expect(filename).toBe("webpack-development-client-hmr.yaml")
+      expect(filename).toBe("webpack-development-client-hmr.yml")
     })
 
     test("generates correct filename for json format", () => {
@@ -67,7 +67,7 @@ describe("configExporter", () => {
         "client-modern",
         "yaml"
       )
-      expect(filename).toBe("webpack-development-client-modern.yaml")
+      expect(filename).toBe("webpack-development-client-modern.yml")
     })
 
     test("generates correct filename for custom output name client-legacy", () => {
@@ -78,7 +78,7 @@ describe("configExporter", () => {
         "client-legacy",
         "yaml"
       )
-      expect(filename).toBe("webpack-production-client-legacy.yaml")
+      expect(filename).toBe("webpack-production-client-legacy.yml")
     })
 
     test("generates correct filename for custom output name server-bundle", () => {
@@ -89,7 +89,7 @@ describe("configExporter", () => {
         "server-bundle",
         "yaml"
       )
-      expect(filename).toBe("rspack-development-server-bundle.yaml")
+      expect(filename).toBe("rspack-development-server-bundle.yml")
     })
 
     test("generates correct filename with buildName override", () => {
@@ -101,7 +101,7 @@ describe("configExporter", () => {
         "yaml",
         "dev-hmr"
       )
-      expect(filename).toBe("webpack-dev-hmr-client-modern.yaml")
+      expect(filename).toBe("webpack-dev-hmr-client-modern.yml")
     })
   })
 


### PR DESCRIPTION
## Summary
- Fix inconsistent verbose flag usage by replacing `process.env.VERBOSE` with `options.verbose` throughout the CLI
- Change exported file extension from `.yaml` to `.yml` for consistency with Ruby conventions

## Changes

### Verbose Flag Fix
- Replace `process.env.VERBOSE` with `options.verbose` at lines 1058, 1078, 1146, 1341, 1549, 1557 in cli.ts
- Pass `verbose` flag through function chain:
  - `autoDetectBundler(env, appRoot, verbose)`
  - `findConfigFile(bundler, appRoot, env, verbose)`
  - `loadShakapackerConfig(env, appRoot, verbose)`
- Ensures `--verbose` CLI flag works correctly in all code paths

### File Extension Change
- Update `fileWriter.ts` to generate `.yml` extension instead of `.yaml`
- Update integration test expectations
- Update CLI help text example

## Test Plan
- [x] All linting passes (`yarn lint`)
- [x] All tests pass (`yarn test test/configExporter`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Propagated an explicit verbose option through CLI and config-loading flows so logging now follows the CLI verbosity setting.

* **Chores**
  * YAML configuration exports now use .yml instead of .yaml.
  * Tests updated to expect the .yml extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->