### PR TITLE
Fix ESLint no-continue violations (#783)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -186,8 +186,7 @@ module.exports = [
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "no-useless-escape": "off",
-      "no-continue": "off"
+      "no-useless-escape": "off"
     }
   },
   {
@@ -211,7 +210,6 @@ module.exports = [
       // Template expressions (valid use cases with union types)
       "@typescript-eslint/restrict-template-expressions": "off",
       // Style preferences
-      "no-continue": "off",
       "import/prefer-default-export": "off",
       "no-await-in-loop": "off",
       "no-underscore-dangle": "off",
@@ -253,8 +251,7 @@ module.exports = [
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "no-useless-escape": "off",
-      "no-continue": "off"
+      "no-useless-escape": "off"
     }
   },
   {

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1099,19 +1099,17 @@ async function loadConfigsForEnv(
         console.warn(
           `[Config Exporter] Warning: Skipping dangerous environment variable: ${key}`
         )
-        continue
-      }
-      if (!isBuildEnvVar(key)) {
+      } else if (!isBuildEnvVar(key)) {
         console.warn(
           `[Config Exporter] Warning: Skipping non-whitelisted environment variable: ${key}. ` +
             `Allowed variables are: ${BUILD_ENV_VARS.join(", ")}`
         )
-        continue
+      } else {
+        if (options.verbose) {
+          console.log(`[Config Exporter]   ${key}=${value}`)
+        }
+        process.env[key] = value
       }
-      if (options.verbose) {
-        console.log(`[Config Exporter]   ${key}=${value}`)
-      }
-      process.env[key] = value
     }
 
     // Determine final env: CLI flag > build config NODE_ENV > default

--- a/package/utils/pathValidation.ts
+++ b/package/utils/pathValidation.ts
@@ -138,17 +138,16 @@ export function validatePaths(paths: string[], basePath: string): string[] {
       console.warn(
         `[SHAKAPACKER WARNING] Skipping potentially unsafe path: ${userPath}`
       )
-      continue
-    }
-
-    try {
-      const safePath = safeResolvePath(basePath, userPath)
-      validatedPaths.push(safePath)
-    } catch (error) {
-      console.warn(
-        `[SHAKAPACKER WARNING] Invalid path configuration: ${userPath}\n` +
-          `Error: ${error instanceof Error ? error.message : String(error)}`
-      )
+    } else {
+      try {
+        const safePath = safeResolvePath(basePath, userPath)
+        validatedPaths.push(safePath)
+      } catch (error) {
+        console.warn(
+          `[SHAKAPACKER WARNING] Invalid path configuration: ${userPath}\n` +
+            `Error: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Refactors control flow to eliminate `continue` statements in favor of if-else blocks for better code readability. This addresses issue #783 by incrementally reducing suppressed ESLint errors.

Key improvements:
- Removed 3 instances of `no-continue` violations across 2 files
- Removed `"no-continue": "off"` overrides from eslint.config.js
- All changes are non-breaking and maintain identical functionality

## Changes

### package/utils/pathValidation.ts
- Refactored `validatePaths` function to use else block instead of continue statement
- Improved code readability while maintaining security validation logic

### package/configExporter/cli.ts  
- Converted two continue statements to if-else-if chain
- Environment variable validation now uses cleaner control flow
- Security checks remain identical

### eslint.config.js
- Removed `"no-continue": "off"` from 3 override blocks
- Files affected: babel/preset.ts, config.ts, configExporter/**/*.ts, utils/**/*.ts

## Testing

- ✅ All lint checks pass: `yarn lint`
- ✅ RuboCop passes: `bundle exec rubocop`
- ✅ Pre-commit hooks pass
- ✅ TypeScript compilation passes

## Related Issues

Part of #783: TypeScript ESLint Technical Debt (381 suppressed errors)
- This PR fixes 3 errors and removes 3 rule overrides
- Follows Phase 1 approach: Non-Breaking Fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)