### PR TITLE
Update dummy app lockfile to shakapacker 9.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,4 +251,4 @@ DEPENDENCIES
   shakapacker!
 
 BUNDLED WITH
-   4.0.7
+   2.5.23

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -336,4 +336,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   4.0.7
+   2.5.23


### PR DESCRIPTION
## Summary
- updates `spec/dummy/Gemfile.lock` so the local path gem is locked at stable `shakapacker 9.6.0` instead of `9.6.0.rc.3`
- keeps the Bundler/Ruby support-policy discussion out of `9.x`; that broader work is tracked in #960 for `10.0.0`

## Test plan
- [ ] CI passes
- [ ] Lockfile-only diff reviewed

## Notes
- no application code changes
- no Bundler baseline change in this PR