### PR TITLE
Add changelog entries for PRs #963 and #900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [v9.6.1] - March 8, 2026
+
 ### Fixed
 
 - **Fixed `Env#current` crashing when Rails is not loaded**. [PR #963](https://github.com/shakacode/shakapacker/pull/963) by [ihabadham](https://github.com/ihabadham). Added `defined?(Rails)` guard to `Shakapacker::Env#current` so it falls back to `RAILS_ENV`/`RACK_ENV` environment variables when called from non-Rails Ruby processes (e.g., `bin/dev` scripts). Previously, this would raise a `NameError` and silently fall back to `"production"`.
@@ -874,7 +876,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.0...main
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.1...main
+[v9.6.1]: https://github.com/shakacode/shakapacker/compare/v9.6.0...v9.6.1
 [v9.6.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0
 [v9.5.0]: https://github.com/shakacode/shakapacker/compare/v9.4.0...v9.5.0
 [v9.4.0]: https://github.com/shakacode/shakapacker/compare/v9.3.4...v9.4.0


### PR DESCRIPTION
## Summary

- Added [Unreleased] changelog entries for two merged PRs missing from CHANGELOG.md:
  - **PR #963**: Fixed `Env#current` crashing when Rails is not loaded (bug fix by @ihabadham)
  - **PR #900**: Added Node package API documentation (by @justin808)
- Skipped non-user-visible PRs: #958, #957, #959

## Test plan

- [x] `yarn lint` passes
- [x] Changelog formatting matches existing conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change confined to `CHANGELOG.md`, with no runtime or build behavior impact.
> 
> **Overview**
> Updates `CHANGELOG.md` under **[Unreleased]** to document two previously-merged changes: a fix preventing `Env#current` from crashing when Rails isn’t loaded, and new documentation for the Node package JavaScript API (`docs/node_package_api.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81bf2b8b4964f9cc9632a61b9595db5988b14dd0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling when Rails is not loaded.

* **Documentation**
  * Added new Node package API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->