### PR TITLE
Fix NODE_ENV not being set when running shakapacker-dev-server

### DIFF
--- a/lib/shakapacker/dev_server_runner.rb
+++ b/lib/shakapacker/dev_server_runner.rb
@@ -18,6 +18,8 @@ module Shakapacker
         exit(0)
       end
 
+      Shakapacker.ensure_node_env!
+
       # Check for --build flag
       build_index = argv.index("--build")
       if build_index
@@ -65,6 +67,8 @@ module Shakapacker
     end
 
     def self.run_with_build_config(argv, build_config)
+      Shakapacker.ensure_node_env!
+
       # Apply build config environment variables
       build_config[:environment].each do |key, value|
         ENV[key] = value.to_s


### PR DESCRIPTION
The DevServerRunner class was missing calls to Shakapacker.ensure_node_env! in both the main run() method and run_with_build_config() method. This caused NODE_ENV to be undefined when users ran bin/shakapacker-dev-server, breaking webpack configs that dynamically require environment-specific files.

This fix ensures NODE_ENV is properly set to match RAILS_ENV (or "production" by default) before executing the dev server, consistent with how WebpackRunner and the base Runner class handle environment initialization.

Fixes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Summary

<!--
  Describe the code changes in your pull request here - were there any bugs you had fixed, features you added, tradeoffs you made?
  If so, mention them. If these changes have open GitHub issues, tag them here as well to keep the conversation linked.
-->

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development server now ensures the Node environment is properly initialized before starting, preventing potential environment-related configuration issues.

* **Tests**
  * Added verification that NODE_ENV is correctly set to "development" when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->