### PR TITLE
Fix TypeScript ESLint Phase 2a: Simple non-breaking fixes (27 errors)

### DIFF
--- a/package/types.ts
+++ b/package/types.ts
@@ -63,7 +63,7 @@ type WebSocketType = "sockjs" | "ws"
  * @see {import('webpack-dev-server').Configuration}
  */
 export interface DevServerConfig {
-  allowed_hosts?: "all" | "auto" | string | string[]
+  allowed_hosts?: string | string[]
   bonjour?: boolean | Record<string, unknown> // bonjour.BonjourOptions
   client?: Record<string, unknown> // Client
   compress?: boolean
@@ -71,7 +71,7 @@ export interface DevServerConfig {
   headers?: Header | (() => Header)
   history_api_fallback?: boolean | Record<string, unknown> // HistoryApiFallbackOptions
   hmr?: "only" | boolean
-  host?: "local-ip" | "local-ipv4" | "local-ipv6" | string
+  host?: string
   http2?: boolean
   https?: boolean | https.ServerOptions
   ipc?: boolean | string
@@ -85,23 +85,21 @@ export interface DevServerConfig {
     | string[]
     | Record<string, unknown>
     | Record<string, unknown>[]
-  port?: "auto" | string | number
+  port?: string | number
   proxy?: unknown // ProxyConfigMap | ProxyConfigArray
   setup_exit_signals?: boolean
-  static?: boolean | string | unknown // Static | Array<string | Static>
-  watch_files?: string | string[] | unknown // WatchFiles | Array<WatchFiles | string>
+  static?: unknown // Static | Array<string | Static>
+  watch_files?: unknown // WatchFiles | Array<WatchFiles | string>
   web_socket_server?:
     | string
     | boolean
-    | WebSocketType
     | {
-        type?: string | boolean | WebSocketType
+        type?: string | boolean
         options?: Record<string, unknown>
       }
   server?:
     | string
     | boolean
-    | ServerType
-    | { type?: string | boolean | ServerType; options?: https.ServerOptions }
+    | { type?: string | boolean; options?: https.ServerOptions }
   [otherWebpackDevServerConfigKey: string]: unknown
 }

--- a/package/utils/debug.ts
+++ b/package/utils/debug.ts
@@ -18,24 +18,20 @@ const isDebugMode = (): boolean => {
 
 const debug = (message: string, ...args: unknown[]): void => {
   if (isDebugMode()) {
-    // eslint-disable-next-line no-console
     console.log(`[Shakapacker] ${message}`, ...args)
   }
 }
 
 const warn = (message: string, ...args: unknown[]): void => {
-  // eslint-disable-next-line no-console
   console.warn(`[Shakapacker] WARNING: ${message}`, ...args)
 }
 
 const error = (message: string, ...args: unknown[]): void => {
-  // eslint-disable-next-line no-console
   console.error(`[Shakapacker] ERROR: ${message}`, ...args)
 }
 
 const info = (message: string, ...args: unknown[]): void => {
   if (isDebugMode()) {
-    // eslint-disable-next-line no-console
     console.info(`[Shakapacker] INFO: ${message}`, ...args)
   }
 }

--- a/package/utils/getStyleRule.ts
+++ b/package/utils/getStyleRule.ts
@@ -6,13 +6,13 @@ const inliningCss = require("./inliningCss")
 
 interface StyleRule {
   test: RegExp
-  use: any[]
+  use: unknown[]
   type?: string
 }
 
 const getStyleRule = (
   test: RegExp,
-  preprocessors: any[] = []
+  preprocessors: unknown[] = []
 ): StyleRule | null => {
   if (moduleExists("css-loader")) {
     const tryPostcss = () =>

--- a/package/utils/helpers.ts
+++ b/package/utils/helpers.ts
@@ -63,10 +63,10 @@ const packageFullVersion = (packageName: string): string => {
     // eslint-disable-next-line import/no-dynamic-require, global-require
     const packageJson = require(packageJsonPath) as { version: string }
     return packageJson.version
-  } catch (error: any) {
+  } catch (error: unknown) {
     // Re-throw the error with proper code to maintain compatibility with babel preset
     // The preset expects MODULE_NOT_FOUND errors to handle missing core-js gracefully
-    if (error.code === "MODULE_NOT_FOUND") {
+    if ((error as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
       throw error
     }
     // For other errors, warn and re-throw

--- a/package/utils/requireOrError.ts
+++ b/package/utils/requireOrError.ts
@@ -6,7 +6,7 @@ interface ErrorWithCause extends Error {
   cause?: unknown
 }
 
-const requireOrError = (moduleName: string): any => {
+const requireOrError = (moduleName: string): unknown => {
   try {
     return require(moduleName)
   } catch (originalError: unknown) {

--- a/package/webpackDevServerConfig.ts
+++ b/package/webpackDevServerConfig.ts
@@ -25,11 +25,11 @@ interface WebpackDevServerConfig {
     [key: string]: unknown
   }
   client?: Record<string, unknown>
-  allowedHosts?: "all" | "auto" | string | string[]
+  allowedHosts?: string | string[]
   bonjour?: boolean | Record<string, unknown>
   compress?: boolean
   headers?: Record<string, unknown> | (() => Record<string, unknown>)
-  host?: "local-ip" | "local-ipv4" | "local-ipv6" | string
+  host?: string
   http2?: boolean
   https?: boolean | Record<string, unknown>
   ipc?: boolean | string
@@ -42,12 +42,12 @@ interface WebpackDevServerConfig {
     | string[]
     | Record<string, unknown>
     | Record<string, unknown>[]
-  port?: "auto" | string | number
+  port?: string | number
   proxy?: unknown
   server?: string | boolean | Record<string, unknown>
   setupExitSignals?: boolean
   setupMiddlewares?: (middlewares: unknown[], devServer: unknown) => unknown[]
-  watchFiles?: string | string[] | unknown
+  watchFiles?: unknown
   webSocketServer?: string | boolean | Record<string, unknown>
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary

This PR addresses simple, safe ESLint fixes that don't change any runtime behavior or APIs.

Part of #789 - TypeScript ESLint Phase 2a: Simple Non-Breaking Fixes
Related to #783 - TypeScript ESLint Technical Debt resolution
Follows PR #788 - Phase 1 completion

## Changes Made

### 1. Remove Unused ESLint Directives (4 errors)
**File:** `package/utils/debug.ts`

Removed unused `// eslint-disable-next-line no-console` comments. These directives are no longer needed since the `no-console` rule is not triggering for these console methods in a debug utility module.

**Impact:** Cleanup only - no functional changes

### 2. Fix Explicit `any` Types (4 errors)
**Files:**
- `package/utils/getStyleRule.ts` - Replaced `any[]` with `unknown[]` for loader arrays
- `package/utils/helpers.ts` - Replaced `error: any` with `error: unknown` and added proper type assertion
- `package/utils/requireOrError.ts` - Replaced `any` return type with `unknown`

**Impact:** Internal only - improves type safety without changing behavior

### 3. Fix Redundant Type Constituents (19 errors)
**Files:**
- `package/types.ts` - Simplified `DevServerConfig` interface type unions
- `package/webpackDevServerConfig.ts` - Simplified webpack dev server config type unions

**Examples:**
```typescript
// Before:
allowed_hosts?: "all" | "auto" | string | string[]
host?: "local-ip" | "local-ipv4" | "local-ipv6" | string
port?: "auto" | string | number
static?: boolean | string | unknown
watch_files?: string | string[] | unknown

// After:
allowed_hosts?: string | string[]
host?: string
port?: string | number
static?: unknown
watch_files?: unknown
```

**Reasoning:**
- When a union includes `string`, specific string literals like `"all"` or `"auto"` are redundant because `string` already includes all possible strings
- When a union includes `unknown`, all other types are redundant because `unknown` is the top type that includes everything

**Impact:** Type definitions become cleaner and more accurate. No runtime changes, no API changes.

## Error Reduction

- **Before**: 247 ESLint errors
- **After**: 220 ESLint errors
- **Fixed**: 27 errors (10.9% reduction)

## Testing

- ✅ All existing linting passes with standard ignore patterns
- ✅ TypeScript compilation succeeds (`tsc --noEmit`)
- ✅ Pre-commit hooks pass (type checking, linting, prettier)
- ✅ Security validation tests pass
- ⚠️ Some build tests fail, but these failures exist on main and are unrelated to these changes

## Remaining Work

After this PR:
- **220 errors remaining** (down from original 293)
- **Next**: Phase 2b - Type Safety Improvements (~94 errors) - Issue #790

## Related Issues and PRs

- #783 - Parent issue: TypeScript ESLint Technical Debt
- #789 - This issue: Phase 2a Simple Fixes
- #788 - Phase 1 completion (46 errors fixed)
- #790 - Phase 2b: Type Safety Improvements (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined type constraints and annotations across configuration and utility modules for improved type safety.
  * Simplified error handling with more precise type definitions.
  * Removed unnecessary linting directives from utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->