### PR TITLE
Strip changelog version header from GitHub release notes

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -318,7 +318,8 @@ def extract_changelog_section(changelog_path:, npm_version:)
   return nil unless start_index
 
   end_index = ((start_index + 1)...lines.length).find { |idx| lines[idx].start_with?("## [") } || lines.length
-  lines[start_index...end_index].join.rstrip
+  # Skip the version header line itself — GitHub releases display the title separately.
+  lines[(start_index + 1)...end_index].join.strip
 end
 
 def prepare_github_release_context(gem_root:, npm_version:, gem_version:)


### PR DESCRIPTION
## Summary

- **Removed duplicate version header from GitHub release notes body**. `extract_changelog_section` was including the `## [vX.Y.Z] - Date` header line in the notes, causing it to render redundantly since GitHub releases already display a separate title (`v9.6.1`). Now skips the header line and returns only the section content.

## Test plan

- [x] `bundle exec rubocop rakelib/release.rake` passes
- [ ] Verify with `rake "sync_github_release[9.6.1,true]"` dry run
- [ ] Re-sync v9.6.1 release after merging: `rake "sync_github_release[9.6.1]"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to release-note formatting; minimal functional impact outside GitHub release text output.
> 
> **Overview**
> Updates `extract_changelog_section` in `rakelib/release.rake` to **exclude the version header line** (`## [vX.Y.Z] ...`) from the GitHub release notes body, returning only the section content.
> 
> This prevents duplicate version titles in GitHub releases and slightly changes whitespace trimming by using `strip` on the extracted content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c643c56968c4fc9e91728ca309e68da788c47c9e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved changelog extraction during release process to properly skip version headers and handle whitespace trimming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->