### PR TITLE
Upgrade React on Rails to 16.2.1

### DIFF
--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -51,7 +51,7 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "shakapacker", path: "../.."
-gem "react_on_rails", "= 16.1"
+gem "react_on_rails", "= 16.2.1"
 
 gem "net-smtp", "~> 0.3.3"
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
-    react_on_rails (16.1.0)
+    react_on_rails (16.2.1)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -327,7 +327,7 @@ DEPENDENCIES
   net-smtp (~> 0.3.3)
   puma (>= 5.0)
   rails (~> 8.0.3)
-  react_on_rails (= 16.1)
+  react_on_rails (= 16.2.1)
   rspec-rails (~> 6.0.0)
   selenium-webdriver (>= 4.9)
   shakapacker!

--- a/spec/dummy/package-lock.json
+++ b/spec/dummy/package-lock.json
@@ -28,7 +28,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-on-rails": "^16.1.0",
+        "react-on-rails": "^16.2.1",
         "rspack-manifest-plugin": "^5.1.0",
         "shakapacker": "file:.yalc/shakapacker",
         "style-loader": "^4.0.0",
@@ -55,7 +55,7 @@
       }
     },
     ".yalc/shakapacker": {
-      "version": "9.3.0-beta.1",
+      "version": "9.5.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
@@ -81,7 +81,7 @@
         "babel-loader": "^8.2.4 || ^9.0.0 || ^10.0.0",
         "compression-webpack-plugin": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "css-loader": "^6.8.1 || ^7.0.0",
-        "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
+        "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "esbuild-loader": "^2.0.0 || ^3.0.0 || ^4.0.0",
         "mini-css-extract-plugin": "^2.0.0",
         "rspack-manifest-plugin": "^5.0.0",
@@ -6802,20 +6802,12 @@
       "license": "MIT"
     },
     "node_modules/react-on-rails": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react-on-rails/-/react-on-rails-16.1.1.tgz",
-      "integrity": "sha512-Ntw/4HSB/p9QJ1V2kc0aETzK0W0Vy0suSh0Ugs3Ctfso2ovIT2YUegJJyPtFzX9jUZSR6Q/tkmkgNgzASkO0pw==",
-      "hasInstallScript": true,
-      "license": "MIT",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/react-on-rails/-/react-on-rails-16.2.1.tgz",
+      "integrity": "sha512-47hZ5y69sU6H8RK8H0RDBvBnl4N314DibxsmRVtFIKeoIvvd6nlPyNCqp54jgNehB/mA15VG2H7EeVMHL0u8kA==",
       "peerDependencies": {
         "react": ">= 16",
-        "react-dom": ">= 16",
-        "react-on-rails-rsc": "19.0.2"
-      },
-      "peerDependenciesMeta": {
-        "react-on-rails-rsc": {
-          "optional": true
-        }
+        "react-dom": ">= 16"
       }
     },
     "node_modules/react-refresh": {

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -28,7 +28,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-on-rails": "^16.1.0",
+    "react-on-rails": "^16.2.1",
     "rspack-manifest-plugin": "^5.1.0",
     "shakapacker": "file:.yalc/shakapacker",
     "style-loader": "^4.0.0",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -3789,10 +3789,10 @@ react-is@^16.13.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-on-rails@^16.1.0:
-  version "16.1.1"
-  resolved "https://registry.npmjs.org/react-on-rails/-/react-on-rails-16.1.1.tgz"
-  integrity sha512-Ntw/4HSB/p9QJ1V2kc0aETzK0W0Vy0suSh0Ugs3Ctfso2ovIT2YUegJJyPtFzX9jUZSR6Q/tkmkgNgzASkO0pw==
+react-on-rails@^16.2.1:
+  version "16.2.1"
+  resolved "https://registry.npmjs.org/react-on-rails/-/react-on-rails-16.2.1.tgz"
+  integrity sha512-47hZ5y69sU6H8RK8H0RDBvBnl4N314DibxsmRVtFIKeoIvvd6nlPyNCqp54jgNehB/mA15VG2H7EeVMHL0u8kA==
 
 react-refresh@^0.17.0, "react-refresh@>=0.10.0 <1.0.0":
   version "0.17.0"
@@ -4070,7 +4070,7 @@ setprototypeof@1.2.0:
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 "shakapacker@file:.yalc/shakapacker":
-  version "9.3.0-beta.1"
+  version "9.5.0"
   resolved "file:.yalc/shakapacker"
   dependencies:
     js-yaml "^4.1.0"


### PR DESCRIPTION
## Summary
- Upgrade react_on_rails gem from 16.1 to 16.2.1
- Upgrade react-on-rails npm package from 16.1.0 to 16.2.1
- Update all lockfiles (Gemfile.lock, yarn.lock, package-lock.json)

This brings in the latest stable release without the 16.3.0 release candidates.

## Test plan
- [x] All 931 RSpec tests pass
- [x] Bundle install succeeds
- [x] Yarn install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)