### PR TITLE
Add entry shape regression test for type narrowing

### DIFF
--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -56,6 +56,17 @@ describe("Base config", () => {
       expect(baseConfig.entry["generated/something"]).toBeUndefined()
     })
 
+    test("keeps entry value shapes stable for TypeScript narrowing", () => {
+      expect(typeof baseConfig.entry.application).toBe("string")
+      expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
+      expect(baseConfig.entry.multi_entry).toEqual(
+        expect.arrayContaining([
+          expect.any(String),
+          expect.any(String)
+        ])
+      )
+    })
+
     test("should returns top level and nested entry points with config.nested_entries == true", () => {
       process.env.SHAKAPACKER_CONFIG = "config/shakapacker_nested_entries.yml"
       const config2 = require("../../../package/config")


### PR DESCRIPTION
Closes #792

## Summary
- add a regression test in `test/package/environments/base.test.js` to verify entry value shape expectations
- explicitly assert that single-entry values stay `string` and multi-file entries stay `string[]`

## Why
`package/environments/base.ts` now relies on TypeScript narrowing for existing entry values. This test locks in the runtime shape assumptions that underpin that narrowing path.

## Validation
- `yarn test test/package/environments/base.test.js`
