### PR TITLE
Prefix compile-time type test functions with underscore

### DIFF
--- a/package/environments/__type-tests__/rspack-plugin-compatibility.ts
+++ b/package/environments/__type-tests__/rspack-plugin-compatibility.ts
@@ -9,26 +9,26 @@
 import type { RspackPlugin, RspackPluginInstance } from "../types"
 
 // Test 1: RspackPlugin should be assignable to RspackPluginInstance
-const testPluginToInstance = (plugin: RspackPlugin): RspackPluginInstance =>
+const _testPluginToInstance = (plugin: RspackPlugin): RspackPluginInstance =>
   plugin
 
 // Test 2: RspackPluginInstance should be assignable to RspackPlugin
-const testInstanceToPlugin = (instance: RspackPluginInstance): RspackPlugin =>
+const _testInstanceToPlugin = (instance: RspackPluginInstance): RspackPlugin =>
   instance
 
 // Test 3: Array compatibility
-const testArrayCompatibility = (
+const _testArrayCompatibility = (
   plugins: RspackPlugin[]
 ): RspackPluginInstance[] => plugins
-const testArrayCompatibilityReverse = (
+const _testArrayCompatibilityReverse = (
   instances: RspackPluginInstance[]
 ): RspackPlugin[] => instances
 
 // Test 4: Optional parameter compatibility
-const testOptionalParam = (
+const _testOptionalParam = (
   plugin?: RspackPlugin
 ): RspackPluginInstance | undefined => plugin
-const testOptionalParamReverse = (
+const _testOptionalParamReverse = (
   instance?: RspackPluginInstance
 ): RspackPlugin | undefined => instance
 


### PR DESCRIPTION
## Summary
Fixes 6 ESLint no-unused-vars violations in rspack-plugin-compatibility.ts by prefixing compile-time type test functions.

## Changes
Prefixed 6 type test functions with underscore:
- _testPluginToInstance
- _testInstanceToPlugin
- _testArrayCompatibility
- _testArrayCompatibilityReverse
- _testOptionalParam
- _testOptionalParamReverse

## Why These Functions Exist
These are compile-time type tests that validate RspackPlugin backward compatibility. They:
- Never execute at runtime
- Will fail TypeScript compilation if types are incompatible
- Serve as type system guards for API changes
- Are a common pattern in TypeScript type testing

## Test Plan
- yarn lint passes
- TypeScript compilation succeeds
- Type tests remain effective

## Risk Assessment
Risk Level: None
- Only function names changed
- Type tests still work identically
- Zero runtime impact

Part of issue #783