### PR TITLE
Fix ESLint no-await-in-loop violations (#783)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -211,7 +211,6 @@ module.exports = [
       "@typescript-eslint/restrict-template-expressions": "off",
       // Style preferences
       "import/prefer-default-export": "off",
-      "no-await-in-loop": "off",
       "no-underscore-dangle": "off",
       "no-shadow": "off",
       "no-restricted-globals": "off",

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -646,6 +646,7 @@ async function runValidateCommand(options: ExportOptions): Promise<number> {
         "development"
 
       // Auto-detect bundler using the build's environment
+      // eslint-disable-next-line no-await-in-loop -- Sequential execution required: each build modifies shared global state (env vars, config cache) that must be cleared/restored between iterations
       const defaultBundler = await autoDetectBundler(
         buildEnv,
         appRoot,
@@ -660,6 +661,7 @@ async function runValidateCommand(options: ExportOptions): Promise<number> {
       )
 
       // Validate the build
+      // eslint-disable-next-line no-await-in-loop -- Sequential execution required: each build modifies shared global state (env vars, config cache) that must be cleared/restored between iterations
       const result = await validator.validateBuild(resolvedBuild, appRoot)
       results.push(result)
 
@@ -738,6 +740,7 @@ async function runAllBuildsCommand(options: ExportOptions): Promise<number> {
 
       // Create a modified options object for this build
       const buildOptions = { ...resolvedOptions, build: buildName }
+      // eslint-disable-next-line no-await-in-loop -- Sequential execution required: each build modifies shared global state (env vars, config cache) that must be cleared/restored between iterations
       const configs = await loadConfigsForEnv(undefined, buildOptions, appRoot)
 
       for (const { config: cfg, metadata } of configs) {
@@ -817,6 +820,7 @@ async function runDoctorMode(
           // Clear shakapacker config cache between builds
           shakapackerConfigCache = null
 
+          // eslint-disable-next-line no-await-in-loop -- Sequential execution required: each build modifies shared global state (env vars, config cache) that must be cleared/restored between iterations
           const configs = await loadConfigsForEnv(
             undefined,
             { ...options, build: buildName },
@@ -884,6 +888,7 @@ async function runDoctorMode(
         process.env.WEBPACK_SERVE = "true"
       }
 
+      // eslint-disable-next-line no-await-in-loop -- Sequential execution required: each config modifies shared global state (env vars, config cache) that must be cleared/restored between iterations
       const configs = await loadConfigsForEnv(env, options, appRoot)
 
       for (const { config, metadata } of configs) {


### PR DESCRIPTION
## Summary
- Added appropriate `eslint-disable-next-line` comments for 5 `no-await-in-loop` violations in `package/configExporter/cli.ts`
- Removed the global `no-await-in-loop: "off"` rule from `eslint.config.js` for the `configExporter` directory
- Each disable comment explains why sequential execution is required (shared global state modifications)

## Changes
The await-in-loop pattern in this file is intentional and necessary because:
- Each build iteration modifies shared global state (environment variables and config cache)
- Environment variables must be cleared and restored between builds to prevent leakage
- The shakapacker config cache must be cleared to force re-reading for each build
- Console output provides immediate feedback as each build completes

Attempting to parallelize these operations would cause race conditions and incorrect behavior.

## Test plan
- Verified `yarn lint` passes with no errors
- Confirmed tests pass with the same status as before changes (21 pre-existing failures unrelated to this change)
- Ran `bundle exec rubocop` to ensure no Ruby linting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)