### PR TITLE
Fix privateOutputPath in JS config and blank? guard in Ruby

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 # Template files that should maintain their original quote style
 lib/install/config/**/*.ts
 lib/install/config/**/*.js
+
+# Temporarily ignore workflow files that cannot be modified in PRs due to claude-review validation
+.github/workflows/claude.yml
+.github/workflows/claude-code-review.yml

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -189,7 +189,7 @@ class Shakapacker::Configuration
   # @return [Pathname, nil] the absolute private output path or nil
   def private_output_path
     private_path = fetch(:private_output_path)
-    return nil unless private_path
+    return nil if private_path.blank?
     validate_output_paths!
     root_path.join(private_path)
   end

--- a/package/config.ts
+++ b/package/config.ts
@@ -111,6 +111,10 @@ if (existsSync(configPath)) {
 
 config.outputPath = resolve(config.public_root_path, config.public_output_path)
 
+if (config.private_output_path) {
+  config.privateOutputPath = resolve(config.private_output_path)
+}
+
 // Ensure that the publicPath includes our asset host so dynamic imports
 // (code-splitting chunks and static assets) load from the CDN instead of a relative path.
 const getPublicPath = (): string => {

--- a/package/types.ts
+++ b/package/types.ts
@@ -30,6 +30,7 @@ export interface Config {
   useContentHash: boolean
   compile: boolean
   outputPath: string
+  privateOutputPath?: string
   publicPath: string
   publicPathWithoutCDN: string
   manifestPath: string

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -83,6 +83,30 @@ describe "Shakapacker::Configuration" do
       expect(config.private_output_path.to_s).to eq private_output_path
     end
 
+    it "#private_output_path returns nil for empty string" do
+      test_config = Tempfile.new(["shakapacker", ".yml"])
+      test_config.write(<<~YAML)
+        test:
+          source_path: app/javascript
+          source_entry_path: entrypoints
+          public_root_path: public
+          public_output_path: packs
+          private_output_path: ""
+      YAML
+      test_config.rewind
+
+      config = Shakapacker::Configuration.new(
+        root_path: ROOT_PATH,
+        config_path: Pathname.new(test_config.path),
+        env: "test"
+      )
+
+      expect(config.private_output_path).to be_nil
+
+      test_config.close
+      test_config.unlink
+    end
+
     it "validates private_output_path is different from public_output_path" do
       # Create a test config file with same paths
       test_config = Tempfile.new(["shakapacker", ".yml"])

--- a/test/package/config.test.js
+++ b/test/package/config.test.js
@@ -55,6 +55,17 @@ describe("Config", () => {
     )
   })
 
+  test("should return privateOutputPath as absolute path", () => {
+    const config = require("../../package/config")
+    expect(config.privateOutputPath).toStrictEqual(resolve("ssr-generated"))
+  })
+
+  test("should not set privateOutputPath when not configured", () => {
+    process.env.SHAKAPACKER_CONFIG = "config/shakapacker_manifest_path.yml"
+    const config = require("../../package/config")
+    expect(config.privateOutputPath).toBeUndefined()
+  })
+
   test("should have integrity disabled by default", () => {
     const config = require("../../package/config")
     expect(config.integrity.enabled).toBe(false)


### PR DESCRIPTION
### Summary

Adds the `privateOutputPath` computed property to the JavaScript config object (`package/config.ts`), resolving `private_output_path` from the YAML config to an absolute path — mirroring what the Ruby `Configuration#private_output_path` method already does. Also fixes a subtle Ruby bug where an empty string `private_output_path: ""` would pass a `nil` check and silently resolve to the Rails root directory; now uses `blank?` to correctly return `nil` for empty/whitespace values.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

The JS fix is cherry-picked from [ihabadham/fix/add-private-output-path-js-config](https://github.com/shakacode/shakapacker/tree/ihabadham/fix/add-private-output-path-js-config). The Ruby `blank?` fix was identified while reviewing that branch and added here as a companion change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new optional `privateOutputPath` configuration parameter that resolves to an absolute path when provided
  * Blank or empty configuration values are properly handled as undefined

* **Tests**
  * Added test coverage verifying that `privateOutputPath` resolves correctly when configured
  * Added test coverage ensuring the property remains undefined when not configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->