### PR TITLE
Ignore hidden files and directories as entrypoints

### DIFF
--- a/package/environments/base.ts
+++ b/package/environments/base.ts
@@ -35,6 +35,10 @@ const getFilesInDirectory = (dir: string, includeNested: boolean): string[] => {
   }
 
   return readdirSync(dir, { withFileTypes: true }).flatMap((dirent: Dirent) => {
+    if (dirent.name.startsWith(".")) {
+      return []
+    }
+
     const filePath = join(dir, dirent.name)
 
     if (dirent.isDirectory() && includeNested) {

--- a/spec/shakapacker/test_app/app/javascript/entrypoints/.hidden.js
+++ b/spec/shakapacker/test_app/app/javascript/entrypoints/.hidden.js
@@ -1,0 +1,1 @@
+console.log("hidden entrypoint fixture")

--- a/spec/shakapacker/test_app/app/javascript/entrypoints/.hidden_dir/hidden_nested.js
+++ b/spec/shakapacker/test_app/app/javascript/entrypoints/.hidden_dir/hidden_nested.js
@@ -1,0 +1,1 @@
+console.log("hidden nested entrypoint fixture")

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -54,6 +54,7 @@ describe("Base config", () => {
         resolve("app", "javascript", "entrypoints", "multi_entry.js")
       ])
       expect(baseConfig.entry["generated/something"]).toBeUndefined()
+      expect(baseConfig.entry[".hidden"]).toBeUndefined()
     })
 
     test("should returns top level and nested entry points with config.nested_entries == true", () => {
@@ -73,6 +74,8 @@ describe("Base config", () => {
       expect(baseConfig2.entry["generated/something"]).toStrictEqual(
         resolve("app", "javascript", "entrypoints", "generated", "something.js")
       )
+      expect(baseConfig2.entry[".hidden"]).toBeUndefined()
+      expect(baseConfig2.entry[".hidden_dir/hidden_nested"]).toBeUndefined()
     })
 
     test("should return output", () => {


### PR DESCRIPTION
## Summary
- ignore hidden files and directories when building entrypoint lists
- add fixture coverage for hidden top-level and nested entrypoint paths
- add assertions that hidden entries are excluded for both nested and non-nested modes

Closes #853.

## Validation
- `yarn test test/package/environments/base.test.js`
