### PR TITLE
Fix claude-code-review checkout action version

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
- replace `actions/checkout@v6` with the latest published major (`actions/checkout@v4`) in `.github/workflows/claude-code-review.yml`
- restores workflow compatibility (v6 does not exist)

## Testing
- `yarn prettier --check .github/workflows/claude-code-review.yml`

Closes #967.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the GitHub Actions workflow to reference an existing `actions/checkout` major version, with no application/runtime code impact.
> 
> **Overview**
> Fixes the `Claude Code Review` GitHub Actions workflow by switching the checkout step from the non-existent `actions/checkout@v6` to `actions/checkout@v4`, restoring workflow compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9fb17cfbd278d94c4cf708515b672e6aa3dfdd9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->