### PR TITLE
Supersede #961 by using pack-config-diff

### DIFF
--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yalc link shakapacker
           yarn install
+          yalc link shakapacker
 
       - name: Switch to Webpack
         run: bin/test-bundler webpack
@@ -109,8 +109,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yalc link shakapacker
           yarn install
+          yalc link shakapacker
 
       - name: Switch to RSpack
         run: bin/test-bundler rspack
@@ -162,8 +162,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yalc link shakapacker
           yarn install
+          yalc link shakapacker
 
       - name: Test switching between bundlers
         run: |

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          yarn install
           yalc add shakapacker
 
       - name: Switch to Webpack
@@ -108,6 +109,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          yarn install
           yalc add shakapacker
 
       - name: Switch to RSpack
@@ -160,6 +162,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          yarn install
           yalc add shakapacker
 
       - name: Test switching between bundlers

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           yarn install
           yalc add shakapacker
+          yarn install
 
       - name: Switch to Webpack
         run: bin/test-bundler webpack
@@ -111,6 +112,7 @@ jobs:
         run: |
           yarn install
           yalc add shakapacker
+          yarn install
 
       - name: Switch to RSpack
         run: bin/test-bundler rspack
@@ -164,6 +166,7 @@ jobs:
         run: |
           yarn install
           yalc add shakapacker
+          yarn install
 
       - name: Test switching between bundlers
         run: |

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -56,8 +56,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install
-          yalc link shakapacker
+          yalc add shakapacker
 
       - name: Switch to Webpack
         run: bin/test-bundler webpack
@@ -109,8 +108,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install
-          yalc link shakapacker
+          yalc add shakapacker
 
       - name: Switch to RSpack
         run: bin/test-bundler rspack
@@ -162,8 +160,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install
-          yalc link shakapacker
+          yalc add shakapacker
 
       - name: Test switching between bundlers
         run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ lib/install/config/**/*.js
 # Temporarily ignore workflow files that cannot be modified in PRs due to claude-review validation
 .github/workflows/claude.yml
 .github/workflows/claude-code-review.yml
+.context/

--- a/README.md
+++ b/README.md
@@ -960,6 +960,32 @@ This exports development and production configurations for both client and serve
 
 For more options and usage examples, see the [Troubleshooting Guide](./docs/troubleshooting.md#exporting-webpack--rspack-configuration).
 
+#### Comparing Configurations
+
+Once you've exported configurations, compare them semantically with `bin/diff-bundler-config` (powered by [`pack-config-diff`](https://github.com/shakacode/pack-config-diff)):
+
+```bash
+# Compare development vs production configs
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports/webpack-development-client.yaml \
+  --right=shakapacker-config-exports/webpack-production-client.yaml
+
+# Get a quick summary
+bin/diff-bundler-config \
+  --left=config1.yaml \
+  --right=config2.yaml \
+  --format=summary
+```
+
+This is useful for:
+
+- Understanding environment-specific config changes
+- Debugging unexpected behavior differences
+- Migration validation (webpack -> rspack)
+- Reviewing bundler config changes in PRs
+
+For full usage, see the [Configuration Diff Guide](./docs/config-diff.md).
+
 ### Integrations
 
 Shakapacker out of the box supports JS and static assets (fonts, images etc.) compilation. To enable support for CoffeeScript or TypeScript install relevant packages:

--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,8 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "yalc link shakapacker",
         "npm install",
+        "yalc link shakapacker",
         "bin/test-bundler webpack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -44,8 +44,8 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "yalc link shakapacker",
         "npm install",
+        "yalc link shakapacker",
         "bin/test-bundler rspack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -61,8 +61,8 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "yalc link shakapacker",
         "npm install",
+        "yalc link shakapacker",
         "NODE_ENV=test RAILS_ENV=test npm exec --no -- rspack build --config config/rspack/rspack.config.js",
         "bundle exec rspec"
       ])

--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
-        "yalc link shakapacker",
+        "yalc add shakapacker",
         "bin/test-bundler webpack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -44,8 +43,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
-        "yalc link shakapacker",
+        "yalc add shakapacker",
         "bin/test-bundler rspack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -61,8 +59,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
-        "yalc link shakapacker",
+        "yalc add shakapacker",
         "NODE_ENV=test RAILS_ENV=test npm exec --no -- rspack build --config config/rspack/rspack.config.js",
         "bundle exec rspec"
       ])

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
+        "yarn install",
         "yalc add shakapacker",
         "yarn install",
         "bin/test-bundler webpack",
@@ -45,7 +45,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
+        "yarn install",
         "yalc add shakapacker",
         "yarn install",
         "bin/test-bundler rspack",
@@ -63,7 +63,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
-        "npm install",
+        "yarn install",
         "yalc add shakapacker",
         "yarn install",
         "NODE_ENV=test RAILS_ENV=test npm exec --no -- rspack build --config config/rspack/rspack.config.js",

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
+        "npm install",
         "yalc add shakapacker",
         "bin/test-bundler webpack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
@@ -43,6 +44,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
+        "npm install",
         "yalc add shakapacker",
         "bin/test-bundler rspack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
@@ -59,6 +61,7 @@ namespace :run_spec do
       sh_in_dir(".", "yalc publish")
       sh_in_dir(spec_dummy_dir, [
         "bundle install",
+        "npm install",
         "yalc add shakapacker",
         "NODE_ENV=test RAILS_ENV=test npm exec --no -- rspack build --config config/rspack/rspack.config.js",
         "bundle exec rspec"

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ namespace :run_spec do
         "bundle install",
         "npm install",
         "yalc add shakapacker",
+        "yarn install",
         "bin/test-bundler webpack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -46,6 +47,7 @@ namespace :run_spec do
         "bundle install",
         "npm install",
         "yalc add shakapacker",
+        "yarn install",
         "bin/test-bundler rspack",
         "NODE_ENV=test RAILS_ENV=test bin/shakapacker",
         "bundle exec rspec"
@@ -63,6 +65,7 @@ namespace :run_spec do
         "bundle install",
         "npm install",
         "yalc add shakapacker",
+        "yarn install",
         "NODE_ENV=test RAILS_ENV=test npm exec --no -- rspack build --config config/rspack/rspack.config.js",
         "bundle exec rspec"
       ])

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -19,10 +19,25 @@ function isMissingPackConfigDiff(error) {
   )
 }
 
