### PR TITLE
Read the shakapacker instance config in compiler strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance specific config.
+
 ## [v10.0.0-rc.0] - April 1, 2026
 
 ### Added

--- a/lib/shakapacker/base_strategy.rb
+++ b/lib/shakapacker/base_strategy.rb
@@ -1,7 +1,7 @@
 module Shakapacker
   class BaseStrategy
-    def initialize
-      @config = Shakapacker.config
+    def initialize(instance)
+      @instance = instance
     end
 
     def after_compile_hook
@@ -10,7 +10,13 @@ module Shakapacker
 
     private
 
-      attr_reader :config
+      def config
+        @instance.config
+      end
+
+      def env
+        @instance.env
+      end
 
       def default_watched_paths
         [
@@ -18,7 +24,7 @@ module Shakapacker
           "#{config.source_path}{,/**/*}",
           "package.json", "package-lock.json", "yarn.lock",
           "pnpm-lock.yaml", "bun.lockb",
-          "config/webpack{,/**/*}"
+          "config/{webpack,rspack}{,/**/*}"
         ].freeze
       end
   end

--- a/lib/shakapacker/compiler_strategy.rb
+++ b/lib/shakapacker/compiler_strategy.rb
@@ -3,14 +3,14 @@ require_relative "digest_strategy"
 
 module Shakapacker
   class CompilerStrategy
-    def self.from_config
-      strategy_from_config = Shakapacker.config.compiler_strategy
+    def self.from_config(instance)
+      strategy_from_config = instance.config.compiler_strategy
 
       case strategy_from_config
       when "mtime"
-        Shakapacker::MtimeStrategy.new
+        Shakapacker::MtimeStrategy.new(instance)
       when "digest"
-        Shakapacker::DigestStrategy.new
+        Shakapacker::DigestStrategy.new(instance)
       else
         raise "Unknown strategy '#{strategy_from_config}'. " \
               "Available options are 'mtime' and 'digest'."

--- a/lib/shakapacker/digest_strategy.rb
+++ b/lib/shakapacker/digest_strategy.rb
@@ -46,7 +46,7 @@ module Shakapacker
         files = Dir[*expanded_paths].reject { |f| File.directory?(f) }
         file_ids = files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
 
-        asset_host = Shakapacker.config.asset_host.to_s
+        asset_host = config.asset_host.to_s
         Digest::SHA1.hexdigest(file_ids.join("/").concat(asset_host))
       end
 
@@ -56,7 +56,7 @@ module Shakapacker
       end
 
       def compilation_digest_path
-        config.cache_path.join("last-compilation-digest-#{Shakapacker.env}")
+        config.cache_path.join("last-compilation-digest-#{env}")
       end
   end
 end

--- a/lib/shakapacker/instance.rb
+++ b/lib/shakapacker/instance.rb
@@ -81,7 +81,7 @@ class Shakapacker::Instance
   # @return [Shakapacker::CompilerStrategy] the compiler strategy
   # @api private
   def strategy
-    @strategy ||= Shakapacker::CompilerStrategy.from_config
+    @strategy ||= Shakapacker::CompilerStrategy.from_config(self)
   end
 
   # Returns the compiler for this instance

--- a/spec/shakapacker/compiler_strategy_spec.rb
+++ b/spec/shakapacker/compiler_strategy_spec.rb
@@ -5,20 +5,29 @@ describe "Shakapacker::CompilerStrategy" do
     it "returns an instance of MtimeStrategy when compiler_strategy is set to mtime" do
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("mtime")
 
-      expect(Shakapacker::CompilerStrategy.from_config).to be_an_instance_of(Shakapacker::MtimeStrategy)
+      expect(Shakapacker::CompilerStrategy.from_config(Shakapacker.instance)).to be_an_instance_of(Shakapacker::MtimeStrategy)
     end
 
     it "returns an instance of DigestStrategy when compiler_strategy is set to digest" do
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("digest")
 
-      expect(Shakapacker::CompilerStrategy.from_config).to be_an_instance_of(Shakapacker::DigestStrategy)
+      expect(Shakapacker::CompilerStrategy.from_config(Shakapacker.instance)).to be_an_instance_of(Shakapacker::DigestStrategy)
     end
 
     it "raise an exception for unknown compiler_strategy in the config file" do
       expected_error_message = "Unknown strategy 'other'. Available options are 'mtime' and 'digest'."
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("other")
 
-      expect { Shakapacker::CompilerStrategy.from_config }.to raise_error(expected_error_message)
+      expect { Shakapacker::CompilerStrategy.from_config(Shakapacker.instance) }.to raise_error(expected_error_message)
+    end
+
+    it "uses the given instance's config, not the global config" do
+      custom_instance = Shakapacker::Instance.new
+      allow(custom_instance.config).to receive(:compiler_strategy).and_return("mtime")
+      allow(Shakapacker.config).to receive(:compiler_strategy).and_return("digest")
+
+      strategy = Shakapacker::CompilerStrategy.from_config(custom_instance)
+      expect(strategy).to be_an_instance_of(Shakapacker::MtimeStrategy)
     end
   end
 end

--- a/spec/shakapacker/digest_strategy_spec.rb
+++ b/spec/shakapacker/digest_strategy_spec.rb
@@ -8,7 +8,7 @@ describe "DigestStrategy" do
   end
 
   before :all do
-    @digest_strategy = Shakapacker::DigestStrategy.new
+    @digest_strategy = Shakapacker::DigestStrategy.new(Shakapacker.instance)
     remove_compilation_digest_path
   end
 

--- a/spec/shakapacker/mtime_strategy_spec.rb
+++ b/spec/shakapacker/mtime_strategy_spec.rb
@@ -1,7 +1,7 @@
 require_relative "spec_helper_initializer"
 
 describe "Shakapacker::MtimeStrategy" do
-  let(:mtime_strategy) { Shakapacker::MtimeStrategy.new }
+  let(:mtime_strategy) { Shakapacker::MtimeStrategy.new(Shakapacker.instance) }
   let(:manifest_timestamp) { Time.parse("2021-01-01 12:34:56 UTC") }
 
   describe "#fresh?" do


### PR DESCRIPTION
### Summary

My app setup is: a standard root shakapacker config, plus several engine-specific shakapackers (with their own yarn workspace), all hooked up into `assets:precompile` and `assets:clobber` like the root shakapacker (manually).

I noticed that `rake assets:precompile` was refusing to recompile when I changed source code in the engines.

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Add/update test to cover these changes
- ~[ ] Update documentation~
- [x] Update CHANGELOG file

### Other Information

Forward instance of BaseStrategy constructor and the rest implements itself, including minor `Shakapacker.env -> instance.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compiler strategies now honor instance-specific configuration and use the instance environment/asset host for compilation digests.

* **Chores**
  * Configuration watch patterns updated to include rspack alongside webpack.

* **Tests**
  * Test suite updated to validate instance-scoped strategy selection and instance-based strategy construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->