### PR TITLE
Fix webpack-subresource-integrity v5 named export handling

### DIFF
--- a/package/plugins/webpack.ts
+++ b/package/plugins/webpack.ts
@@ -58,7 +58,7 @@ const getPlugins = (): unknown[] => {
     config.integrity?.enabled &&
     moduleExists("webpack-subresource-integrity")
   ) {
-    // webpack-subresource-integrity >=5.1 exports the plugin as a named export.
+    // webpack-subresource-integrity v5+ exports the plugin as a named export.
     const subresourceIntegrityModule = requireOrError(
       "webpack-subresource-integrity"
     )

--- a/test/package/plugins/webpackSubresourceIntegrity.test.js
+++ b/test/package/plugins/webpackSubresourceIntegrity.test.js
@@ -52,7 +52,6 @@ const loadPluginsWithSriModule = (sriModule) => {
 
 describe("webpack plugins - webpack-subresource-integrity compatibility", () => {
   afterEach(() => {
-    jest.resetModules()
     jest.clearAllMocks()
   })
 


### PR DESCRIPTION
## Summary
- support both export styles from `webpack-subresource-integrity` in webpack plugins:
  - default export constructor (older versions)
  - named `SubresourceIntegrityPlugin` export (v5.1+)
- keep runtime behavior unchanged for existing setups
- add regression tests covering both module shapes

## Testing
- `yarn test test/package/plugins/webpackSubresourceIntegrity.test.js --runInBand`
- `yarn lint`
- `yarn prettier --check package/plugins/webpack.ts test/package/plugins/webpackSubresourceIntegrity.test.js`

Closes #972.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small compatibility tweak to plugin loading plus focused unit tests; behavior should be unchanged except preventing runtime breakage with newer `webpack-subresource-integrity` exports.
> 
> **Overview**
> Updates the webpack plugin setup to support both `webpack-subresource-integrity` module shapes by using the named `SubresourceIntegrityPlugin` export when present and falling back to the default export.
> 
> Adds regression tests that mock each export style to ensure the plugin is instantiated with the expected SRI options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a5972f707ac87cc2629c7801c44a036b90d464a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->