### PR TITLE
Fix Claude review OIDC permission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Summary

Adds the missing `id-token: write` permission to the Claude Code Review workflow so `anthropics/claude-code-action` can obtain an OIDC token and run successfully on pull requests. This fixes the failure seen on PR #945.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

`CLAUDE_CODE_OAUTH_TOKEN` was already configured; the failure was caused by missing workflow permissions, not a missing repository secret or GitHub UI setting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small, isolated CI change, but it expands workflow permissions by allowing OIDC token minting (`id-token: write`), which is security-relevant if misused.
> 
> **Overview**
> Fixes the `Claude Code Review` workflow failing by adding **OIDC token minting permission** (`permissions: id-token: write`) so `anthropics/claude-code-action@v1` can obtain an OIDC token during PR runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d11b59e8e396d6fe2c4f04aec82efe1969ebed35. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to expand integration capabilities during the code review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->