### PR TITLE
Fix style violations in yamlSerializer.ts

### DIFF
--- a/package/configExporter/yamlSerializer.ts
+++ b/package/configExporter/yamlSerializer.ts
@@ -1,6 +1,6 @@
+import { relative, isAbsolute } from "path"
 import { ConfigMetadata } from "./types"
 import { getDocForKey } from "./configDocs"
-import { relative, isAbsolute } from "path"
 
 /**
  * Serializes webpack/rspack config to YAML format with optional inline documentation.
@@ -8,6 +8,7 @@ import { relative, isAbsolute } from "path"
  */
 export class YamlSerializer {
   private annotate: boolean
+
   private appRoot: string
 
   constructor(options: { annotate: boolean; appRoot: string }) {
@@ -22,7 +23,7 @@ export class YamlSerializer {
     const output: string[] = []
 
     // Add metadata header
-    output.push(this.createHeader(metadata))
+    output.push(YamlSerializer.createHeader(metadata))
     output.push("")
 
     // Serialize the config
@@ -31,9 +32,9 @@ export class YamlSerializer {
     return output.join("\n")
   }
 
-  private createHeader(metadata: ConfigMetadata): string {
+  private static createHeader(metadata: ConfigMetadata): string {
     const lines: string[] = []
-    lines.push("# " + "=".repeat(77))
+    lines.push(`# ${"=".repeat(77)}`)
     lines.push("# Webpack/Rspack Configuration Export")
     lines.push(`# Generated: ${metadata.exportedAt}`)
     lines.push(`# Environment: ${metadata.environment}`)
@@ -42,7 +43,7 @@ export class YamlSerializer {
     if (metadata.configCount > 1) {
       lines.push(`# Total Configs: ${metadata.configCount}`)
     }
-    lines.push("# " + "=".repeat(77))
+    lines.push(`# ${"=".repeat(77)}`)
     return lines.join("\n")
   }
 
@@ -90,7 +91,7 @@ export class YamlSerializer {
     if (cleaned.includes("\n")) {
       const lines = cleaned.split("\n")
       const lineIndent = " ".repeat(indent + 2)
-      return "|\n" + lines.map((line) => lineIndent + line).join("\n")
+      return `|\n${lines.map((line) => lineIndent + line).join("\n")}`
     }
 
     // Escape strings that need quoting
@@ -149,7 +150,7 @@ export class YamlSerializer {
       const itemPath = `${keyPath}[${index}]`
 
       // Check if this is a plugin object and add its name as a comment
-      const pluginName = this.getConstructorName(item)
+      const pluginName = YamlSerializer.getConstructorName(item)
       const isPlugin = pluginName && /(^|\.)plugins\[\d+\]/.test(itemPath)
       const isEmpty =
         typeof item === "object" &&
@@ -211,12 +212,12 @@ export class YamlSerializer {
       }
     })
 
-    return "\n" + lines.join("\n")
+    return `\n${lines.join("\n")}`
   }
 
   private serializeObject(obj: any, indent: number, keyPath: string): string {
     const keys = Object.keys(obj)
-    const constructorName = this.getConstructorName(obj)
+    const constructorName = YamlSerializer.getConstructorName(obj)
 
     // For empty objects, show constructor name if available
     if (keys.length === 0) {
@@ -297,14 +298,14 @@ export class YamlSerializer {
       return str
     }
 
-    return "./" + rel
+    return `./${rel}`
   }
 
   /**
    * Extracts the constructor name from an object
    * Returns null for plain objects (Object constructor)
    */
-  private getConstructorName(obj: any): string | null {
+  private static getConstructorName(obj: any): string | null {
     if (!obj || typeof obj !== "object") return null
     if (Array.isArray(obj)) return null
 

--- a/test/package/yamlSerializer.test.js
+++ b/test/package/yamlSerializer.test.js
@@ -1,0 +1,186 @@
+const {
+  YamlSerializer
+} = require("../../package/configExporter/yamlSerializer")
+
+describe("YamlSerializer", () => {
+  let serializer
+
+  beforeEach(() => {
+    serializer = new YamlSerializer({
+      annotate: false,
+      appRoot: "/test/app"
+    })
+  })
+
+  describe("serialize", () => {
+    test("includes metadata header in serialized output", () => {
+      const config = { mode: "development" }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("# Webpack/Rspack Configuration Export")
+      expect(result).toContain("# Generated: 2025-01-15T12:00:00Z")
+      expect(result).toContain("# Environment: development")
+      expect(result).toContain("# Bundler: webpack")
+      expect(result).toContain("# Config Type: client")
+      expect(result).toContain("mode: development")
+    })
+
+    test("includes config count when multiple configs present", () => {
+      const config = { mode: "production" }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "production",
+        bundler: "rspack",
+        configType: "server",
+        configCount: 3
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("# Total Configs: 3")
+    })
+
+    test("omits config count when only one config present", () => {
+      const config = { mode: "production" }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "production",
+        bundler: "rspack",
+        configType: "server",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).not.toContain("# Total Configs:")
+    })
+
+    test("serializes simple objects correctly", () => {
+      const config = {
+        mode: "development",
+        devtool: "source-map"
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("mode: development")
+      expect(result).toContain("devtool: source-map")
+    })
+
+    test("serializes nested objects", () => {
+      const config = {
+        output: {
+          path: "/dist",
+          filename: "bundle.js"
+        }
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("output:")
+      expect(result).toContain("path: /dist")
+      expect(result).toContain("filename: bundle.js")
+    })
+
+    test("handles empty objects with constructor names", () => {
+      class CustomPlugin {}
+      const config = {
+        plugins: [new CustomPlugin()]
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("plugins:")
+      expect(result).toContain("CustomPlugin")
+    })
+
+    test("serializes arrays", () => {
+      const config = {
+        entry: ["./src/index.js", "./src/app.js"]
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("entry:")
+      expect(result).toContain("- ./src/index.js")
+      expect(result).toContain("- ./src/app.js")
+    })
+
+    test("handles functions in config", () => {
+      const config = {
+        output: {
+          filename() {
+            return "bundle.js"
+          }
+        }
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      expect(result).toContain("output:")
+      expect(result).toContain("filename: |")
+      expect(result).toContain("filename()")
+    })
+
+    test("handles RegExp in config", () => {
+      const config = {
+        test: /\.js$/
+      }
+      const metadata = {
+        exportedAt: "2025-01-15T12:00:00Z",
+        environment: "development",
+        bundler: "webpack",
+        configType: "client",
+        configCount: 1
+      }
+
+      const result = serializer.serialize(config, metadata)
+
+      // RegExp objects serialize as empty objects {}
+      expect(result).toContain("test: {}")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves 9 ESLint errors in `yamlSerializer.ts` to reduce technical debt:

- **Auto-fixed (7 issues)**: Import order, string concatenation to template literals, missing blank lines between class members
- **Manually fixed (2 issues)**: Converted `createHeader()` and `getConstructorName()` to static methods

Both methods don't use instance state, so making them static follows best practices and resolves `class-methods-use-this` violations.

## Test plan

- All existing tests pass
- RuboCop passes
- ESLint passes including the fixed file

## Impact

This is a non-breaking internal refactoring that:
- Reduces ESLint technical debt by 9 errors
- Improves code quality and consistency
- Follows the phased approach outlined in ESLINT_TECHNICAL_DEBT.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced YAML export with improved formatting for headers, borders, and consistent relative path handling throughout serialization.

* **Tests**
  * Added comprehensive test coverage for YAML serialization, validating metadata headers, nested object handling, arrays, functions, and special value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->