### PR TITLE
Add CodeRabbit as Supporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,3 +1348,10 @@ The following companies support our Open Source projects, and ShakaCode uses the
 <a href="https://www.honeybadger.io">
   <img src="https://user-images.githubusercontent.com/4244251/184881133-79ee9c3c-8165-4852-958e-31687b9536f4.png" alt="Honeybadger" height="55px">
 </a>
+<a href="https://coderabbit.ai">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_7229870ac5.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg">
+    <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg" height="55px">
+  </picture>
+</a>


### PR DESCRIPTION
## Summary

Add CodeRabbit to the Supporters section on the Shakapacker README.

- Added CodeRabbit logo with official branding from https://coderabbit.ai/brand
- Implemented dark/light mode support using `<picture>` tags
- Used SVG format for crisp rendering at all sizes
- Maintains consistent styling with other supporters (55px height)

## Test Plan

- [x] Verified logo displays correctly in both light and dark modes
- [x] Confirmed link points to https://coderabbit.ai
- [x] Ran `yarn lint` to ensure formatting compliance
- [x] Pre-commit hooks passed

## Preview

The CodeRabbit logo will appear after Honeybadger in the Supporters section with proper dark/light mode support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CodeRabbit partner badge with theme-aware display (dark and light variants) to project README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->