### PR TITLE
Use `asset` as the default file rule type

### DIFF
--- a/package/rules/file.ts
+++ b/package/rules/file.ts
@@ -8,7 +8,7 @@ const {
 export = {
   test: /\.(bmp|gif|jpe?g|png|tiff|ico|avif|webp|eot|otf|ttf|woff|woff2|svg)$/,
   exclude: /\.(js|mjs|jsx|ts|tsx)$/,
-  type: "asset/resource",
+  type: "asset",
   generator: {
     filename: (pathData: { filename?: string }) => {
       // Guard against null/undefined pathData or filename

--- a/test/package/rules/file.test.js
+++ b/test/package/rules/file.test.js
@@ -35,6 +35,10 @@ describe("file", () => {
     types.forEach((type) => expect(file.exclude.test(type)).toBe(true))
   })
 
+  test("uses webpack asset module type by default", () => {
+    expect(file.type).toBe("asset")
+  })
+
   test("correct generated output path is returned for top level files", () => {
     const pathData = {
       filename: "app/javascript/image.svg"


### PR DESCRIPTION
## Summary
- switch default file rule module type from `asset/resource` to `asset`
- add explicit test coverage for the default module type

Closes #419.

## Validation
- `yarn test test/package/rules/file.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated asset module type handling in file rules to use standard webpack asset classification for consistent asset processing behavior.

* **Tests**
  * Added test case to validate the file rule correctly applies the default asset module type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->