### PR TITLE
Remove unused imports to fix ESLint violations

### DIFF
--- a/package/config.ts
+++ b/package/config.ts
@@ -6,12 +6,11 @@ const { ensureTrailingSlash } = require("./utils/helpers")
 const { railsEnv } = require("./env")
 const configPath = require("./utils/configPath")
 const defaultConfigPath = require("./utils/defaultConfigPath")
-import { Config, YamlConfig, LegacyConfig } from "./types"
+import { Config, YamlConfig } from "./types"
 const {
   isValidYamlConfig,
   createConfigValidationError,
-  isPartialConfig,
-  isValidConfig
+  isPartialConfig
 } = require("./utils/typeGuards")
 const {
   isFileNotFoundError,

--- a/package/environments/development.ts
+++ b/package/environments/development.ts
@@ -5,9 +5,7 @@
 
 import type {
   WebpackConfigWithDevServer,
-  RspackConfigWithDevServer,
-  ReactRefreshWebpackPlugin,
-  ReactRefreshRspackPlugin
+  RspackConfigWithDevServer
 } from "./types"
 import type { Config } from "../types"
 

--- a/package/rules/file.ts
+++ b/package/rules/file.ts
@@ -1,4 +1,4 @@
-import { dirname, sep, normalize } from "path"
+import { dirname, normalize } from "path"
 
 const {
   additional_paths: additionalPaths,


### PR DESCRIPTION
## Summary
Removes 5 unused imports across 3 files to fix ESLint no-unused-vars violations.

## Changes

**package/config.ts (2 removals):**
- Removed LegacyConfig type import - not used anywhere in file
- Removed isValidConfig function - not called anywhere in file

**package/environments/development.ts (2 removals):**
- Removed ReactRefreshWebpackPlugin type import - not referenced
- Removed ReactRefreshRspackPlugin type import - not referenced

**package/rules/file.ts (1 removal):**
- Removed sep from path module - dirname and normalize are sufficient

## Test Plan
- yarn lint passes
- Pure import cleanup - no code logic changes
- Verified no references to removed imports exist

## Risk Assessment
Risk Level: Minimal
- Only import statements removed
- No functional code touched
- TypeScript compiler would catch any missed references

Part of issue #783 - breaking down ESLint fixes into focused PRs.