### PR TITLE
Update Prettier to 3.6.2 and fix formatting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,7 @@ Common configuration options with their defaults:
 | `compiler_strategy`            | string  | `"mtime"` (dev), `"digest"` (prod)      | How to determine if recompilation is needed                |
 | `useContentHash`               | boolean | `false` (dev), `true` (prod)            | Include content hashes in asset filenames                  |
 | `webpack_compile_output`       | boolean | `true`                                  | Show webpack/rspack compilation output                     |
-| `shakapacker_precompile`       | boolean | `true`                                  | Include in `bundle exec rake assets:precompile`                       |
+| `shakapacker_precompile`       | boolean | `true`                                  | Include in `bundle exec rake assets:precompile`            |
 | `ensure_consistent_versioning` | boolean | `true`                                  | Enforce gem/npm version matching                           |
 | `dev_server.host`              | string  | `"localhost"`                           | Development server host                                    |
 | `dev_server.port`              | number  | `3035`                                  | Development server port                                    |

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lint-staged": "^15.2.10",
     "memory-fs": "^0.5.0",
     "mini-css-extract-plugin": "^2.9.4",
-    "prettier": "^3.2.5",
+    "prettier": "^3.6.2",
     "rspack-manifest-plugin": "^5.0.3",
     "sass-loader": "^16.0.5",
     "swc-loader": "^0.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5440,7 +5440,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^3.2.5:
+prettier@^3.6.2:
   version "3.6.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==


### PR DESCRIPTION
## Summary
- Upgrade prettier from 3.2.5 to 3.6.2
- Run prettier --write to fix formatting in docs/configuration.md
- All formatting checks now pass

## Context
After merging #832, there was a prettier error during CI. This PR updates prettier to the latest version and fixes all formatting issues.

## Test plan
- [x] `yarn prettier --check .` passes
- [x] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)