### PR TITLE
Validate all-builds path and annotate format options

### DIFF
--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -712,6 +712,18 @@ async function runAllBuildsCommand(options: ExportOptions): Promise<number> {
     // Apply defaults
     const resolvedOptions = applyDefaults(options)
 
+    // Validate paths for security in all-builds mode
+    if (resolvedOptions.saveDir) {
+      safeResolvePath(appRoot, resolvedOptions.saveDir)
+    }
+
+    // Validate annotate/format combination in all-builds mode
+    if (resolvedOptions.annotate && resolvedOptions.format !== "yaml") {
+      throw new Error(
+        "Annotation requires YAML format. Use --no-annotate or --format=yaml."
+      )
+    }
+
     const loader = new ConfigFileLoader(resolvedOptions.configFile)
     if (!loader.exists()) {
       const configPath = resolvedOptions.configFile || DEFAULT_CONFIG_FILE

--- a/test/package/configExporter.test.js
+++ b/test/package/configExporter.test.js
@@ -455,5 +455,37 @@ describe("configExporter", () => {
         parseArguments(["--all-builds", "--save-dir=./configs"])
       }).not.toThrow()
     })
+
+    test("run rejects --all-builds with annotate and non-yaml format", async () => {
+      const { run } = require("../../package/configExporter/cli")
+      const mockConsoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
+
+      const result = await run(["--all-builds", "--annotate", "--format=json"])
+
+      expect(result).toBe(1)
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Annotation requires YAML format")
+      )
+
+      mockConsoleError.mockRestore()
+    })
+
+    test("run validates --all-builds save-dir path traversal", async () => {
+      const { run } = require("../../package/configExporter/cli")
+      const mockConsoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
+
+      const result = await run(["--all-builds", "--save-dir=../outside"])
+
+      expect(result).toBe(1)
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("[SHAKAPACKER SECURITY] Path traversal attempt")
+      )
+
+      mockConsoleError.mockRestore()
+    })
   })
 })


### PR DESCRIPTION
Closes #782

## Summary
- add `safeResolvePath` validation for `--all-builds --save-dir` in `runAllBuildsCommand`
- enforce `--annotate` requires YAML format in `runAllBuildsCommand` (matching normal `run()` behavior)
- add regression tests through `run()` for both validation paths

## Why
`runAllBuildsCommand` previously skipped validations that `run()` already applied in non-`--all-builds` paths, creating inconsistent behavior and weaker path-safety guarantees.

## Validation
- `yarn test test/package/configExporter.test.js`
