### PR TITLE
Supersede #911: compiler_spec call-count refactor with lint unblock

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -99,11 +99,16 @@ Present the triage to the user - **DO NOT automatically start addressing items**
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
 - `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions
 - Wait for the user to tell you which items to address
-- If useful, suggest replying with a brief rationale on declined items, but do not do so unless the user asks
+- Always offer an explicit optional follow-up to post rationale replies on selected `SKIPPED` or declined `DISCUSS` items
+- Never post those rationale replies unless the user explicitly selects which items to reply to
+- Ask two things when relevant:
+  - Which items to address in code/tests/docs
+  - Which skipped/declined items (if any) should receive a rationale reply
 
 ## Step 7: Address Items, Reply, and Resolve
 
 When addressing items, after completing each selected todo item, reply to the original review comment explaining how it was addressed.
+If the user selects skipped/declined items for rationale replies, post those replies too.
 
 **For issue comments (general PR comments):**
 
@@ -176,6 +181,7 @@ SKIPPED (3):
 5. spec/helper_spec.rb:20 - "Consolidate assertions" (@claude[bot]) - test style preference
 
 Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
+Optional: I can also post rationale replies for skipped/declined items (e.g., "reply 3,5" or "reply all skipped").
 ```
 
 # Important Notes
@@ -188,6 +194,7 @@ Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
 - **NEVER automatically address all review comments** - always wait for user direction
 - When given a specific review URL, no need to ask for more information
 - **ALWAYS reply to comments after addressing them** to close the feedback loop
+- After triage, always offer to post rationale replies for selected `SKIPPED`/declined items, but only post them with explicit user approval
 - Resolve the review thread after replying when the concern is actually addressed and a thread ID is available
 - Default to real issues only. Do not spend a review cycle on optional polish unless the user explicitly asks for it
 - Triage comments before creating todos. Only `MUST-FIX` items should become todos by default

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -190,7 +190,7 @@ describe "Shakapacker::Compiler" do
       allow(File).to receive(:exist?).with(anything).and_return(true)
 
       expect(Shakapacker.compiler.compile).to be true
-      expect(Open3).to have_received(:capture3).with(hash_including, hook_executable, anything, anything, hash_including).once
+      expect(Open3).to have_received(:capture3).with(hash_including, hook_executable, "--arg1", "--arg2", hash_including).once
     end
 
     it "warns when hook executable does not exist" do
@@ -218,6 +218,7 @@ describe "Shakapacker::Compiler" do
       expect(Shakapacker.logger).to receive(:warn).with(/executable not found/).at_least(:once)
       expect(Shakapacker.logger).to receive(:warn).at_least(:once)
       expect(Shakapacker.compiler.compile).to be true
+      expect(Open3).to have_received(:capture3).with(hash_including, hook_executable, hash_including).once
     end
 
     it "raises error for malformed hook command with unmatched quotes" do


### PR DESCRIPTION
Supersedes #911.

Includes:
- original compiler_spec call-count refactor
- .prettierignore workflow-file ignore update to avoid unrelated lint failures

Closes #855

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that changes how mocks detect the hook call; production behavior is unchanged, with minimal risk beyond potential spec brittleness.
> 
> **Overview**
> Updates `spec/shakapacker/compiler_spec.rb` to remove manual `call_count` logic in several `precompile_hook` examples and instead branch the `Open3.capture3` stub based on the invoked command/executable, using shared `hook_command`/`hook_executable` variables.
> 
> This makes the tests align with the real `Open3.capture3(env, executable, *args, chdir: ...)` signature and improves robustness for cases like quoted paths, missing executables, command chaining, and env-var-prefixed hook commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3df53f219799bd613c6b22c468c9fb23c04fe2be. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for precompile hook handling: special-character/quote cases, executable-vs-argument behavior to prevent shell interpretation, path traversal and security checks, environment variable extraction/merging, malformed command handling, and skip-logic scenarios.
* **Documentation**
  * Clarified triage flow to always offer optional rationale replies for skipped/declined items, require explicit user selection before posting, and added prompt guidance for rationale replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->