### PR TITLE
Add v9.7.0 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## [Unreleased]
 
-## [v9.7.0-rc.0] - March 15, 2026
+## [v9.7.0] - March 15, 2026
 
 ### Added
 
@@ -18,6 +18,7 @@
 ### Fixed
 
 - **Fixed config exporter path traversal and annotation format validation**. [PR #914](https://github.com/shakacode/shakapacker/pull/914) by [justin808](https://github.com/justin808). Added `safeResolvePath` security check to prevent path traversal in export save paths, and enforced YAML format when using annotations with build exports.
+- **Fixed `webpack-subresource-integrity` v5 named export handling**. [PR #978](https://github.com/shakacode/shakapacker/pull/978) by [justin808](https://github.com/justin808). Supports both the default export (older versions) and the named `SubresourceIntegrityPlugin` export (v5.1+), preventing runtime breakage when upgrading the plugin. Fixes [#972](https://github.com/shakacode/shakapacker/issues/972).
 
 ## [v9.6.1] - March 8, 2026
 
@@ -886,8 +887,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.7.0-rc.0...main
-[v9.7.0-rc.0]: https://github.com/shakacode/shakapacker/compare/v9.6.1...v9.7.0-rc.0
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.7.0...main
+[v9.7.0]: https://github.com/shakacode/shakapacker/compare/v9.6.1...v9.7.0
 [v9.6.1]: https://github.com/shakacode/shakapacker/compare/v9.6.0...v9.6.1
 [v9.6.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0
 [v9.5.0]: https://github.com/shakacode/shakapacker/compare/v9.4.0...v9.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 ## [Unreleased]
 
+## [v9.7.0-rc.0] - March 15, 2026
+
+### Added
+
+- **Added rspack v2 support**. [PR #975](https://github.com/shakacode/shakapacker/pull/975) by [justin808](https://github.com/justin808). Peer dependencies now accept both rspack v1 and v2 (`^1.0.0 || ^2.0.0-0`). No source code changes were needed — all existing APIs work identically in v2. Note that rspack v2 requires Node.js 20.19.0+.
+
+### Fixed
+
+- **Fixed config exporter path traversal and annotation format validation**. [PR #914](https://github.com/shakacode/shakapacker/pull/914) by [justin808](https://github.com/justin808). Added `safeResolvePath` security check to prevent path traversal in export save paths, and enforced YAML format when using annotations with build exports.
+
 ## [v9.6.1] - March 8, 2026
 
 ### Fixed
@@ -876,7 +886,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.6.1...main
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v9.7.0-rc.0...main
+[v9.7.0-rc.0]: https://github.com/shakacode/shakapacker/compare/v9.6.1...v9.7.0-rc.0
 [v9.6.1]: https://github.com/shakacode/shakapacker/compare/v9.6.0...v9.6.1
 [v9.6.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0
 [v9.5.0]: https://github.com/shakacode/shakapacker/compare/v9.4.0...v9.5.0


### PR DESCRIPTION
### Summary

Adds the v9.7.0 changelog section with release notes for all user-visible changes since v9.6.1:

- **Added**: rspack v2 support (PR #975)
- **Fixed**: Config exporter path traversal and annotation format validation (PR #914)
- **Fixed**: `webpack-subresource-integrity` v5 named export handling (PR #978, fixes #972)

Version diff links at the bottom of the file are updated accordingly.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

Non-user-visible PRs (#920, #965, #970, #971, #977, #979, #981, #982) were intentionally excluded per changelog policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating `CHANGELOG.md`; no runtime code or dependency changes are introduced in this PR.
> 
> **Overview**
> Adds a new `v9.7.0` section to `CHANGELOG.md` documenting user-visible changes (rspack v2 support and two fixes around config export security/validation and `webpack-subresource-integrity` v5 exports).
> 
> Updates the compare links at the bottom so `[Unreleased]` now compares from `v9.7.0`, and adds the new `[v9.7.0]` tag link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8942a436bcb6f751f78611978a0e8eb7a7720f58. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rspack v2 support

* **Bug Fixes**
  * Improved security and validation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->