### PR TITLE
Fix default useContentHash to eliminate production warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 Changes since the last non-beta release.
 
+### Fixed
+
+- **Default `useContentHash` setting in template** now set to `true` to eliminate production warning. [PR #773](https://github.com/shakacode/shakapacker/pull/773) by [justin808](https://github.com/justin808). Fixes [#703](https://github.com/shakacode/shakapacker/issues/703).
+  - Changed default from `false` to `true` in template's default section
+  - Added explicit `useContentHash: false` override for development environment
+  - Removed redundant production override (inherits `true` from default)
+  - Eliminates confusing warning about content hashing in production
+  - Aligns with webpack best practices for cache busting
+
 ## [v9.3.0] - October 28, 2025
 
 ### Added

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -69,7 +69,7 @@ default: &default
   # Select whether the compiler will always use a content hash and not just in production
   # Don't use contentHash except for production for performance
   # https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling
-  useContentHash: false
+  useContentHash: true
 
   # Setting the asset host here will override Rails.application.config.asset_host.
   # Here, you can set different asset_host per environment. Note that
@@ -100,6 +100,9 @@ development:
   <<: *default
   compile: true
   compiler_strategy: mtime
+
+  # Disable content hashing in development for faster builds
+  useContentHash: false
 
   # Early hints disabled by default in development
   # To enable: Set enabled: true AND start Puma with: bundle exec puma --early-hints
@@ -163,9 +166,6 @@ production:
 
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
-
-  # Use content hash for naming assets. Cannot be overridden in production.
-  useContentHash: true
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
## Summary

Fixes the confusing production warning about `useContentHash` that appears when using the default `shakapacker.yml` template generated by `bin/rails shakapacker:install`.

## Changes

- Changed default `useContentHash` from `false` to `true` in the template's default section
- Added explicit `useContentHash: false` override in the development section for better build performance
- Removed redundant `useContentHash: true` from production section (now inherits from default)

## Problem Fixed

Previously, the template had `useContentHash: false` in the default section but overrode it to `true` in production. This caused a warning to appear:

```
⚠️ WARNING
Setting 'useContentHash' to 'false' in the production environment (specified by NODE_ENV environment variable) is not allowed!
Content hashes get added to the filenames regardless of setting useContentHash in 'shakapacker.yml' to false.
```

## Impact

- Eliminates confusing warning for users using the default configuration
- Aligns default behavior with webpack best practices
- No breaking changes - production already enforces content hashing
- Development performance maintained with explicit `false` override

Fixes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbose help flag support (--help=verbose) to display detailed information about bundler configuration options.

* **Fixed**
  * Updated default content hashing setting from disabled to enabled by default. Development environment explicitly disables hashing, while production now inherits the new enabled default behavior, aligning with cache-busting best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->