+function exitWithCode(exitCode) {
+  if (!Number.isInteger(exitCode)) {
+    console.error(
+      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} returned a non-integer exit code: ${String(exitCode)}`
+    )
+    process.exit(1)
+  }
+
+  process.exit(exitCode)
+}
+
 function runViaNpx() {
+  console.error(
+    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
+      "Falling back to npx and prompting before download."
+  )
   const result = spawnSync(
     "npx",
-    ["-y", PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
+    [PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 
@@ -60,8 +75,18 @@ if (typeof run !== "function") {
 }
 
 try {
-  const exitCode = run(process.argv.slice(2))
-  process.exit(exitCode)
+  const runResult = run(process.argv.slice(2))
+
+  if (runResult && typeof runResult.then === "function") {
+    runResult
+      .then((exitCode) => exitWithCode(exitCode))
+      .catch((error) => {
+        console.error(formatError(error))
+        process.exit(1)
+      })
+  } else {
+    exitWithCode(runResult)
+  }
 } catch (error) {
   console.error(formatError(error))
   process.exit(1)

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -31,10 +31,7 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
-  if (
-    (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") &&
-    !process.stdin.isTTY
-  ) {
+  if (process.env.CI && !process.stdin.isTTY) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
@@ -59,7 +56,7 @@ function runViaNpx() {
     process.exit(2)
   }
 
-  process.exit(result.status ?? 1)
+  process.exit(result.status ?? 2)
 }
 
 let run
@@ -69,7 +66,8 @@ try {
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
-    return runViaNpx()
+    runViaNpx()
+    process.exit(2)
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process")
+
+function runViaNpx() {
+  const result = spawnSync(
+    "npx",
+    ["-y", "github:shakacode/pack-config-diff", ...process.argv.slice(2)],
+    { stdio: "inherit" }
+  )
+
+  if (result.error) {
+    console.error(
+      `[Shakapacker] Failed to run pack-config-diff via npx: ${result.error.message}`
+    )
+    process.exit(1)
+  }
+
+  process.exit(result.status ?? 1)
+}
+
+let run
+
+try {
+  const loadedModule = require("pack-config-diff")
+  run = loadedModule.run
+} catch (error) {
+  if (error && error.code === "MODULE_NOT_FOUND") {
+    runViaNpx()
+  }
+
+  throw error
+}
+
+try {
+  const exitCode = run(process.argv.slice(2))
+  process.exit(exitCode)
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -24,7 +24,7 @@ function exitWithCode(exitCode) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} returned a non-integer exit code: ${String(exitCode)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   process.exit(exitCode)
@@ -39,7 +39,7 @@ function runViaNpx() {
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   console.error(
@@ -56,7 +56,7 @@ function runViaNpx() {
     console.error(
       `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   process.exit(result.status ?? 1)
@@ -74,7 +74,7 @@ try {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 }
 
@@ -82,7 +82,7 @@ if (typeof run !== "function") {
   console.error(
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} did not export a run() function`
   )
-  process.exit(1)
+  process.exit(2)
 }
 
 try {
@@ -93,12 +93,12 @@ try {
       .then((exitCode) => exitWithCode(exitCode))
       .catch((error) => {
         console.error(formatError(error))
-        process.exit(1)
+        process.exit(2)
       })
   } else {
     exitWithCode(runResult)
   }
 } catch (error) {
   console.error(formatError(error))
-  process.exit(1)
+  process.exit(2)
 }

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -2,16 +2,33 @@
 
 const { spawnSync } = require("child_process")
 
+const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
+const PACK_CONFIG_DIFF_REF =
+  "github:shakacode/pack-config-diff#6bb09f4ba933ef5978c534b1c278156e438dce2e"
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMissingPackConfigDiff(error) {
+  return (
+    error &&
+    error.code === "MODULE_NOT_FOUND" &&
+    typeof error.message === "string" &&
+    error.message.includes(`'${PACK_CONFIG_DIFF_PACKAGE}'`)
+  )
+}
+
 function runViaNpx() {
   const result = spawnSync(
     "npx",
-    ["-y", "github:shakacode/pack-config-diff", ...process.argv.slice(2)],
+    ["-y", PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 
   if (result.error) {
     console.error(
-      `[Shakapacker] Failed to run pack-config-diff via npx: ${result.error.message}`
+      `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
     )
     process.exit(1)
   }
@@ -22,20 +39,30 @@ function runViaNpx() {
 let run
 
 try {
-  const loadedModule = require("pack-config-diff")
+  const loadedModule = require(PACK_CONFIG_DIFF_PACKAGE)
   run = loadedModule.run
 } catch (error) {
-  if (error && error.code === "MODULE_NOT_FOUND") {
+  if (isMissingPackConfigDiff(error)) {
     runViaNpx()
+  } else {
+    console.error(
+      `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
+    )
+    process.exit(1)
   }
+}
 
-  throw error
+if (typeof run !== "function") {
+  console.error(
+    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} did not export a run() function`
+  )
+  process.exit(1)
 }
 
 try {
   const exitCode = run(process.argv.slice(2))
   process.exit(exitCode)
 } catch (error) {
-  console.error(error.message)
+  console.error(formatError(error))
   process.exit(1)
 }

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -31,6 +31,17 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
+  if (
+    (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") &&
+    !process.stdin.isTTY
+  ) {
+    console.error(
+      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
+        `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
+    )
+    process.exit(1)
+  }
+
   console.error(
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
       "Falling back to npx and prompting before download."
@@ -58,7 +69,7 @@ try {
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
-    runViaNpx()
+    return runViaNpx()
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -9,7 +9,8 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE]
+      (pkg.optionalDependencies && pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {
     // Fall through to default
@@ -42,7 +43,7 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
-  if (process.env.CI && !process.stdin.isTTY) {
+  if (process.env.CI) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -9,7 +9,8 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      (pkg.optionalDependencies && pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.optionalDependencies &&
+        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
       (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -40,7 +40,9 @@ function exitWithCode(exitCode) {
     process.exit(2)
   }
 
-  process.exit(exitCode)
+  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
+  // Any other code is a tool failure — normalize to 2, matching the npx fallback path.
+  process.exit(exitCode <= 1 ? exitCode : 2)
 }
 
 function runViaNpx() {

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -77,7 +77,7 @@ function runViaNpx() {
 let run
 
 try {
-  const loadedModule = require(PACK_CONFIG_DIFF_PACKAGE)
+  const loadedModule = require("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -1,9 +1,23 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require("child_process")
+const path = require("path")
 
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-const PACK_CONFIG_DIFF_NPX_SPEC = "pack-config-diff@^0.1.0"
+
+function getNpxSpec() {
+  try {
+    const pkg = require(path.join(__dirname, "..", "package.json"))
+    const version =
+      (pkg.optionalDependencies &&
+        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
+    if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
+  } catch (_) {
+    // Fall through to default
+  }
+  return `${PACK_CONFIG_DIFF_PACKAGE}@^0.1.0`
+}
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
@@ -42,11 +56,9 @@ function runViaNpx() {
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
       "Falling back to npx and prompting before download."
   )
-  const result = spawnSync(
-    "npx",
-    [PACK_CONFIG_DIFF_NPX_SPEC, ...process.argv.slice(2)],
-    { stdio: "inherit" }
-  )
+  const result = spawnSync("npx", [getNpxSpec(), ...process.argv.slice(2)], {
+    stdio: "inherit"
+  })
 
   if (result.error) {
     console.error(
@@ -55,7 +67,13 @@ function runViaNpx() {
     process.exit(2)
   }
 
-  process.exit(result.status ?? 2)
+  if (result.signal || result.status == null) {
+    process.exit(2)
+  }
+
+  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
+  // Any other code (e.g. 127 = npx not found, 126 = permission denied) is a tool failure.
+  process.exit(result.status <= 1 ? result.status : 2)
 }
 
 let run
@@ -66,7 +84,6 @@ try {
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
     runViaNpx()
-    process.exit(2)
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const { createRequire } = require("module")
+
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
 
 function formatError(error) {
@@ -22,7 +24,12 @@ function exitWithCode(exitCode) {
 let run
 
 try {
-  const loadedModule = require("pack-config-diff")
+  // Resolve pack-config-diff via shakapacker's dependency tree so strict package
+  // managers (pnpm, Yarn PnP) can find the transitive dependency.
+  const shakapackerRequire = createRequire(
+    require.resolve("shakapacker/package.json")
+  )
+  const loadedModule = shakapackerRequire("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
   console.error(

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -1,35 +1,9 @@
 #!/usr/bin/env node
 
-const { spawnSync } = require("child_process")
-const path = require("path")
-
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-
-function getNpxSpec() {
-  try {
-    const pkg = require(path.join(__dirname, "..", "package.json"))
-    const version =
-      (pkg.optionalDependencies &&
-        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
-      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
-    if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
-  } catch (_) {
-    // Fall through to default
-  }
-  return `${PACK_CONFIG_DIFF_PACKAGE}@^0.1.0`
-}
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
-}
-
-function isMissingPackConfigDiff(error) {
-  return (
-    error &&
-    error.code === "MODULE_NOT_FOUND" &&
-    typeof error.message === "string" &&
-    error.message.includes(`'${PACK_CONFIG_DIFF_PACKAGE}'`)
-  )
 }
 
 function exitWithCode(exitCode) {
@@ -41,41 +15,8 @@ function exitWithCode(exitCode) {
   }
 
   // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
-  // Any other code is a tool failure — normalize to 2, matching the npx fallback path.
+  // Any other code is a tool failure — normalize to 2.
   process.exit(exitCode <= 1 ? exitCode : 2)
-}
-
-function runViaNpx() {
-  if (process.env.CI) {
-    console.error(
-      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
-        `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
-    )
-    process.exit(2)
-  }
-
-  console.error(
-    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
-      "Falling back to npx and prompting before download."
-  )
-  const result = spawnSync("npx", [getNpxSpec(), ...process.argv.slice(2)], {
-    stdio: "inherit"
-  })
-
-  if (result.error) {
-    console.error(
-      `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
-    )
-    process.exit(2)
-  }
-
-  if (result.signal || result.status == null) {
-    process.exit(2)
-  }
-
-  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
-  // Any other code (e.g. 127 = npx not found, 126 = permission denied) is a tool failure.
-  process.exit(result.status <= 1 ? result.status : 2)
 }
 
 let run
@@ -84,14 +25,10 @@ try {
   const loadedModule = require("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
-  if (isMissingPackConfigDiff(error)) {
-    runViaNpx()
-  } else {
-    console.error(
-      `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
-    )
-    process.exit(2)
-  }
+  console.error(
+    `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
+  )
+  process.exit(2)
 }
 
 if (typeof run !== "function") {

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -9,9 +9,7 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      (pkg.optionalDependencies &&
-        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
-      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
+      pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE]
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {
     // Fall through to default

--- a/bin/diff-bundler-config
+++ b/bin/diff-bundler-config
@@ -3,8 +3,7 @@
 const { spawnSync } = require("child_process")
 
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-const PACK_CONFIG_DIFF_REF =
-  "github:shakacode/pack-config-diff#6bb09f4ba933ef5978c534b1c278156e438dce2e"
+const PACK_CONFIG_DIFF_NPX_SPEC = "pack-config-diff@^0.1.0"
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
@@ -45,7 +44,7 @@ function runViaNpx() {
   )
   const result = spawnSync(
     "npx",
-    [PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
+    [PACK_CONFIG_DIFF_NPX_SPEC, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 

--- a/docs/config-diff.md
+++ b/docs/config-diff.md
@@ -1,0 +1,158 @@
+# Configuration Diff Tool
+
+Shakapacker includes a semantic configuration diff workflow for webpack/rspack configs via [`pack-config-diff`](https://github.com/shakacode/pack-config-diff).
+
+This gives you structured, meaningful diffs instead of raw line-by-line file diffs.
+
+## Why use this instead of `diff`?
+
+Traditional file diff tools are great for source code, but generated bundler configs are noisy and deeply nested.
+
+Semantic diffing is better for this use case because it:
+
+- Understands nested webpack/rspack configuration objects
+- Supports filtering noisy sections with `--ignore-keys` and `--ignore-paths`
+- Normalizes machine-specific absolute paths by default
+- Supports summary, detailed, JSON, and YAML output formats
+- Handles config-specific value types (functions, RegExp, Date)
+
+## Quick Start
+
+Export configs, then diff them:
+
+```bash
+# Export all standard configs (dev/prod + client/server)
+bin/shakapacker-config --doctor
+
+# Compare development vs production client config
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports/webpack-development-client.yaml \
+  --right=shakapacker-config-exports/webpack-production-client.yaml
+```
+
+## Common Workflows
+
+### 1. Works in development, broken in production
+
+```bash
+bin/shakapacker-config --doctor
+
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports/webpack-development-client.yaml \
+  --right=shakapacker-config-exports/webpack-production-client.yaml \
+  --format=summary
+```
+
+### 2. Compare client vs server bundles
+
+```bash
+bin/shakapacker-config --doctor
+
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports/webpack-production-client.yaml \
+  --right=shakapacker-config-exports/webpack-production-server.yaml
+```
+
+### 3. Webpack to Rspack migration validation
+
+```bash
+# Export webpack state
+bin/shakapacker-config --doctor
+
+# Switch bundler
+bundle exec rake shakapacker:switch_bundler rspack --install-deps
+
+# Export rspack state
+bin/shakapacker-config --doctor
+
+# Compare two snapshots (rename or copy files as needed)
+bin/diff-bundler-config \
+  --left=webpack-production-client.yaml \
+  --right=rspack-production-client.yaml \
+  --ignore-paths="plugins.*"
+```
+
+### 4. Capture machine-readable report for CI or PR artifacts
+
+```bash
+bin/diff-bundler-config \
+  --left=baseline.yaml \
+  --right=current.yaml \
+  --format=json \
+  --output=config-diff.json
+```
+
+## Output Formats
+
+```bash
+# Detailed (default)
+bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=detailed
+
+# Summary
+bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=summary
+
+# JSON
+bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=json
+
+# YAML
+bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=yaml
+```
+
+## Useful Options
+
+```bash
+# Include unchanged values
+--include-unchanged
+
+# Limit recursion depth
+--max-depth=5
+
+# Ignore keys globally
+--ignore-keys=timestamp,version
+
+# Ignore paths (supports wildcards)
+--ignore-paths="plugins.*,output.path"
+
+# Disable automatic path normalization
+--no-normalize-paths
+```
+
+## Supported Input Files
+
+- JSON (`.json`)
+- YAML (`.yaml`, `.yml`)
+- JavaScript (`.js`)
+- TypeScript (`.ts`, requires `ts-node`)
+
+## Exit Codes
+
+- `0`: no differences found
+- `1`: differences found or error occurred
+
+This makes the tool easy to use in CI checks.
+
+## Programmatic Usage
+
+You can use the package directly in scripts:
+
+```js
+const { DiffEngine, DiffFormatter } = require("pack-config-diff")
+
+const engine = new DiffEngine({
+  ignorePaths: ["plugins.*"]
+})
+
+const result = engine.compare(leftConfig, rightConfig, {
+  leftFile: "webpack.dev.js",
+  rightFile: "webpack.prod.js"
+})
+
+const formatter = new DiffFormatter()
+console.log(formatter.formatDetailed(result))
+```
+
+## See Also
+
+- [Troubleshooting Guide](./troubleshooting.md)
+- [Rspack Migration Guide](./rspack_migration_guide.md)
+- [pack-config-diff repository](https://github.com/shakacode/pack-config-diff)

--- a/docs/config-diff.md
+++ b/docs/config-diff.md
@@ -129,7 +129,7 @@ bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=yaml
 - `0`: no differences found
 - `1`: differences found or error occurred
 
-This makes the tool easy to use in CI checks.
+For CI usage, treat non-zero as "configs are not identical" and inspect stderr/output for error details.
 
 ## Programmatic Usage
 

--- a/docs/config-diff.md
+++ b/docs/config-diff.md
@@ -127,9 +127,10 @@ bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=yaml
 ## Exit Codes
 
 - `0`: no differences found
-- `1`: differences found or error occurred
+- `1`: differences found
+- `2`: wrapper/runtime error (module load error, invalid return code, npx fallback failure)
 
-For CI usage, treat non-zero as "configs are not identical" and inspect stderr/output for error details.
+For CI usage, treat `1` as "configs differ" and `2` as "tool/runtime failure".
 
 ## Programmatic Usage
 

--- a/docs/config-diff.md
+++ b/docs/config-diff.md
@@ -128,7 +128,7 @@ bin/diff-bundler-config --left=a.yaml --right=b.yaml --format=yaml
 
 - `0`: no differences found
 - `1`: differences found
-- `2`: wrapper/runtime error (module load error, invalid return code, npx fallback failure)
+- `2`: wrapper/runtime error (module load error, invalid return code)
 
 For CI usage, treat `1` as "configs differ" and `2` as "tool/runtime failure".
 

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -823,9 +823,11 @@ bin/rake shakapacker:switch_bundler rspack -- --install-deps
 # Export rspack configs to compare
 bin/shakapacker-config --doctor
 
-# Compare the files in shakapacker-config-exports/
-diff shakapacker-config-exports/webpack-production-client.yaml \
-     shakapacker-config-exports/rspack-production-client.yaml
+# Compare with semantic config diffing
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports/webpack-production-client.yaml \
+  --right=shakapacker-config-exports/rspack-production-client.yaml \
+  --format=summary
 ```
 
 The config export utility creates annotated YAML files that make it easy to:
@@ -836,6 +838,7 @@ The config export utility creates annotated YAML files that make it easy to:
 - Debug configuration issues
 
 See the [Troubleshooting Guide](./troubleshooting.md#exporting-webpack--rspack-configuration) for more details.
+For semantic diff workflows, see the [Configuration Diff Guide](./config-diff.md).
 
 ## Resources
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,7 +56,10 @@ If you're experiencing FOUC where content briefly appears unstyled before CSS lo
 
    # Compare development vs production configs
    bin/shakapacker-config --save --save-dir=./configs
-   diff configs/webpack-development-client.yaml configs/webpack-production-client.yaml
+   bin/diff-bundler-config \
+     --left=configs/webpack-development-client.yaml \
+     --right=configs/webpack-production-client.yaml \
+     --format=summary
 
    # View config in terminal (no files created)
    bin/shakapacker-config
@@ -72,8 +75,10 @@ If you're experiencing FOUC where content briefly appears unstyled before CSS lo
    - Examples: `webpack-development-client.yaml`, `rspack-production-server.yaml`
    - YAML format includes inline documentation explaining each config key
    - Separate files for client and server bundles (cleaner than combined)
+   - Pair with `bin/diff-bundler-config` for semantic comparisons
 
    See `bin/shakapacker-config --help` for all available options.
+   For semantic comparisons, see the [Configuration Diff Guide](./config-diff.md).
 
 6. **Validate your webpack/rspack builds**: Use `bin/shakapacker-config --validate` to test that all your build configurations compile successfully. This is especially useful for:
    - **CI/CD pipelines**: Catch configuration errors before deployment

--- a/knip.ts
+++ b/knip.ts
@@ -1,7 +1,13 @@
 import type { KnipConfig } from "knip"
 
 const config: KnipConfig = {
-  project: ["package/**/*.{ts,js}", "test/**/*.{ts,js}", "scripts/**/*.js"],
+  project: [
+    "package/**/*.{ts,js}",
+    "test/**/*.{ts,js}",
+    "scripts/**/*.js",
+    "bin/diff-bundler-config",
+    "lib/install/bin/diff-bundler-config"
+  ],
   ignore: [
     "package/**/*.d.ts",
     "package/**/*.js",
@@ -28,6 +34,8 @@ const config: KnipConfig = {
     "@rspack/cli",
     "webpack-cli",
     "husky",
+    // Used by bin/diff-bundler-config wrappers (outside knip's core package scan)
+    "pack-config-diff",
     // Optional dependencies used in webpack/rspack configs
     "mini-css-extract-plugin",
     "webpack-assets-manifest",

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -19,10 +19,25 @@ function isMissingPackConfigDiff(error) {
   )
 }
 
+function exitWithCode(exitCode) {
+  if (!Number.isInteger(exitCode)) {
+    console.error(
+      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} returned a non-integer exit code: ${String(exitCode)}`
+    )
+    process.exit(1)
+  }
+
+  process.exit(exitCode)
+}
+
 function runViaNpx() {
+  console.error(
+    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
+      "Falling back to npx and prompting before download."
+  )
   const result = spawnSync(
     "npx",
-    ["-y", PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
+    [PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 
@@ -60,8 +75,18 @@ if (typeof run !== "function") {
 }
 
 try {
-  const exitCode = run(process.argv.slice(2))
-  process.exit(exitCode)
+  const runResult = run(process.argv.slice(2))
+
+  if (runResult && typeof runResult.then === "function") {
+    runResult
+      .then((exitCode) => exitWithCode(exitCode))
+      .catch((error) => {
+        console.error(formatError(error))
+        process.exit(1)
+      })
+  } else {
+    exitWithCode(runResult)
+  }
 } catch (error) {
   console.error(formatError(error))
   process.exit(1)

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -31,10 +31,7 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
-  if (
-    (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") &&
-    !process.stdin.isTTY
-  ) {
+  if (process.env.CI && !process.stdin.isTTY) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
@@ -59,7 +56,7 @@ function runViaNpx() {
     process.exit(2)
   }
 
-  process.exit(result.status ?? 1)
+  process.exit(result.status ?? 2)
 }
 
 let run
@@ -69,7 +66,8 @@ try {
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
-    return runViaNpx()
+    runViaNpx()
+    process.exit(2)
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process")
+
+function runViaNpx() {
+  const result = spawnSync(
+    "npx",
+    ["-y", "github:shakacode/pack-config-diff", ...process.argv.slice(2)],
+    { stdio: "inherit" }
+  )
+
+  if (result.error) {
+    console.error(
+      `[Shakapacker] Failed to run pack-config-diff via npx: ${result.error.message}`
+    )
+    process.exit(1)
+  }
+
+  process.exit(result.status ?? 1)
+}
+
+let run
+
+try {
+  const loadedModule = require("pack-config-diff")
+  run = loadedModule.run
+} catch (error) {
+  if (error && error.code === "MODULE_NOT_FOUND") {
+    runViaNpx()
+  }
+
+  throw error
+}
+
+try {
+  const exitCode = run(process.argv.slice(2))
+  process.exit(exitCode)
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -24,7 +24,7 @@ function exitWithCode(exitCode) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} returned a non-integer exit code: ${String(exitCode)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   process.exit(exitCode)
@@ -39,7 +39,7 @@ function runViaNpx() {
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   console.error(
@@ -56,7 +56,7 @@ function runViaNpx() {
     console.error(
       `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 
   process.exit(result.status ?? 1)
@@ -74,7 +74,7 @@ try {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
     )
-    process.exit(1)
+    process.exit(2)
   }
 }
 
@@ -82,7 +82,7 @@ if (typeof run !== "function") {
   console.error(
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} did not export a run() function`
   )
-  process.exit(1)
+  process.exit(2)
 }
 
 try {
@@ -93,12 +93,12 @@ try {
       .then((exitCode) => exitWithCode(exitCode))
       .catch((error) => {
         console.error(formatError(error))
-        process.exit(1)
+        process.exit(2)
       })
   } else {
     exitWithCode(runResult)
   }
 } catch (error) {
   console.error(formatError(error))
-  process.exit(1)
+  process.exit(2)
 }

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -2,16 +2,33 @@
 
 const { spawnSync } = require("child_process")
 
+const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
+const PACK_CONFIG_DIFF_REF =
+  "github:shakacode/pack-config-diff#6bb09f4ba933ef5978c534b1c278156e438dce2e"
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMissingPackConfigDiff(error) {
+  return (
+    error &&
+    error.code === "MODULE_NOT_FOUND" &&
+    typeof error.message === "string" &&
+    error.message.includes(`'${PACK_CONFIG_DIFF_PACKAGE}'`)
+  )
+}
+
 function runViaNpx() {
   const result = spawnSync(
     "npx",
-    ["-y", "github:shakacode/pack-config-diff", ...process.argv.slice(2)],
+    ["-y", PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 
   if (result.error) {
     console.error(
-      `[Shakapacker] Failed to run pack-config-diff via npx: ${result.error.message}`
+      `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
     )
     process.exit(1)
   }
@@ -22,20 +39,30 @@ function runViaNpx() {
 let run
 
 try {
-  const loadedModule = require("pack-config-diff")
+  const loadedModule = require(PACK_CONFIG_DIFF_PACKAGE)
   run = loadedModule.run
 } catch (error) {
-  if (error && error.code === "MODULE_NOT_FOUND") {
+  if (isMissingPackConfigDiff(error)) {
     runViaNpx()
+  } else {
+    console.error(
+      `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
+    )
+    process.exit(1)
   }
+}
 
-  throw error
+if (typeof run !== "function") {
+  console.error(
+    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} did not export a run() function`
+  )
+  process.exit(1)
 }
 
 try {
   const exitCode = run(process.argv.slice(2))
   process.exit(exitCode)
 } catch (error) {
-  console.error(error.message)
+  console.error(formatError(error))
   process.exit(1)
 }

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -31,6 +31,17 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
+  if (
+    (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") &&
+    !process.stdin.isTTY
+  ) {
+    console.error(
+      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
+        `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
+    )
+    process.exit(1)
+  }
+
   console.error(
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
       "Falling back to npx and prompting before download."
@@ -58,7 +69,7 @@ try {
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
-    runViaNpx()
+    return runViaNpx()
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -9,7 +9,8 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE]
+      (pkg.optionalDependencies && pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {
     // Fall through to default
@@ -42,7 +43,7 @@ function exitWithCode(exitCode) {
 }
 
 function runViaNpx() {
-  if (process.env.CI && !process.stdin.isTTY) {
+  if (process.env.CI) {
     console.error(
       `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
         `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -9,7 +9,8 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      (pkg.optionalDependencies && pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.optionalDependencies &&
+        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
       (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -40,7 +40,9 @@ function exitWithCode(exitCode) {
     process.exit(2)
   }
 
-  process.exit(exitCode)
+  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
+  // Any other code is a tool failure — normalize to 2, matching the npx fallback path.
+  process.exit(exitCode <= 1 ? exitCode : 2)
 }
 
 function runViaNpx() {

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -77,7 +77,7 @@ function runViaNpx() {
 let run
 
 try {
-  const loadedModule = require(PACK_CONFIG_DIFF_PACKAGE)
+  const loadedModule = require("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,9 +1,23 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require("child_process")
+const path = require("path")
 
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-const PACK_CONFIG_DIFF_NPX_SPEC = "pack-config-diff@^0.1.0"
+
+function getNpxSpec() {
+  try {
+    const pkg = require(path.join(__dirname, "..", "package.json"))
+    const version =
+      (pkg.optionalDependencies &&
+        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
+      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
+    if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
+  } catch (_) {
+    // Fall through to default
+  }
+  return `${PACK_CONFIG_DIFF_PACKAGE}@^0.1.0`
+}
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
@@ -42,11 +56,9 @@ function runViaNpx() {
     `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
       "Falling back to npx and prompting before download."
   )
-  const result = spawnSync(
-    "npx",
-    [PACK_CONFIG_DIFF_NPX_SPEC, ...process.argv.slice(2)],
-    { stdio: "inherit" }
-  )
+  const result = spawnSync("npx", [getNpxSpec(), ...process.argv.slice(2)], {
+    stdio: "inherit"
+  })
 
   if (result.error) {
     console.error(
@@ -55,7 +67,13 @@ function runViaNpx() {
     process.exit(2)
   }
 
-  process.exit(result.status ?? 2)
+  if (result.signal || result.status == null) {
+    process.exit(2)
+  }
+
+  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
+  // Any other code (e.g. 127 = npx not found, 126 = permission denied) is a tool failure.
+  process.exit(result.status <= 1 ? result.status : 2)
 }
 
 let run
@@ -66,7 +84,6 @@ try {
 } catch (error) {
   if (isMissingPackConfigDiff(error)) {
     runViaNpx()
-    process.exit(2)
   } else {
     console.error(
       `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const { createRequire } = require("module")
+
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
 
 function formatError(error) {
@@ -22,7 +24,12 @@ function exitWithCode(exitCode) {
 let run
 
 try {
-  const loadedModule = require("pack-config-diff")
+  // Resolve pack-config-diff via shakapacker's dependency tree so strict package
+  // managers (pnpm, Yarn PnP) can find the transitive dependency.
+  const shakapackerRequire = createRequire(
+    require.resolve("shakapacker/package.json")
+  )
+  const loadedModule = shakapackerRequire("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
   console.error(

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,35 +1,9 @@
 #!/usr/bin/env node
 
-const { spawnSync } = require("child_process")
-const path = require("path")
-
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-
-function getNpxSpec() {
-  try {
-    const pkg = require(path.join(__dirname, "..", "package.json"))
-    const version =
-      (pkg.optionalDependencies &&
-        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
-      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
-    if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
-  } catch (_) {
-    // Fall through to default
-  }
-  return `${PACK_CONFIG_DIFF_PACKAGE}@^0.1.0`
-}
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
-}
-
-function isMissingPackConfigDiff(error) {
-  return (
-    error &&
-    error.code === "MODULE_NOT_FOUND" &&
-    typeof error.message === "string" &&
-    error.message.includes(`'${PACK_CONFIG_DIFF_PACKAGE}'`)
-  )
 }
 
 function exitWithCode(exitCode) {
@@ -41,41 +15,8 @@ function exitWithCode(exitCode) {
   }
 
   // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
-  // Any other code is a tool failure — normalize to 2, matching the npx fallback path.
+  // Any other code is a tool failure — normalize to 2.
   process.exit(exitCode <= 1 ? exitCode : 2)
-}
-
-function runViaNpx() {
-  if (process.env.CI) {
-    console.error(
-      `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally, and npx fallback requires an interactive prompt. ` +
-        `Install ${PACK_CONFIG_DIFF_PACKAGE} locally before running in CI.`
-    )
-    process.exit(2)
-  }
-
-  console.error(
-    `[Shakapacker] ${PACK_CONFIG_DIFF_PACKAGE} is not installed locally. ` +
-      "Falling back to npx and prompting before download."
-  )
-  const result = spawnSync("npx", [getNpxSpec(), ...process.argv.slice(2)], {
-    stdio: "inherit"
-  })
-
-  if (result.error) {
-    console.error(
-      `[Shakapacker] Failed to run ${PACK_CONFIG_DIFF_PACKAGE} via npx: ${formatError(result.error)}`
-    )
-    process.exit(2)
-  }
-
-  if (result.signal || result.status == null) {
-    process.exit(2)
-  }
-
-  // Forward only pack-config-diff's documented exit codes (0 = no diffs, 1 = diffs found).
-  // Any other code (e.g. 127 = npx not found, 126 = permission denied) is a tool failure.
-  process.exit(result.status <= 1 ? result.status : 2)
 }
 
 let run
@@ -84,14 +25,10 @@ try {
   const loadedModule = require("pack-config-diff")
   run = loadedModule.run
 } catch (error) {
-  if (isMissingPackConfigDiff(error)) {
-    runViaNpx()
-  } else {
-    console.error(
-      `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
-    )
-    process.exit(2)
-  }
+  console.error(
+    `[Shakapacker] Failed to load ${PACK_CONFIG_DIFF_PACKAGE}: ${formatError(error)}`
+  )
+  process.exit(2)
 }
 
 if (typeof run !== "function") {

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -9,9 +9,7 @@ function getNpxSpec() {
   try {
     const pkg = require(path.join(__dirname, "..", "package.json"))
     const version =
-      (pkg.optionalDependencies &&
-        pkg.optionalDependencies[PACK_CONFIG_DIFF_PACKAGE]) ||
-      (pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE])
+      pkg.dependencies && pkg.dependencies[PACK_CONFIG_DIFF_PACKAGE]
     if (version) return `${PACK_CONFIG_DIFF_PACKAGE}@${version}`
   } catch (_) {
     // Fall through to default

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -3,8 +3,7 @@
 const { spawnSync } = require("child_process")
 
 const PACK_CONFIG_DIFF_PACKAGE = "pack-config-diff"
-const PACK_CONFIG_DIFF_REF =
-  "github:shakacode/pack-config-diff#6bb09f4ba933ef5978c534b1c278156e438dce2e"
+const PACK_CONFIG_DIFF_NPX_SPEC = "pack-config-diff@^0.1.0"
 
 function formatError(error) {
   return error instanceof Error ? error.message : String(error)
@@ -45,7 +44,7 @@ function runViaNpx() {
   )
   const result = spawnSync(
     "npx",
-    [PACK_CONFIG_DIFF_REF, ...process.argv.slice(2)],
+    [PACK_CONFIG_DIFF_NPX_SPEC, ...process.argv.slice(2)],
     { stdio: "inherit" }
   )
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -394,10 +394,6 @@ module Shakapacker
           "bin/shakapacker-config" => "Config export binstub"
         }
 
-        optional_binstubs = {
-          "bin/diff-bundler-config" => "Optional config diff binstub"
-        }
-
         required_binstubs.each do |path, description|
           unless root_path.join(path).exist?
             missing_binstubs << "#{path} (#{description})"
@@ -407,12 +403,6 @@ module Shakapacker
         unless missing_binstubs.empty?
           add_action_required("Missing binstubs: #{missing_binstubs.join(', ')}.")
           add_action_required("  Fix: Run 'bundle exec rake shakapacker:binstubs' to create them.")
-        end
-
-        optional_binstubs.each do |path, description|
-          next if root_path.join(path).exist?
-
-          add_warning("Missing #{path} (#{description}). Run 'bundle exec rake shakapacker:binstubs' to add it.")
         end
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -388,14 +388,17 @@ module Shakapacker
       def check_binstub
         missing_binstubs = []
 
-        expected_binstubs = {
+        required_binstubs = {
           "bin/shakapacker" => "Main Shakapacker binstub",
           "bin/shakapacker-dev-server" => "Development server binstub",
-          "bin/shakapacker-config" => "Config export binstub",
-          "bin/diff-bundler-config" => "Config diff binstub"
+          "bin/shakapacker-config" => "Config export binstub"
         }
 
-        expected_binstubs.each do |path, description|
+        optional_binstubs = {
+          "bin/diff-bundler-config" => "Optional config diff binstub"
+        }
+
+        required_binstubs.each do |path, description|
           unless root_path.join(path).exist?
             missing_binstubs << "#{path} (#{description})"
           end
@@ -404,6 +407,12 @@ module Shakapacker
         unless missing_binstubs.empty?
           add_action_required("Missing binstubs: #{missing_binstubs.join(', ')}.")
           add_action_required("  Fix: Run 'bundle exec rake shakapacker:binstubs' to create them.")
+        end
+
+        optional_binstubs.each do |path, description|
+          next if root_path.join(path).exist?
+
+          add_warning("Missing #{path} (#{description}). Run 'bundle exec rake shakapacker:binstubs' to add it.")
         end
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -391,7 +391,8 @@ module Shakapacker
         expected_binstubs = {
           "bin/shakapacker" => "Main Shakapacker binstub",
           "bin/shakapacker-dev-server" => "Development server binstub",
-          "bin/shakapacker-config" => "Config export binstub"
+          "bin/shakapacker-config" => "Config export binstub",
+          "bin/diff-bundler-config" => "Config diff binstub"
         }
 
         expected_binstubs.each do |path, description|
@@ -1014,7 +1015,8 @@ module Shakapacker
               "bin/shakapacker",
               "bin/shakapacker-dev-server",
               "bin/shakapacker-config",
-              "bin/shakapacker-watch"
+              "bin/shakapacker-watch",
+              "bin/diff-bundler-config"
             ]
 
             existing_binstubs = binstubs.select { |b| doctor.root_path.join(b).exist? }

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -12,6 +12,17 @@ module Shakapacker
     CATEGORY_RECOMMENDED = :recommended
     CATEGORY_INFO = :info
 
+    REQUIRED_BINSTUBS = {
+      "bin/shakapacker" => "Main Shakapacker binstub",
+      "bin/shakapacker-dev-server" => "Development server binstub",
+      "bin/shakapacker-config" => "Config export binstub"
+    }.freeze
+
+    OPTIONAL_BINSTUBS = %w[
+      bin/shakapacker-watch
+      bin/diff-bundler-config
+    ].freeze
+
     def initialize(config = nil, root_path = nil, options = {})
       @config = config || Shakapacker.config
       @root_path = root_path || (defined?(Rails) ? Rails.root : Pathname.new(Dir.pwd))
@@ -388,13 +399,7 @@ module Shakapacker
       def check_binstub
         missing_binstubs = []
 
-        required_binstubs = {
-          "bin/shakapacker" => "Main Shakapacker binstub",
-          "bin/shakapacker-dev-server" => "Development server binstub",
-          "bin/shakapacker-config" => "Config export binstub"
-        }
-
-        required_binstubs.each do |path, description|
+        REQUIRED_BINSTUBS.each do |path, description|
           unless root_path.join(path).exist?
             missing_binstubs << "#{path} (#{description})"
           end
@@ -1010,20 +1015,12 @@ module Shakapacker
           end
 
           def print_binstub_status
-            required_binstubs = %w[
-              bin/shakapacker
-              bin/shakapacker-dev-server
-              bin/shakapacker-config
-            ]
-            optional_binstubs = %w[
-              bin/shakapacker-watch
-              bin/diff-bundler-config
-            ]
+            required_paths = REQUIRED_BINSTUBS.keys
 
-            existing_required = required_binstubs.select { |b| doctor.root_path.join(b).exist? }
-            existing_optional = optional_binstubs.select { |b| doctor.root_path.join(b).exist? }
+            existing_required = required_paths.select { |b| doctor.root_path.join(b).exist? }
+            existing_optional = OPTIONAL_BINSTUBS.select { |b| doctor.root_path.join(b).exist? }
 
-            if existing_required.length == required_binstubs.length
+            if existing_required.length == required_paths.length
               puts "✓ All required Shakapacker binstubs found (#{existing_required.join(', ')})"
             elsif existing_required.any?
               existing_required.each do |binstub|

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -1010,22 +1010,29 @@ module Shakapacker
           end
 
           def print_binstub_status
-            binstubs = [
-              "bin/shakapacker",
-              "bin/shakapacker-dev-server",
-              "bin/shakapacker-config",
-              "bin/shakapacker-watch",
-              "bin/diff-bundler-config"
+            required_binstubs = %w[
+              bin/shakapacker
+              bin/shakapacker-dev-server
+              bin/shakapacker-config
+            ]
+            optional_binstubs = %w[
+              bin/shakapacker-watch
+              bin/diff-bundler-config
             ]
 
-            existing_binstubs = binstubs.select { |b| doctor.root_path.join(b).exist? }
+            existing_required = required_binstubs.select { |b| doctor.root_path.join(b).exist? }
+            existing_optional = optional_binstubs.select { |b| doctor.root_path.join(b).exist? }
 
-            if existing_binstubs.length == binstubs.length
-              puts "✓ All Shakapacker binstubs found (#{existing_binstubs.join(', ')})"
-            elsif existing_binstubs.any?
-              existing_binstubs.each do |binstub|
+            if existing_required.length == required_binstubs.length
+              puts "✓ All required Shakapacker binstubs found (#{existing_required.join(', ')})"
+            elsif existing_required.any?
+              existing_required.each do |binstub|
                 puts "✓ #{binstub} found"
               end
+            end
+
+            existing_optional.each do |binstub|
+              puts "✓ #{binstub} found (optional)"
             end
           end
 

--- a/lib/tasks/shakapacker/doctor.rake
+++ b/lib/tasks/shakapacker/doctor.rake
@@ -11,7 +11,7 @@ namespace :shakapacker do
     • Required and optional npm dependencies
     • JavaScript transpiler (Babel, SWC, esbuild) configuration
     • CSS, CSS Modules, and stylesheet preprocessor setup
-    • Binstubs presence (shakapacker, shakapacker-dev-server, shakapacker-config)
+    • Binstubs presence (shakapacker, shakapacker-dev-server, shakapacker-config, diff-bundler-config)
     • Version consistency between gem and npm package
     • Legacy Webpacker file detection
 

--- a/lib/tasks/shakapacker/doctor.rake
+++ b/lib/tasks/shakapacker/doctor.rake
@@ -11,7 +11,8 @@ namespace :shakapacker do
     • Required and optional npm dependencies
     • JavaScript transpiler (Babel, SWC, esbuild) configuration
     • CSS, CSS Modules, and stylesheet preprocessor setup
-    • Binstubs presence (shakapacker, shakapacker-dev-server, shakapacker-config, diff-bundler-config)
+    • Required binstubs (shakapacker, shakapacker-dev-server, shakapacker-config)
+    • Optional binstubs (shakapacker-watch, diff-bundler-config)
     • Version consistency between gem and npm package
     • Legacy Webpacker file detection
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
+    "pack-config-diff": "github:shakacode/pack-config-diff",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "pack-config-diff": "github:shakacode/pack-config-diff",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
+    "pack-config-diff": "^0.1.0",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
+    "pack-config-diff": "^0.1.0",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"
@@ -201,9 +202,6 @@
     "webpack-subresource-integrity": {
       "optional": true
     }
-  },
-  "optionalDependencies": {
-    "pack-config-diff": "^0.1.0"
   },
   "packageManager": "yarn@1.22.22",
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -44,12 +44,10 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
+    "pack-config-diff": "^0.1.0",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"
-  },
-  "optionalDependencies": {
-    "pack-config-diff": "^0.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "pack-config-diff": "^0.1.0",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"
@@ -202,6 +201,9 @@
     "webpack-subresource-integrity": {
       "optional": true
     }
+  },
+  "optionalDependencies": {
+    "pack-config-diff": "^0.1.0"
   },
   "packageManager": "yarn@1.22.22",
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "pack-config-diff": "^0.1.0",
     "path-complete-extname": "^1.0.0",
     "webpack-merge": "^5.8.0",
     "yargs": "^17.7.2"
+  },
+  "optionalDependencies": {
+    "pack-config-diff": "^0.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/package/types/README.md
+++ b/package/types/README.md
@@ -75,7 +75,7 @@ const config: Config = {
   source_path: "app/javascript",
   source_entry_path: "packs",
   public_root_path: "public",
-  public_output_path: "packs",
+  public_output_path: "packs"
   // ... other config
 }
 
@@ -83,8 +83,8 @@ const webpackConfig: WebpackConfigWithDevServer = {
   mode: "development",
   devServer: {
     hot: true,
-    port: 3035,
-  },
+    port: 3035
+  }
   // ... other webpack config
 }
 ```

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "binstub synchronization" do
+  GEM_ROOT = File.expand_path("../..", __dir__)
+
+  # Binstubs that exist in both bin/ and lib/install/bin/ must stay identical.
+  # lib/install/bin/ contains the templates copied into user projects on install;
+  # bin/ contains the versions used by Shakapacker's own repo and test apps.
+  shared_binstubs = Dir.glob(File.join(GEM_ROOT, "lib/install/bin/*")).select do |install_path|
+    File.exist?(File.join(GEM_ROOT, "bin", File.basename(install_path)))
+  end
+
+  shared_binstubs.each do |install_path|
+    name = File.basename(install_path)
+
+    it "bin/#{name} matches lib/install/bin/#{name}" do
+      bin_content = File.read(File.join(GEM_ROOT, "bin", name))
+      install_content = File.read(install_path)
+      expect(bin_content).to eq(install_content),
+        "bin/#{name} and lib/install/bin/#{name} have diverged. " \
+        "Update both files to keep them in sync."
+    end
+  end
+end

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -1,20 +1,20 @@
 require "spec_helper"
 
 describe "binstub synchronization" do
-  GEM_ROOT = File.expand_path("../..", __dir__)
+  gem_root = File.expand_path("../..", __dir__)
 
   # Binstubs that exist in both bin/ and lib/install/bin/ must stay identical.
   # lib/install/bin/ contains the templates copied into user projects on install;
   # bin/ contains the versions used by Shakapacker's own repo and test apps.
-  shared_binstubs = Dir.glob(File.join(GEM_ROOT, "lib/install/bin/*")).select do |install_path|
-    File.exist?(File.join(GEM_ROOT, "bin", File.basename(install_path)))
+  shared_binstubs = Dir.glob(File.join(gem_root, "lib/install/bin/*")).select do |install_path|
+    File.exist?(File.join(gem_root, "bin", File.basename(install_path)))
   end
 
   shared_binstubs.each do |install_path|
     name = File.basename(install_path)
 
     it "bin/#{name} matches lib/install/bin/#{name}" do
-      bin_content = File.read(File.join(GEM_ROOT, "bin", name))
+      bin_content = File.read(File.join(gem_root, "bin", name))
       install_content = File.read(install_path)
       expect(bin_content).to eq(install_content),
         "bin/#{name} and lib/install/bin/#{name} have diverged. " \

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -679,6 +679,7 @@ describe Shakapacker::Doctor do
     let(:binstub_path) { root_path.join("bin/shakapacker") }
     let(:dev_server_binstub_path) { root_path.join("bin/shakapacker-dev-server") }
     let(:export_config_binstub_path) { root_path.join("bin/shakapacker-config") }
+    let(:diff_config_binstub_path) { root_path.join("bin/diff-bundler-config") }
 
     context "when all binstubs exist" do
       before do
@@ -686,6 +687,7 @@ describe Shakapacker::Doctor do
         File.write(binstub_path, "#!/usr/bin/env ruby")
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
         File.write(export_config_binstub_path, "#!/usr/bin/env node")
+        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "does not add warnings" do
@@ -699,6 +701,7 @@ describe Shakapacker::Doctor do
         FileUtils.mkdir_p(binstub_path.dirname)
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
         File.write(export_config_binstub_path, "#!/usr/bin/env node")
+        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "adds missing binstubs warning" do
@@ -712,6 +715,7 @@ describe Shakapacker::Doctor do
         FileUtils.mkdir_p(binstub_path.dirname)
         File.write(binstub_path, "#!/usr/bin/env ruby")
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
+        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "adds missing binstubs warning" do
@@ -720,10 +724,24 @@ describe Shakapacker::Doctor do
       end
     end
 
-    context "when no binstubs exist" do
-      it "adds missing binstubs warning for all three" do
+    context "when diff-bundler-config binstub does not exist" do
+      before do
+        FileUtils.mkdir_p(binstub_path.dirname)
+        File.write(binstub_path, "#!/usr/bin/env ruby")
+        File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
+        File.write(export_config_binstub_path, "#!/usr/bin/env node")
+      end
+
+      it "adds missing binstubs warning" do
         doctor.send(:check_binstub)
-        expect(warning_messages).to include(match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config/))
+        expect(warning_messages).to include(match(/Missing binstubs:.*bin\/diff-bundler-config/))
+      end
+    end
+
+    context "when no binstubs exist" do
+      it "adds missing binstubs warning for all configured binstubs" do
+        doctor.send(:check_binstub)
+        expect(warning_messages).to include(match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config.*bin\/diff-bundler-config/))
       end
     end
   end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -734,14 +734,21 @@ describe Shakapacker::Doctor do
 
       it "adds missing binstubs warning" do
         doctor.send(:check_binstub)
-        expect(warning_messages).to include(match(/Missing binstubs:.*bin\/diff-bundler-config/))
+        expect(warning_messages).to include(
+          match(/Missing bin\/diff-bundler-config \(Optional config diff binstub\)/)
+        )
       end
     end
 
     context "when no binstubs exist" do
       it "adds missing binstubs warning for all configured binstubs" do
         doctor.send(:check_binstub)
-        expect(warning_messages).to include(match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config.*bin\/diff-bundler-config/))
+        expect(warning_messages).to include(
+          match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config/)
+        )
+        expect(warning_messages).to include(
+          match(/Missing bin\/diff-bundler-config \(Optional config diff binstub\)/)
+        )
       end
     end
   end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -679,7 +679,6 @@ describe Shakapacker::Doctor do
     let(:binstub_path) { root_path.join("bin/shakapacker") }
     let(:dev_server_binstub_path) { root_path.join("bin/shakapacker-dev-server") }
     let(:export_config_binstub_path) { root_path.join("bin/shakapacker-config") }
-    let(:diff_config_binstub_path) { root_path.join("bin/diff-bundler-config") }
 
     context "when all binstubs exist" do
       before do
@@ -687,7 +686,6 @@ describe Shakapacker::Doctor do
         File.write(binstub_path, "#!/usr/bin/env ruby")
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
         File.write(export_config_binstub_path, "#!/usr/bin/env node")
-        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "does not add warnings" do
@@ -701,7 +699,6 @@ describe Shakapacker::Doctor do
         FileUtils.mkdir_p(binstub_path.dirname)
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
         File.write(export_config_binstub_path, "#!/usr/bin/env node")
-        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "adds missing binstubs warning" do
@@ -715,7 +712,6 @@ describe Shakapacker::Doctor do
         FileUtils.mkdir_p(binstub_path.dirname)
         File.write(binstub_path, "#!/usr/bin/env ruby")
         File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
-        File.write(diff_config_binstub_path, "#!/usr/bin/env node")
       end
 
       it "adds missing binstubs warning" do
@@ -724,30 +720,11 @@ describe Shakapacker::Doctor do
       end
     end
 
-    context "when diff-bundler-config binstub does not exist" do
-      before do
-        FileUtils.mkdir_p(binstub_path.dirname)
-        File.write(binstub_path, "#!/usr/bin/env ruby")
-        File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
-        File.write(export_config_binstub_path, "#!/usr/bin/env node")
-      end
-
-      it "adds missing binstubs warning" do
-        doctor.send(:check_binstub)
-        expect(warning_messages).to include(
-          match(/Missing bin\/diff-bundler-config \(Optional config diff binstub\)/)
-        )
-      end
-    end
-
     context "when no binstubs exist" do
       it "adds missing binstubs warning for all configured binstubs" do
         doctor.send(:check_binstub)
         expect(warning_messages).to include(
           match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config/)
-        )
-        expect(warning_messages).to include(
-          match(/Missing bin\/diff-bundler-config \(Optional config diff binstub\)/)
         )
       end
     end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -56,6 +56,15 @@ describe Shakapacker::Doctor do
     doctor.warnings.map { |w| w[:message] }
   end
 
+  def capture_stdout
+    old_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+
   describe "warning formatting" do
     it "formats warnings with correct indentation and spacing" do
       # Create a test scenario with warnings
@@ -721,11 +730,67 @@ describe Shakapacker::Doctor do
     end
 
     context "when no binstubs exist" do
-      it "adds missing binstubs warning for all configured binstubs" do
+      it "adds missing binstubs warning for all required binstubs" do
         doctor.send(:check_binstub)
         expect(warning_messages).to include(
           match(/Missing binstubs:.*bin\/shakapacker.*bin\/shakapacker-dev-server.*bin\/shakapacker-config/)
         )
+      end
+
+      it "does not warn about optional binstub diff-bundler-config" do
+        doctor.send(:check_binstub)
+        expect(warning_messages).not_to include(match(/diff-bundler-config/))
+      end
+    end
+  end
+
+  describe "binstub status display" do
+    let(:reporter) { Shakapacker::Doctor::Reporter.new(doctor) }
+    let(:binstub_path) { root_path.join("bin/shakapacker") }
+    let(:dev_server_binstub_path) { root_path.join("bin/shakapacker-dev-server") }
+    let(:export_config_binstub_path) { root_path.join("bin/shakapacker-config") }
+    let(:diff_bundler_config_path) { root_path.join("bin/diff-bundler-config") }
+
+    context "when all required binstubs exist" do
+      before do
+        FileUtils.mkdir_p(binstub_path.dirname)
+        File.write(binstub_path, "#!/usr/bin/env ruby")
+        File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
+        File.write(export_config_binstub_path, "#!/usr/bin/env node")
+      end
+
+      it "prints all required binstubs found message" do
+        output = capture_stdout { reporter.send(:print_binstub_status) }
+        expect(output).to include("All required Shakapacker binstubs found")
+      end
+    end
+
+    context "when diff-bundler-config optional binstub exists" do
+      before do
+        FileUtils.mkdir_p(binstub_path.dirname)
+        File.write(binstub_path, "#!/usr/bin/env ruby")
+        File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
+        File.write(export_config_binstub_path, "#!/usr/bin/env node")
+        File.write(diff_bundler_config_path, "#!/usr/bin/env node")
+      end
+
+      it "prints optional binstub as found" do
+        output = capture_stdout { reporter.send(:print_binstub_status) }
+        expect(output).to include("diff-bundler-config found (optional)")
+      end
+    end
+
+    context "when diff-bundler-config is absent" do
+      before do
+        FileUtils.mkdir_p(binstub_path.dirname)
+        File.write(binstub_path, "#!/usr/bin/env ruby")
+        File.write(dev_server_binstub_path, "#!/usr/bin/env ruby")
+        File.write(export_config_binstub_path, "#!/usr/bin/env node")
+      end
+
+      it "does not mention diff-bundler-config" do
+        output = capture_stdout { reporter.send(:print_binstub_status) }
+        expect(output).not_to include("diff-bundler-config")
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,6 +5173,13 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pack-config-diff@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/pack-config-diff/-/pack-config-diff-0.1.0.tgz#c15025e196ff85009806890cca0841e96aaa6a1b"
+  integrity sha512-gx60G4pnT4GFQ7WECdf7SCq9vdsvBhodLXXzwisy37/t0zkAZ3hMgLCdOGivudF1l0gcLZhIWVYreS89be15QA==
+  dependencies:
+    js-yaml "^4.1.0"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,6 +5173,12 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+"pack-config-diff@github:shakacode/pack-config-diff":
+  version "1.0.0"
+  resolved "https://codeload.github.com/shakacode/pack-config-diff/tar.gz/6bb09f4ba933ef5978c534b1c278156e438dce2e"
+  dependencies:
+    js-yaml "^4.1.0"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,12 +5173,6 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-"pack-config-diff@github:shakacode/pack-config-diff":
-  version "1.0.0"
-  resolved "https://codeload.github.com/shakacode/pack-config-diff/tar.gz/6bb09f4ba933ef5978c534b1c278156e438dce2e"
-  dependencies:
-    js-yaml "^4.1.0"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
## Summary
This PR supersedes [#961](https://github.com/shakacode/shakapacker/pull/961) by using the extracted [`pack-config-diff`](https://github.com/shakacode/pack-config-diff) package instead of introducing an in-repo `configDiffer` module.

## What changed
- Added `bin/diff-bundler-config` and `lib/install/bin/diff-bundler-config` wrappers.
- Added `pack-config-diff` dependency in `package.json`.
- Added new guide: `docs/config-diff.md`.
- Updated docs/examples to use semantic diffing:
  - `README.md` (Debugging Configuration section)
  - `docs/troubleshooting.md`
  - `docs/rspack_migration_guide.md`
- Updated doctor binstub checks/specs to include `bin/diff-bundler-config`.

## Behavior notes
- The binstub resolves `pack-config-diff` via shakapacker's dependency tree (using `createRequire`) so strict package managers (pnpm, Yarn PnP) can find it.
- If the module cannot be loaded, the binstub prints a diagnostic message and exits with code 2.

## Why this supersedes #961
- #961 introduced and maintained a large internal diff engine under Shakapacker.
- This PR keeps Shakapacker focused and delegates diffing to the dedicated extracted project.
- Future diff improvements now land in one place (`pack-config-diff`) and are consumed here via the wrapper.

## Validation
- `bundle exec rspec spec/shakapacker/doctor_spec.rb`
- `bundle exec rspec spec/shakapacker/engine_rake_tasks_spec.rb`
- `node bin/diff-bundler-config --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new shipped CLI wrapper and a new runtime dependency (`pack-config-diff`), plus updates CI/test harness to install via `yalc add`; risk is mainly around packaging/installation and exit-code behavior in developer/CI workflows.
> 
> **Overview**
> Introduces a new `bin/diff-bundler-config` (and installer template in `lib/install/bin/`) that wraps `pack-config-diff` to provide *semantic* webpack/rspack configuration diffs with normalized exit codes.
> 
> Updates docs to recommend `bin/diff-bundler-config` instead of raw `diff`, adds a dedicated `docs/config-diff.md` guide, and adjusts `shakapacker:doctor` to treat `diff-bundler-config` as an optional binstub (with new specs to keep shared binstubs in sync).
> 
> CI and rake test tasks switch local package consumption from `yalc link`/`npm install` to `yalc add` with `yarn install`, and the JS tooling config (`knip`) is updated to account for the new binstubs/dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef1c254c6806cea1c77a28a37f3a95287fd4529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a CLI to produce semantic configuration diffs for bundler configs with clear exit codes.

* **Documentation**
  * New Configuration Diff Guide and README troubleshooting subsection; migration guide updated to recommend semantic diffs and show examples.

* **Chores / Tests**
  * Installer/doctor and tests updated to treat the diff CLI as optional.

* **CI / Tooling**
  * Updated local package handling in CI and test tasks; formatting ignore list extended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->