### PR TITLE
Remove yalc artifact from spec/dummy lockfiles

### DIFF
--- a/spec/dummy/package-lock.json
+++ b/spec/dummy/package-lock.json
@@ -30,7 +30,7 @@
         "react-dom": "^18.3.1",
         "react-on-rails": "^16.2.1",
         "rspack-manifest-plugin": "^5.1.0",
-        "shakapacker": "^9.6.1",
+        "shakapacker": "9.6.1",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.3.14",
         "typescript": "^4.7.3",

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -30,7 +30,7 @@
     "react-dom": "^18.3.1",
     "react-on-rails": "^16.2.1",
     "rspack-manifest-plugin": "^5.1.0",
-    "shakapacker": "^9.6.1",
+    "shakapacker": "9.6.1",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.14",
     "typescript": "^4.7.3",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -4175,7 +4175,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@^9.6.1:
+shakapacker@9.6.1:
   version "9.6.1"
   resolved "https://registry.npmjs.org/shakapacker/-/shakapacker-9.6.1.tgz"
   integrity sha512-xE1RAm6c1C6o1Erj+8Iih/WqmauKpcGUiZ2t8NJRBlKmOypvWpyk+h2DQ3u02ii3aiOYlDDSboJMk/yzmaIOPA==


### PR DESCRIPTION
## Summary
- replace `file:.yalc/shakapacker` with the published `9.6.1` dependency in `spec/dummy/package.json`
- regenerate both `spec/dummy/package-lock.json` and `spec/dummy/yarn.lock` so they no longer reference local `.yalc` paths
- verify `spec/dummy` resolves `shakapacker@9.6.1`

## Testing
- `npm install --package-lock-only --ignore-scripts` (in `spec/dummy`)
- `yarn install --non-interactive` (in `spec/dummy`)
- `npm ls shakapacker` (in `spec/dummy`)

Closes #968.
