### PR TITLE
Fix switch_bundler to not remove shared dependencies

### DIFF
--- a/spec/shakapacker/bundler_switcher_spec.rb
+++ b/spec/shakapacker/bundler_switcher_spec.rb
@@ -408,9 +408,9 @@ describe Shakapacker::BundlerSwitcher do
         expect(manager).to receive(:remove).with(["webpack", "webpack-cli", "webpack-dev-server", "@pmmmwh/react-refresh-webpack-plugin"]).and_return(true)
         expect(manager).to receive(:remove).with(["webpack-assets-manifest"]).and_return(true)
 
-        # Expect add calls for rspack deps
+        # Expect add calls for rspack deps (including shared deps)
         expect(manager).to receive(:add).with(["@rspack/cli", "@rspack/plugin-react-refresh"], type: :dev).and_return(true)
-        expect(manager).to receive(:add).with(["@rspack/core", "rspack-manifest-plugin"], type: :production).and_return(true)
+        expect(manager).to receive(:add).with(["@rspack/core", "rspack-manifest-plugin", "webpack-merge"], type: :production).and_return(true)
 
         # Expect install call to resolve optional dependencies
         expect(manager).to receive(:install).and_return(true)
@@ -432,9 +432,9 @@ describe Shakapacker::BundlerSwitcher do
         # Should NOT call remove
         expect(manager).not_to receive(:remove)
 
-        # Should only call add
+        # Should only call add (including shared deps)
         expect(manager).to receive(:add).with(["@rspack/cli", "@rspack/plugin-react-refresh"], type: :dev).and_return(true)
-        expect(manager).to receive(:add).with(["@rspack/core", "rspack-manifest-plugin"], type: :production).and_return(true)
+        expect(manager).to receive(:add).with(["@rspack/core", "rspack-manifest-plugin", "webpack-merge"], type: :production).and_return(true)
 
         # Should call install to resolve optional dependencies
         expect(manager).to receive(:install).and_return(true)
@@ -517,10 +517,11 @@ describe Shakapacker::BundlerSwitcher do
       allow(switcher).to receive(:get_package_json).and_return(package_json)
       allow(package_json).to receive(:manager).and_return(manager)
 
+      # Shared deps (webpack-merge) should not be removed, only dev deps
       expect(manager).to receive(:remove).with(["webpack", "custom-webpack-dep"]).and_return(true)
-      expect(manager).to receive(:remove).with(["webpack-merge"]).and_return(true)
+      # No prod deps removal call expected because webpack-merge is shared and gets filtered out
       expect(manager).to receive(:add).with(["@rspack/cli", "custom-rspack-dep"], type: :dev).and_return(true)
-      expect(manager).to receive(:add).with(["@rspack/core"], type: :production).and_return(true)
+      expect(manager).to receive(:add).with(["@rspack/core", "webpack-merge"], type: :production).and_return(true)
       expect(manager).to receive(:install).and_return(true)
 
       switcher.switch_to("rspack", install_deps: true)


### PR DESCRIPTION
## Summary

- Remove `@swc/core`, `swc-loader`, and `webpack-merge` from webpack-only dependencies
- These packages are shared between webpack and rspack configurations and should not be removed when switching bundlers

## Problem

As reported in #827, the `switch_bundler` task was removing packages that are actually needed for rspack configurations:

1. **@swc/core** and **swc-loader**: SWC is the recommended JavaScript transpiler for rspack. These packages work with both webpack and rspack, so they shouldn't be removed when switching from webpack to rspack.

2. **webpack-merge**: This configuration utility library is useful for composing configurations regardless of which bundler is being used.

## Changes

Updated `DEFAULT_WEBPACK_DEPS` in `lib/shakapacker/bundler_switcher.rb`:
- Removed `@swc/core` and `swc-loader` from dev dependencies
- Removed `webpack-merge` from prod dependencies

These packages can now remain installed when switching between bundlers, preventing configuration issues.

## Test Plan

- [x] Updated specs to reflect new dependency lists
- [x] All existing tests pass
- [x] RuboCop passes

Fixes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced shared build dependencies that are preserved across bundler switches, reducing unnecessary uninstallations and ensuring consistent installs (e.g., shared merge utility included in production deps).
* **Tests**
  * Updated and expanded tests to verify shared-dependency behavior across switch paths, grouping removal expectations and confirming shared packages are not removed and are added where needed.
* **Documentation**
  * Clarified comments about shared vs. custom dependencies and default vs. custom dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->