### PR TITLE
Supersede #910: entry shape test with lint unblock

### DIFF
--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -63,17 +63,22 @@ describe("Base config", () => {
         (entryValue) => typeof entryValue === "string"
       )
       const arrayEntries = entryValues.filter(Array.isArray)
+      const flattenedArrayEntries = arrayEntries.flat()
 
       expect(stringEntries.length + arrayEntries.length).toBe(
         entryValues.length
       )
-
-      arrayEntries.forEach((entryValue) => {
-        expect(entryValue.length).toBeGreaterThan(0)
-        entryValue.forEach((value) => {
-          expect(typeof value).toBe("string")
-        })
-      })
+      expect(stringEntries.length).toBeGreaterThan(0)
+      expect(arrayEntries.length).toBeGreaterThan(0)
+      expect(stringEntries.every((entryValue) => entryValue.length > 0)).toBe(
+        true
+      )
+      expect(flattenedArrayEntries.length).toBeGreaterThan(0)
+      expect(
+        flattenedArrayEntries.every(
+          (entryValue) => typeof entryValue === "string"
+        )
+      ).toBe(true)
     })
 
     test("should returns top level and nested entry points with config.nested_entries == true", () => {

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -61,10 +61,7 @@ describe("Base config", () => {
       expect(typeof baseConfig.entry.application).toBe("string")
       expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
       expect(baseConfig.entry.multi_entry).toStrictEqual(
-        expect.arrayContaining([
-          expect.any(String),
-          expect.any(String)
-        ])
+        expect.arrayContaining([expect.any(String), expect.any(String)])
       )
     })
 

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -60,7 +60,7 @@ describe("Base config", () => {
     test("keeps entry value shapes stable for TypeScript narrowing", () => {
       expect(typeof baseConfig.entry.application).toBe("string")
       expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
-      expect(baseConfig.entry.multi_entry).toEqual(
+      expect(baseConfig.entry.multi_entry).toStrictEqual(
         expect.arrayContaining([
           expect.any(String),
           expect.any(String)

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -58,11 +58,26 @@ describe("Base config", () => {
     })
 
     test("keeps entry value shapes stable for TypeScript narrowing", () => {
-      expect(typeof baseConfig.entry.application).toBe("string")
-      expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
-      expect(baseConfig.entry.multi_entry).toStrictEqual(
-        expect.arrayContaining([expect.any(String), expect.any(String)])
+      const entryValues = Object.values(baseConfig.entry)
+      const stringEntries = entryValues.filter(
+        (entryValue) => typeof entryValue === "string"
       )
+      const arrayEntries = entryValues.filter(Array.isArray)
+
+      expect(stringEntries.length + arrayEntries.length).toBe(
+        entryValues.length
+      )
+
+      stringEntries.forEach((entryValue) => {
+        expect(typeof entryValue).toBe("string")
+      })
+
+      arrayEntries.forEach((entryValue) => {
+        expect(entryValue.length).toBeGreaterThan(0)
+        entryValue.forEach((value) => {
+          expect(typeof value).toBe("string")
+        })
+      })
     })
 
     test("should returns top level and nested entry points with config.nested_entries == true", () => {

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -57,6 +57,17 @@ describe("Base config", () => {
       expect(baseConfig.entry[".hidden"]).toBeUndefined()
     })
 
+    test("keeps entry value shapes stable for TypeScript narrowing", () => {
+      expect(typeof baseConfig.entry.application).toBe("string")
+      expect(Array.isArray(baseConfig.entry.multi_entry)).toBe(true)
+      expect(baseConfig.entry.multi_entry).toEqual(
+        expect.arrayContaining([
+          expect.any(String),
+          expect.any(String)
+        ])
+      )
+    })
+
     test("should returns top level and nested entry points with config.nested_entries == true", () => {
       process.env.SHAKAPACKER_CONFIG = "config/shakapacker_nested_entries.yml"
       const config2 = require("../../../package/config")

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -69,16 +69,12 @@ describe("Base config", () => {
         entryValues.length
       )
       expect(stringEntries.length).toBeGreaterThan(0)
-      expect(arrayEntries.length).toBeGreaterThan(0)
-      expect(stringEntries.every((entryValue) => entryValue.length > 0)).toBe(
-        true
+      stringEntries.forEach((entryValue) =>
+        expect(entryValue.length).toBeGreaterThan(0)
       )
-      expect(flattenedArrayEntries.length).toBeGreaterThan(0)
-      expect(
-        flattenedArrayEntries.every(
-          (entryValue) => typeof entryValue === "string"
-        )
-      ).toBe(true)
+      flattenedArrayEntries.forEach((entryValue) =>
+        expect(typeof entryValue).toBe("string")
+      )
     })
 
     test("should returns top level and nested entry points with config.nested_entries == true", () => {

--- a/test/package/environments/base.test.js
+++ b/test/package/environments/base.test.js
@@ -68,10 +68,6 @@ describe("Base config", () => {
         entryValues.length
       )
 
-      stringEntries.forEach((entryValue) => {
-        expect(typeof entryValue).toBe("string")
-      })
-
       arrayEntries.forEach((entryValue) => {
         expect(entryValue.length).toBeGreaterThan(0)
         entryValue.forEach((value) => {


### PR DESCRIPTION
Supersedes #910.

Includes:
- original entry-shape type narrowing regression test
- strict matcher fix from #910
- .prettierignore workflow-file ignore update (with wording fix) to avoid unrelated lint failures

Closes #792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a regression test around `baseConfig.entry` value types; no production code changes, so risk is limited to potential test brittleness across environments.
> 
> **Overview**
> Adds a new Jest regression test in `test/package/environments/base.test.js` to ensure `baseConfig.entry` values remain consistently typed as either *non-empty strings* or *arrays of strings*, preserving stable shapes for TypeScript narrowing.
> 
> No runtime behavior is changed; this strictly tightens test coverage around entrypoint generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00999e35c1381787a0e3261e302a1b2703c7b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to ensure configuration type stability for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->