### PR TITLE
Add gemspec spec tests for Gemfile.lock exclusion (#856)

### DIFF
--- a/spec/shakapacker/gemspec_spec.rb
+++ b/spec/shakapacker/gemspec_spec.rb
@@ -1,0 +1,35 @@
+require_relative "spec_helper_initializer"
+
+describe "shakapacker.gemspec" do
+  let(:gemspec) do
+    Gem::Specification.load(
+      File.expand_path("../../shakapacker.gemspec", __dir__)
+    )
+  end
+
+  describe "s.files" do
+    it "excludes Gemfile.lock" do
+      expect(gemspec.files).not_to include("Gemfile.lock")
+    end
+
+    it "excludes spec directory" do
+      spec_files = gemspec.files.select { |f| f.start_with?("spec/") }
+      expect(spec_files).to be_empty
+    end
+
+    it "excludes node_modules directory" do
+      node_modules_files = gemspec.files.select { |f| f.start_with?("node_modules/") }
+      expect(node_modules_files).to be_empty
+    end
+
+    it "includes lib directory" do
+      lib_files = gemspec.files.select { |f| f.start_with?("lib/") }
+      expect(lib_files).not_to be_empty
+    end
+
+    it "includes RBS type signatures" do
+      rbs_files = gemspec.files.select { |f| f.end_with?(".rbs") }
+      expect(rbs_files).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds comprehensive spec tests to verify that the gemspec correctly excludes files from the packaged gem, particularly the `Gemfile.lock` file which should never be included in gem distributions.

## Changes

- **Added gemspec spec suite** (`spec/shakapacker/gemspec_spec.rb`):
  - Verifies `Gemfile.lock` is excluded from `s.files`
  - Verifies `spec/`, `node_modules/`, and other unwanted directories are excluded
  - Verifies `lib/` directory and RBS type signatures are included
  - Tests load the actual gemspec to ensure the file filtering logic works correctly

- **Updated CHANGELOG.md**:
  - Added entry under `[Unreleased]` documenting the gemspec fix for excluding `Gemfile.lock`

## Testing

All tests pass:
```
bundle exec rspec spec/shakapacker/gemspec_spec.rb
5 examples, 0 failures
```

Fixes #856

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small packaging/test-only change; it only affects which files are included in the released gem and adds regression coverage.
> 
> **Overview**
> Updates `shakapacker.gemspec` file filtering so excluded paths match both directories and standalone files (notably `Gemfile.lock`), preventing the lockfile from being shipped in the built gem.
> 
> Adds a new RSpec suite (`spec/shakapacker/gemspec_spec.rb`) that loads the gemspec and asserts key include/exclude behavior (e.g., excludes `spec/` and `node_modules/`, includes `lib/` and `.rbs`), and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7645b2854f89be46fc7a327349e91379fbbfac4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests for gem packaging configuration to verify proper file inclusion and exclusion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->