### PR TITLE
Stamp v9.6.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 Changes since the last non-beta release.
 
-## [v9.6.0-rc.1] - March 7, 2026
+## [v9.6.0-rc.2] - March 7, 2026
 
 ### Security
 
@@ -868,8 +868,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.0-rc.1...main
-[v9.6.0-rc.1]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0-rc.1
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.0-rc.2...main
+[v9.6.0-rc.2]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0-rc.2
 [v9.5.0]: https://github.com/shakacode/shakapacker/compare/v9.4.0...v9.5.0
 [v9.4.0]: https://github.com/shakacode/shakapacker/compare/v9.3.4...v9.4.0
 [v9.3.4]: https://github.com/shakacode/shakapacker/compare/v9.3.3...v9.3.4


### PR DESCRIPTION
### Summary

Updates CHANGELOG.md header from v9.6.0-rc.1 to v9.6.0-rc.2. No new user-visible changes since rc.1; this rc consolidates internal release tooling improvements (#950, #951, #952, #953).

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~
- ~[ ] Update documentation~
- [x] Update CHANGELOG file

### Other Information

This prerelease continues the v9.6.0 RC series with release workflow refinements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (changelog/version link updates) with no runtime or behavior impact.
> 
> **Overview**
> Updates `CHANGELOG.md` to stamp the release candidate as `v9.6.0-rc.2` (from `v9.6.0-rc.1`) and adjusts the bottom compare links so `Unreleased` now compares from `v9.6.0-rc.2` and includes the new `v9.6.0-rc.2` reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ecbcb71971d94159464fb9b3358e1d9da5471b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to v9.6.0-rc.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->