### PR TITLE
Format Claude workflow files for Prettier compliance

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary
- run Prettier on `.github/workflows/claude.yml`
- run Prettier on `.github/workflows/claude-code-review.yml`
- no behavioral changes; formatting only

## Why
Node lint jobs run `yarn prettier --check .` and currently fail on these two files, which blocks PRs that trigger Node checks (for example #898, #901, #902).

## Validation
- `yarn prettier --check .github/workflows/claude.yml .github/workflows/claude-code-review.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release contains internal maintenance updates to GitHub Actions workflow configurations, including minor formatting adjustments. There is no impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->