### PR TITLE
Fix Prettier formatting in precompile_hook.md

### DIFF
--- a/docs/precompile_hook.md
+++ b/docs/precompile_hook.md
@@ -35,13 +35,13 @@ before launching long-running processes instead of using `precompile_hook`.
 
 ### Comparison
 
-| Aspect | `precompile_hook` | Explicit setup in `bin/dev` |
-|--------|-------------------|-------------------------------|
-| Best for | Default/consistent pre-build tasks | Custom multi-step dev boot flows |
-| Runs when | Immediately before compilation starts | Wherever you place it in startup script |
-| Production integration | Automatic via `assets:precompile` | Requires explicit production wiring |
-| Process manager complexity | Lower | Higher (you own orchestration) |
-| Debugging | Centralized hook command | Fully explicit command-by-command flow |
+| Aspect                     | `precompile_hook`                     | Explicit setup in `bin/dev`             |
+| -------------------------- | ------------------------------------- | --------------------------------------- |
+| Best for                   | Default/consistent pre-build tasks    | Custom multi-step dev boot flows        |
+| Runs when                  | Immediately before compilation starts | Wherever you place it in startup script |
+| Production integration     | Automatic via `assets:precompile`     | Requires explicit production wiring     |
+| Process manager complexity | Lower                                 | Higher (you own orchestration)          |
+| Debugging                  | Centralized hook command              | Fully explicit command-by-command flow  |
 
 ### `shakapacker_precompile` Interaction
 


### PR DESCRIPTION
### Summary

Fix markdown table formatting in `docs/precompile_hook.md` to pass Prettier's code style checks. Aligned table columns with consistent padding.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

This is a documentation formatting fix to resolve the Prettier linting failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts markdown table formatting; no runtime behavior is affected.
> 
> **Overview**
> Fixes the markdown table formatting in `docs/precompile_hook.md` (the *Comparison* section) by reformatting the table header/separator and aligning column padding to satisfy Prettier/lint style checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68993dc15ba1373f1527dfe36250bf505c79ecba. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->