### PR TITLE
Collapse v9.6.0-rc.0 into v9.6.0-rc.1 and make collapse default

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -256,20 +256,12 @@ When the user passes `rc` or `beta` as an argument (or when creating a prereleas
    - RC: `## [v9.6.0-rc.1]`
    - Beta: `## [v9.6.0-beta.2]`
 
-4. **Ask the user which approach to take**:
-
-   **Option 1: Process changes since last prerelease**
-   - Only add entries for commits since the previous prerelease tag
-   - Maintains detailed history of what changed in each prerelease
-   - Good when each prerelease has distinct, meaningful changes
-
-   **Option 2: Collapse all prior prereleases into current prerelease**
-   - Combine all prerelease changelog entries into the new prerelease version
-   - Removes previous prerelease version sections
-   - Cleaner changelog with less version noise
-   - Good when approaching stable release
-
-   After the user chooses, proceed with that approach.
+4. **Always collapse prior prereleases into the current prerelease** (this is the default behavior):
+   - Combine all prior prerelease changelog entries into the new prerelease version section
+   - Remove previous prerelease version sections (e.g., remove `## [v9.6.0-rc.0]` when creating `## [v9.6.0-rc.1]`)
+   - Add any new user-visible changes from commits since the last prerelease
+   - Update version diff links to point from the last stable version to the new prerelease
+   - This keeps the changelog clean with a single prerelease section that accumulates all changes since the last stable release
 
 ### For Prerelease to Stable Version Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 Changes since the last non-beta release.
 
-## [v9.6.0-rc.0] - March 5, 2026
+## [v9.6.0-rc.1] - March 7, 2026
 
 ### Security
 
@@ -72,7 +72,7 @@ Changes since the last non-beta release.
 - **Improved error message when manifest is empty or missing**. [PR #872](https://github.com/shakacode/shakapacker/pull/872) by [justin808](https://github.com/justin808). When the bundler is still compiling (empty manifest) or hasn't run yet (missing manifest file), users now see clear, actionable error messages instead of the generic 7-point checklist.
 - **Fixed NODE_ENV=test causing DefinePlugin warnings**. [PR #870](https://github.com/shakacode/shakapacker/pull/870) by [justin808](https://github.com/justin808). When RAILS_ENV=test, Shakapacker now sets NODE_ENV=development instead of NODE_ENV=test. This prevents webpack/rspack DefinePlugin conflicts since these bundlers only recognize "development" and "production" as valid NODE_ENV values.
 - **Fixed `--json` flag output being corrupted by log messages**. [PR #869](https://github.com/shakacode/shakapacker/pull/869) by [justin808](https://github.com/justin808). When `--json` is in the command arguments, `[Shakapacker]` log messages are now written to stderr instead of stdout, keeping stdout clean for valid JSON output. This allows `bin/shakapacker --profile --json` to be piped to tools like `webpack-bundle-analyzer`. Normal (non-JSON) usage is unchanged. Resolves [#868](https://github.com/shakacode/shakapacker/issues/868).
-- **Require explicit truthy values for `SKIP` and `FORCE` installer env vars**. [PR #926](https://github.com/shakacode/shakapacker/pull/926) by [justin808](https://github.com/justin808). Previously, any set value (including `"false"` or `"0"`) would activate skip/force mode. Now only explicit truthy values (`true`, `1`, `yes`, case-insensitive) are recognized. This behavior change may require CI/scripts that relied on `FORCE=<any non-empty value>` to switch to `FORCE=true`.
+- **Require explicit truthy values for all installer env vars**. [PR #926](https://github.com/shakacode/shakapacker/pull/926), [PR #943](https://github.com/shakacode/shakapacker/pull/943) by [justin808](https://github.com/justin808). Previously, any set value (including `"false"` or `"0"`) would activate these flags. Now only explicit truthy values (`true`, `1`, `yes`, case-insensitive) are recognized for `SKIP`, `FORCE`, `USE_BABEL_PACKAGES`, `SHAKAPACKER_USE_TYPESCRIPT`, and `SKIP_COMMON_LOADERS`. This behavior change may require CI/scripts that relied on arbitrary non-empty values to switch to recognized truthy values like `true`.
 
 ### Documentation
 
@@ -868,8 +868,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.0-rc.0...main
-[v9.6.0-rc.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0-rc.0
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.0-rc.1...main
+[v9.6.0-rc.1]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0-rc.1
 [v9.5.0]: https://github.com/shakacode/shakapacker/compare/v9.4.0...v9.5.0
 [v9.4.0]: https://github.com/shakacode/shakapacker/compare/v9.3.4...v9.4.0
 [v9.3.4]: https://github.com/shakacode/shakapacker/compare/v9.3.3...v9.3.4


### PR DESCRIPTION
### Summary

Consolidates v9.6.0-rc.0 changelog section into v9.6.0-rc.1 and updates the `/update-changelog` command to make collapsing prior prerelease sections the default behavior for RC and beta releases. Adds PR #943 entry covering the extension of truthy env var normalization to all installer flags (USE_BABEL_PACKAGES, SHAKAPACKER_USE_TYPESCRIPT, SKIP_COMMON_LOADERS).

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~
- ~[ ] Update documentation~
- [x] Update CHANGELOG file

### Other Information

This ensures future RC/beta releases have a single consolidated changelog section that accumulates all changes since the last stable release, reducing changelog clutter and version noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog-only updates; no runtime or API behavior changes.
> 
> **Overview**
> Updates the `/update-changelog` command documentation to make **collapsing all prior RC/beta sections into the new prerelease** the default (removing the prior “choose an approach” step).
> 
> Refreshes `CHANGELOG.md` for the `v9.6.0` prerelease by renaming `v9.6.0-rc.0` to `v9.6.0-rc.1`, updating the compare links accordingly, and revising the installer env-var note to cover *all* installer flags (and include PR #943).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de3da75eff75b372d18ea27f0d0b0f062ff88799. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Installer environment variables (SKIP, FORCE, USE_BABEL_PACKAGES, SHAKAPACKER_USE_TYPESCRIPT, SKIP_COMMON_LOADERS) now require explicit truthy values instead of implicit defaults.

* **Improvements**
  * Simplified prerelease changelog organization by consolidating multiple prerelease entries into a single accumulating section, reducing version noise and improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->