### PR TITLE
Exclude .gem files from git and gemspec files list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shakapacker (9.6.0.rc.3)
+    shakapacker (9.6.0.rc.2)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/lib/shakapacker/version.rb
+++ b/lib/shakapacker/version.rb
@@ -1,4 +1,4 @@
 module Shakapacker
   # Change the version in package.json too, please!
-  VERSION = "9.6.0.rc.3".freeze
+  VERSION = "9.6.0.rc.2".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shakapacker",
-  "version": "9.6.0-rc.3",
+  "version": "9.6.0-rc.2",
   "description": "Use webpack to manage app-like JavaScript modules in Rails",
   "homepage": "https://github.com/shakacode/shakapacker",
   "bugs": {

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (9.6.0.rc.3)
+    shakapacker (9.6.0.rc.2)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)


### PR DESCRIPTION
## Summary
- Adds `*.gem` to `.gitignore` to prevent built gem files from being staged by git (e.g., during `release-it`'s commit flow)
- Adds `.gem` file exclusion to the gemspec's reject filter as a safety net

Fixes the release script failure where `bundle install` in `spec/dummy` fails with RubyGems' `validate_self_inclusion_in_files_list` error: `shakapacker-9.6.0.rc.2 contains itself (shakapacker-9.6.0.rc.2.gem), check your files list`

## Test plan
- [ ] Run `bundle exec gem build shakapacker.gemspec` and verify the `.gem` file is gitignored
- [ ] Run a dry-run release to verify the full flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small packaging/release hygiene change limited to `.gitignore` and gemspec file selection logic.
> 
> **Overview**
> Prevents built RubyGems artifacts from being accidentally committed or packaged by **ignoring `*.gem` outputs**.
> 
> Updates `shakapacker.gemspec`’s `s.files` filter to explicitly reject `.gem` files as a safety net, avoiding self-inclusion errors during gem build/release flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d88a857002b620447429fe99f3ce6841c01fd4f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude built gem files from version control and package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->