### PR TITLE
Add merge option for WebpackAssetsManifestPlugin

### DIFF
--- a/package/plugins/webpack.ts
+++ b/package/plugins/webpack.ts
@@ -3,7 +3,7 @@ const { requireOrError } = require("../utils/requireOrError")
 const WebpackAssetsManifest = requireOrError("webpack-assets-manifest")
 const webpack = requireOrError("webpack")
 const config = require("../config")
-const { isProduction } = require("../env")
+const { isProduction, isDevelopment } = require("../env")
 const { moduleExists } = require("../utils/helpers")
 
 const getPlugins = (): unknown[] => {
@@ -15,6 +15,7 @@ const getPlugins = (): unknown[] => {
   const plugins = [
     new webpack.EnvironmentPlugin(process.env),
     new WebpackAssetsManifestConstructor({
+      merge: isDevelopment,
       entrypoints: true,
       writeToDisk: true,
       output: config.manifestPath,


### PR DESCRIPTION
Resolves #747 

This change enables WebpackAssetsManifestPlugin to support HMR in the case that the user has multiple client configurations (say, during an incremental conversion from a legacy configuration to Shakapacker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webpack configuration to enable asset manifest merging in development mode, improving the development build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->