### PR TITLE
Add comprehensive unit tests for rspack exports

### DIFF
--- a/test/package/rspack/index.test.js
+++ b/test/package/rspack/index.test.js
@@ -1,0 +1,190 @@
+const { chdirTestApp, resetEnv } = require("../../helpers")
+
+const rootPath = process.cwd()
+chdirTestApp()
+
+jest.mock("../../../package/utils/helpers", () => {
+  const original = jest.requireActual("../../../package/utils/helpers")
+  const moduleExists = () => false
+  return {
+    ...original,
+    moduleExists
+  }
+})
+
+jest.mock("../../../package/utils/validateDependencies", () => {
+  const original = jest.requireActual(
+    "../../../package/utils/validateDependencies"
+  )
+  return {
+    ...original,
+    validateRspackDependencies: () => {
+      // Mock to skip dependency validation in tests
+    }
+  }
+})
+
+describe("rspack/index", () => {
+  beforeEach(() => {
+    jest.resetModules()
+    resetEnv()
+    process.env.SHAKAPACKER_ASSETS_BUNDLER = "rspack"
+  })
+  afterAll(() => process.chdir(rootPath))
+
+  test("exports webpack-merge v5 functions", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.merge).toBeInstanceOf(Function)
+    expect(rspack.mergeWithRules).toBeInstanceOf(Function)
+    expect(rspack.mergeWithCustomize).toBeInstanceOf(Function)
+    expect(rspack.unique).toBeInstanceOf(Function)
+  })
+
+  test("exports config object", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.config).toBeDefined()
+    expect(rspack.config).toHaveProperty("source_path")
+    expect(rspack.config).toHaveProperty("public_output_path")
+  })
+
+  test("exports devServer object", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.devServer).toBeDefined()
+    expect(typeof rspack.devServer).toBe("object")
+  })
+
+  test("exports env object", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.env).toBeDefined()
+    expect(rspack.env).toHaveProperty("nodeEnv")
+    expect(rspack.env).toHaveProperty("railsEnv")
+  })
+
+  test("exports rules array", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.rules).toBeDefined()
+    expect(Array.isArray(rspack.rules)).toBe(true)
+  })
+
+  test("exports baseConfig object", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.baseConfig).toBeDefined()
+    expect(typeof rspack.baseConfig).toBe("object")
+    expect(rspack.baseConfig).toHaveProperty("output")
+    expect(rspack.baseConfig).toHaveProperty("resolve")
+  })
+
+  test("exports utility functions", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.moduleExists).toBeInstanceOf(Function)
+    expect(rspack.canProcess).toBeInstanceOf(Function)
+    expect(rspack.inliningCss).toBeDefined()
+  })
+
+  test("exports generateRspackConfig function", () => {
+    const rspack = require("../../../package/rspack/index")
+    expect(rspack.generateRspackConfig).toBeInstanceOf(Function)
+  })
+
+  test("generateRspackConfig returns an immutable object", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig1 = generateRspackConfig()
+    const rspackConfig2 = generateRspackConfig()
+
+    rspackConfig1.newKey = "new value"
+    rspackConfig1.output.path = "new path"
+
+    expect(rspackConfig2).not.toHaveProperty("newKey")
+    expect(rspackConfig2.output.path).not.toBe("new path")
+  })
+
+  test("generateRspackConfig merges extra config", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig = generateRspackConfig({
+      newKey: "new value",
+      output: {
+        path: "new path"
+      }
+    })
+
+    expect(rspackConfig).toHaveProperty("newKey", "new value")
+    expect(rspackConfig).toHaveProperty("output.path", "new path")
+    expect(rspackConfig).toHaveProperty("output.publicPath", "/packs/")
+  })
+
+  test("generateRspackConfig errors if multiple configs are provided", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    expect(() => generateRspackConfig({}, {})).toThrow(
+      "use webpack-merge to merge configs before passing them to Shakapacker"
+    )
+  })
+
+  test("generateRspackConfig includes plugins", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig = generateRspackConfig()
+
+    expect(rspackConfig).toHaveProperty("plugins")
+    expect(Array.isArray(rspackConfig.plugins)).toBe(true)
+  })
+
+  test("generateRspackConfig includes optimization", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig = generateRspackConfig()
+
+    expect(rspackConfig).toHaveProperty("optimization")
+    expect(typeof rspackConfig.optimization).toBe("object")
+  })
+
+  test("generateRspackConfig includes module rules", () => {
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig = generateRspackConfig()
+
+    expect(rspackConfig).toHaveProperty("module")
+    expect(rspackConfig.module).toHaveProperty("rules")
+    expect(Array.isArray(rspackConfig.module.rules)).toBe(true)
+  })
+
+  test("generateRspackConfig respects NODE_ENV for environment config", () => {
+    process.env.NODE_ENV = "production"
+    jest.resetModules()
+
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+    const rspackConfig = generateRspackConfig()
+
+    expect(rspackConfig).toHaveProperty("mode", "production")
+  })
+
+  test("generateRspackConfig uses base config when environment config not found", () => {
+    process.env.NODE_ENV = "custom-env-that-does-not-exist"
+    jest.resetModules()
+
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    // Should not throw, should use baseConfig
+    expect(() => generateRspackConfig()).not.toThrow()
+
+    const rspackConfig = generateRspackConfig()
+    expect(rspackConfig).toHaveProperty("output")
+    expect(rspackConfig).toHaveProperty("resolve")
+  })
+
+  test("generateRspackConfig merges environment config with extra config", () => {
+    process.env.NODE_ENV = "development"
+    jest.resetModules()
+
+    const { generateRspackConfig } = require("../../../package/rspack/index")
+
+    const rspackConfig = generateRspackConfig({
+      devtool: "custom-source-map"
+    })
+
+    expect(rspackConfig).toHaveProperty("devtool", "custom-source-map")
+    expect(rspackConfig).toHaveProperty("mode", "development")
+  })
+})


