### PR TITLE
Prefix intentionally unused error variables with underscore

### DIFF
--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -539,7 +539,7 @@ end
   // Make executable
   try {
     chmodSync(binStubPath, 0o755)
-  } catch (e) {
+  } catch (_e) {
     // chmod might fail on some systems, but mode in writeFileSync should handle it
   }
 }
@@ -1196,7 +1196,7 @@ async function loadConfigsForEnv(
   if (configFile.endsWith(".ts")) {
     try {
       require("ts-node/register/transpile-only")
-    } catch (error) {
+    } catch (_error) {
       throw new Error(
         "TypeScript config detected but ts-node is not available. " +
           "Install ts-node as a dev dependency: npm install --save-dev ts-node"
@@ -1633,7 +1633,7 @@ function loadShakapackerConfig(
 
       return result
     }
-  } catch (error: unknown) {
+  } catch (_error: unknown) {
     console.warn(
       `[Config Exporter] Error loading shakapacker config, defaulting to webpack`
     )

--- a/package/env.ts
+++ b/package/env.ts
@@ -51,7 +51,7 @@ try {
     // File not found, use default configuration
     try {
       config = load(readFileSync(defaultConfigPath, "utf8")) as ConfigFile
-    } catch (defaultError) {
+    } catch (_defaultError) {
       throw new Error(
         `Failed to load Shakapacker configuration.\n` +
           `Neither user config (${configPath}) nor default config (${defaultConfigPath}) could be loaded.\n\n` +


### PR DESCRIPTION
## Summary
Fixes 4 ESLint no-unused-vars violations by prefixing error variables that are intentionally unused in catch blocks.

## Changes
**package/configExporter/cli.ts (3 fixes):**
- Line 542: chmod catch - error intentionally ignored (fallback to writeFileSync mode)
- Line 1199: ts-node require catch - error re-thrown with better message
- Line 1636: config load catch - error logged via console.warn

**package/env.ts (1 fix):**
- Line 54: Nested catch for default config - error re-thrown with full context

## Why Underscore Prefix
The underscore prefix is TypeScript/ESLint convention for variables that are:
- Intentionally declared but not used
- Required by syntax (catch must have parameter)
- Acknowledged as unused by developers

This is preferable to eslint-disable comments as it documents intent inline.

## Test Plan
- yarn lint passes
- Zero functional changes
- Error handling behavior unchanged

## Risk Assessment
Risk Level: Minimal
- Only variable names changed
- No logic modifications
- catch blocks still work identically

Part of issue #783