### PR TITLE
Fix gemspec's files regexp to exclude Gemfile.lock

### DIFF
--- a/shakapacker.gemspec
+++ b/shakapacker.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-performance"
 
   s.files = `git ls-files -z`.split("\x0").reject { |f|
-    f.match(%r{^(test|spec|features|tmp|node_modules|packages|coverage|Gemfile.lock|rakelib)/})
+    f.match(%r{^(test|spec|features|tmp|node_modules|packages|coverage|Gemfile.lock|rakelib)($|/)})
   } + Dir.glob("sig/**/*.rbs")
 
   s.test_files = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
### Summary

`Gemfile.lock` is being unexpectedly published as part of the gem. 

No issue technically as it is ignored when installing the gem, but in our case it is triggering vulnerability alerts due to outdated pinned versions during the docker image scan.

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file detection logic to properly exclude directory and file paths in the build system configuration, ensuring more accurate package contents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->