### PR DESCRIPTION
## Summary

Addresses #844 by adding comprehensive Jest unit tests for the rspack public API exports in `package/rspack/index.ts`.

## What was tested

All 17 tests pass and verify:

✅ **Webpack-merge function exports** - merge, mergeWithRules, mergeWithCustomize, unique
✅ **Configuration object exports** - config, devServer, env, rules, baseConfig  
✅ **Utility function exports** - moduleExists, canProcess, inliningCss
✅ **generateRspackConfig() behavior:**
  - Returns immutable config objects
  - Properly merges extra configuration
  - Validates input arguments (errors on multiple configs)
  - Includes required plugins array
  - Includes optimization object
  - Includes module rules array
  - Respects NODE_ENV for environment-specific configs
  - Falls back to base config for unknown environments
  - Correctly merges environment and extra configs

## Key improvements

- **baseConfig verification**: Tests confirm baseConfig is a valid rspack configuration object with required properties (output, resolve), helping catch issues like those reported in #843
- **Dependency validation mocking**: Tests mock `validateRspackDependencies()` to avoid requiring actual rspack dependencies during test runs
- **Environment variable setup**: Tests properly set `SHAKAPACKER_ASSETS_BUNDLER=rspack` to ensure rspack-specific code paths are tested

## Test file location

`test/package/rspack/index.test.js` - mirrors the structure of existing `test/package/index.test.js` for webpack

## Test plan

- [x] All 17 new tests pass
- [x] All existing package tests still pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive rspack integration tests validating the public API surface.
  * Verifies configuration generation is immutable, supports merging additional settings, and rejects multiple-config input.
  * Confirms generated configs include plugins, optimization, and module rules.
  * Checks environment-specific behavior (e.g., production mode) and fallback to base configuration when env-specific settings are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->