### PR TITLE
Add assets_bundler to config if missing during bundler switch

### DIFF
--- a/lib/shakapacker/bundler_switcher.rb
+++ b/lib/shakapacker/bundler_switcher.rb
@@ -220,6 +220,8 @@ module Shakapacker
         if actual_bundler != bundler
           raise "Config update verification failed: expected assets_bundler to be '#{bundler}', but got '#{actual_bundler}'"
         end
+      rescue Psych::SyntaxError => e
+        raise "Config update generated invalid YAML: #{e.message}"
       end
 
       # Generate the assets_bundler YAML entry with proper indentation

--- a/spec/shakapacker/bundler_switcher_spec.rb
+++ b/spec/shakapacker/bundler_switcher_spec.rb
@@ -361,6 +361,24 @@ describe Shakapacker::BundlerSwitcher do
       expect(config["default"]["assets_bundler"]).to eq("rspack")
     end
 
+    it "handles config with multiple blank lines after default" do
+      config_many_blanks = <<~YAML
+        default: &default
+
+
+          source_path: app/javascript
+          javascript_transpiler: babel
+
+        development:
+          <<: *default
+      YAML
+      File.write(config_path, config_many_blanks)
+
+      switcher.switch_to("rspack")
+      config = load_yaml_for_test(config_path)
+      expect(config["default"]["assets_bundler"]).to eq("rspack")
+    end
+
     context "when already using the target bundler" do
       it "does not reinstall deps when install_deps is false" do
         expect(switcher).not_to receive(:system)


### PR DESCRIPTION
## Summary
- Fixes an issue where `rake shakapacker:switch_bundler rspack --install-deps` silently fails when `assets_bundler` is missing from `shakapacker.yml`
- Automatically adds the `assets_bundler` key with appropriate comments when missing
- Prevents early exit when the key is missing but the default value matches the target bundler

## Key Changes
1. **Detection**: Check if `assets_bundler` key exists before early exit logic
2. **Addition**: Add the key intelligently based on config structure:
   - After `javascript_transpiler` if present
   - After `source_path` if `javascript_transpiler` missing
   - After `default: &default` as last resort
3. **Preservation**: Maintain existing behavior for configs that already have the key

## Test Plan
- Added test for adding `assets_bundler` after `javascript_transpiler`
- Added test for adding `assets_bundler` when `javascript_transpiler` is missing
- All existing tests pass
- RuboCop passes

## Impact
This fix is particularly helpful for users migrating from older Shakapacker versions where `assets_bundler` wasn't part of the default config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bundler switching with configuration validation to ensure correct assets_bundler setup when switching between rspack and webpack.
  * Improved configuration file handling with better placement logic and comment preservation.

* **Bug Fixes**
  * Fixed handling of commented-out configuration entries during bundler switches.
  * Enhanced edge-case support for non-standard configuration structures.

* **Tests**
  * Added comprehensive test coverage for bundler switching scenarios and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->