### PR TITLE
Skip Claude code review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the Claude Code Review workflow on fork PRs by adding an `if` condition
- GitHub Actions does not provide OIDC tokens for `pull_request` events from forks, causing `claude-code-action` to fail with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`
- The `claude.yml` workflow (triggered by comments/reviews) is unaffected since those events run in the base repo's context

Fixes the CI failure seen in https://github.com/shakacode/shakapacker/actions/runs/22640291686/job/65614201150?pr=937

## Test plan
- [ ] Open a PR from a fork — Claude Code Review job should be skipped
- [ ] Open a PR from the base repo — Claude Code Review job should run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change to a CI workflow; it only affects whether a job runs and doesn’t touch application code or production behavior.
> 
> **Overview**
> Adds a job-level `if` guard to the `Claude Code Review` GitHub Actions workflow so the `claude-review` job only runs when the PR head repo matches the base repository.
> 
> This prevents the workflow from executing on forked PRs (where required permissions/OIDC tokens aren’t available) while keeping behavior unchanged for same-repo branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 462f7437787a1a497e0e817bf9122297666d4f8b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine pull request review execution scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->