### PR TITLE
Improve SHAKAPACKER_SKIP_PRECOMPILE_HOOK documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changes since the last non-beta release.
 
 ### Added
 
-- **Added `SHAKAPACKER_SKIP_PRECOMPILE_HOOK` environment variable to skip precompile hook**. [PR #XXX](https://github.com/shakacode/shakapacker/pull/XXX) by [justin808](https://github.com/justin808). Set `SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true` to skip the precompile hook during compilation. This is useful when using process managers like Foreman or Overmind to run the hook once before starting multiple webpack processes, preventing duplicate hook execution. **Migration tip:** If you have a custom `bin/dev` script that starts multiple webpack processes, you can now run the precompile hook once in the script and set this environment variable to prevent each webpack process from running the hook again. See the [precompile hook documentation](./docs/precompile_hook.md#skipping-the-hook) for implementation examples.
+- **Added `SHAKAPACKER_SKIP_PRECOMPILE_HOOK` environment variable to skip precompile hook**. [PR #850](https://github.com/shakacode/shakapacker/pull/850) by [justin808](https://github.com/justin808). Set `SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true` to skip the precompile hook during compilation. This is useful when using process managers like Foreman or Overmind to run the hook once before starting multiple webpack processes, preventing duplicate hook execution. **Migration tip:** If you have a custom `bin/dev` script that starts multiple webpack processes, you can now run the precompile hook once in the script and set this environment variable to prevent each webpack process from running the hook again. See the [precompile hook documentation](./docs/precompile_hook.md#skipping-the-hook) for implementation examples.
 
 ## [v9.3.4-beta.0] - November 17, 2025
 

--- a/docs/precompile_hook.md
+++ b/docs/precompile_hook.md
@@ -300,7 +300,7 @@ This is useful when:
 - Running the hook manually and then compiling multiple times
 - Debugging compilation issues without the hook
 
-**Note:** The examples below show how to implement this in your custom `bin/dev` script. If you're using React on Rails, the generated `bin/dev` script already implements this pattern automatically - it runs the precompile hook once before launching processes, then sets `SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true` to prevent duplicate execution.
+**Note:** The examples below show how to implement this in your custom `bin/dev` script. If you're using React on Rails v13.1.0+, the generated `bin/dev` script already implements this pattern automatically - **no action needed**. It runs the precompile hook once before launching processes, then sets `SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true` to prevent duplicate execution.
 
 **Recommended: Use Procfile env prefix**
 

--- a/sig/shakapacker/compiler.rbs
+++ b/sig/shakapacker/compiler.rbs
@@ -52,6 +52,7 @@ class Shakapacker::Compiler
 
   def bin_shakapacker_path: () -> Pathname
 
+  # Returns true if precompile hook should run, false if disabled or skipped via ENV
   def should_run_precompile_hook?: () -> bool
 
   def run_precompile_hook: () -> void


### PR DESCRIPTION
## Summary

Minor documentation improvements based on code review feedback for PR #850:

- **Fix CHANGELOG.md**: Update PR reference from placeholder `#XXX` to actual `#850`
- **Clarify React on Rails docs**: Specify version requirement (v13.1.0+) and add bold "no action needed" to make it crystal clear for users
- **Add RBS comment**: Add explanatory comment to `should_run_precompile_hook?` type signature

## Test plan

- [x] Changes are documentation/type signature comments only
- [x] No functional code changes
- [x] Verified lint-staged passed (prettier formatting applied automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)