### PR TITLE
Supersede #901: default asset rule with lint unblock

### DIFF
--- a/package/rules/file.ts
+++ b/package/rules/file.ts
@@ -8,7 +8,7 @@ const {
 export = {
   test: /\.(bmp|gif|jpe?g|png|tiff|ico|avif|webp|eot|otf|ttf|woff|woff2|svg)$/,
   exclude: /\.(js|mjs|jsx|ts|tsx)$/,
-  type: "asset/resource",
+  type: "asset",
   generator: {
     filename: (pathData: { filename?: string }) => {
       // Guard against null/undefined pathData or filename

--- a/test/package/rules/file.test.js
+++ b/test/package/rules/file.test.js
@@ -35,6 +35,10 @@ describe("file", () => {
     types.forEach((type) => expect(file.exclude.test(type)).toBe(true))
   })
 
+  test("uses webpack asset module type by default", () => {
+    expect(file.type).toBe("asset")
+  })
+
   test("correct generated output path is returned for top level files", () => {
     const pathData = {
       filename: "app/javascript/image.svg"


### PR DESCRIPTION
Supersedes #901.

Includes:
- original change to switch default file rule to asset
- .prettierignore update to avoid CI lint failures from Claude workflow files

Closes #419