### PR TITLE
Supersede #906: entry shape test with lint-compliant matcher

### DIFF
--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -59,7 +59,7 @@ describe("Base config", () => {
     test("keeps entry value shapes stable for TypeScript narrowing", () => {
       expect(typeof baseConfig.entry.application).toBe("string")
       expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
-      expect(baseConfig.entry.multi_entry).toEqual(
+      expect(baseConfig.entry.multi_entry).toStrictEqual(
         expect.arrayContaining([
           expect.any(String),
           expect.any(String)


### PR DESCRIPTION
Supersedes #906. Closes #792.

## Summary
- carry forward the entry-shape regression test from #906
- fix ESLint `jest/prefer-strict-equal` by using `toStrictEqual` for the matcher assertion

## Validation
- yarn test test/package/environments/base.test.js
- yarn eslint test/package/environments/base.test.js --max-warnings 0

## Notes
- This PR does not add commits to #906's existing branch.
