### PR TITLE
Rename create_release to release and fix version.rb staging path

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -7,7 +7,7 @@ You are helping to add an entry to the CHANGELOG.md file for the Shakapacker pro
 This command accepts an optional argument: `$ARGUMENTS`
 
 - **No argument** (`/update-changelog`): Add entries to `[Unreleased]` without stamping a version header. Use this during development.
-- **`release`** (`/update-changelog release`): Add entries and stamp a version header. Auto-compute the next version based on changes (breaking → major, added features → minor, fixes → patch). Then `rake create_release` (with no args) will pick up this version automatically.
+- **`release`** (`/update-changelog release`): Add entries and stamp a version header. Auto-compute the next version based on changes (breaking → major, added features → minor, fixes → patch). Then `rake release` (with no args) will pick up this version automatically.
 - **`rc`** (`/update-changelog rc`): Same as `release`, but stamps an RC prerelease version (e.g., `v9.7.0-rc.0`). Auto-increments the RC index if prior RCs exist for the same base version.
 - **`beta`** (`/update-changelog beta`): Same as `rc`, but stamps a beta prerelease version (e.g., `v9.7.0-beta.0`).
 - **Explicit version** (`/update-changelog 9.7.0-rc.10` or `/update-changelog v9.7.0-rc.10`): Add entries and stamp the exact version provided. Skips auto-computation — use this when you already know the target version. The version string must use npm semver format with optional `-rc.N` or `-beta.N` suffix (e.g., `9.7.0-rc.10`, `9.7.0`). A `v` prefix is optional and will be added automatically if missing. If passed in RubyGems dot format (e.g., `9.7.0.rc.10` or `9.7.0.beta.2`), convert to npm semver dash format (`v9.7.0-rc.10` or `v9.7.0-beta.2`) for the changelog header.
@@ -26,7 +26,7 @@ This command serves three use cases at different points in the release lifecycle
 - Run `/update-changelog release` (or `rc` or `beta`) to add entries AND stamp the version header
 - The version is auto-computed from changelog content (see "Auto-Computing the Next Version" below)
 - Commit and push CHANGELOG.md
-- Then run `rake create_release` (no args needed — it reads the version from CHANGELOG.md)
+- Then run `rake release` (no args needed — it reads the version from CHANGELOG.md)
 - The release task automatically creates a GitHub release from the changelog section
 
 **After a release you forgot to update the changelog for** — Catch-up mode:
@@ -36,7 +36,7 @@ This command serves three use cases at different points in the release lifecycle
 
 ### Why changelog comes BEFORE the release
 
-- `create_release` automatically creates a GitHub release if a changelog section exists — no separate `sync_github_release` step needed
+- `release` automatically creates a GitHub release if a changelog section exists — no separate `sync_github_release` step needed
 - The release task warns if no changelog section is found for the target version
 - A premature version header (if release fails) is harmless — you'll release eventually
 - A missing changelog after release means GitHub release must be created manually
@@ -271,7 +271,7 @@ If no argument was passed, skip this step — entries stay in `## [Unreleased]`.
    - Stage only `CHANGELOG.md` (`git add CHANGELOG.md`) and commit with message `Update CHANGELOG.md for vX.Y.Z` (using the stamped version)
    - Push and open a PR with the changelog diff as the body
    - If the push or PR creation fails, the CHANGELOG is already stamped locally — fix the issue and retry manually
-   - Remind the user to run `bundle exec rake create_release` (no args) after merge to publish and auto-create the GitHub release
+   - Remind the user to run `bundle exec rake release` (no args) after merge to publish and auto-create the GitHub release
 
 ### For Prerelease Versions (RC and Beta)
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,19 +4,8 @@ require "pathname"
 
 # Remove Bundler's default `release` task — it bypasses the custom release flow
 # (CHANGELOG version detection, npm publish, GitHub release sync, etc.).
-# Use `rake create_release` instead.
+# The custom `release` task in rakelib/release.rake replaces it.
 Rake::Task[:release].clear
-desc "Disabled — use `rake create_release` instead (run `rake -D create_release` for usage)"
-task :release do
-  abort <<~MSG
-    ❌ `rake release` is disabled. Use `rake create_release` instead.
-
-    `create_release` handles version detection from CHANGELOG.md, npm publish,
-    GitHub release sync, and version policy checks.
-
-    Run `rake -D create_release` for full usage details.
-  MSG
-end
 
 desc "Run all specs"
 task test: ["run_spec:all_specs"]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,29 +47,29 @@ The simplest way to release is with no arguments — the task reads the version 
 
 ```bash
 # Recommended: reads version from CHANGELOG.md (requires step 1)
-bundle exec rake create_release
+bundle exec rake release
 
 # For a specific version (overrides CHANGELOG.md detection)
-bundle exec rake "create_release[9.1.0]"
+bundle exec rake "release[9.1.0]"
 
 # For a beta release (note: use period, not dash)
-bundle exec rake "create_release[9.2.0.beta.1]"  # Creates npm package 9.2.0-beta.1
+bundle exec rake "release[9.2.0.beta.1]"  # Creates npm package 9.2.0-beta.1
 
 # For a release candidate
-bundle exec rake "create_release[9.6.0.rc.0]"
+bundle exec rake "release[9.6.0.rc.0]"
 
 # Dry run to test without publishing
-bundle exec rake "create_release[9.1.0,true]"
+bundle exec rake "release[9.1.0,true]"
 
 # Skip interactive confirmations (for scripted maintainer runs)
-AUTO_CONFIRM=true bundle exec rake create_release
+AUTO_CONFIRM=true bundle exec rake release
 
 # Override version policy checks (monotonic + changelog/bump consistency)
-RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "create_release[9.1.0]"
-bundle exec rake "create_release[9.1.0,false,true]"
+RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[9.1.0]"
+bundle exec rake "release[9.1.0,false,true]"
 ```
 
-When called with no arguments, `create_release`:
+When called with no arguments, `release`:
 
 1. Reads the first versioned header from CHANGELOG.md (e.g., `## [v9.6.0]`)
 2. Compares it to the current gem version
@@ -79,7 +79,7 @@ When called with no arguments, `create_release`:
 Dry runs use a temporary git worktree so version bumps and installs do not modify your current checkout.
 Dry runs now also print explicit "skipping confirmation" messages and the would-run GitHub release command.
 
-`create_release` validates release-version policy before publishing:
+`release` validates release-version policy before publishing:
 
 - Target version must be greater than the latest tagged release.
 - If the versioned target changelog section exists (`## [vX.Y.Z...]`; not `UNRELEASED`), it maps to expected bump type:
@@ -91,11 +91,11 @@ Dry runs now also print explicit "skipping confirmation" messages and the would-
 Use override only when needed:
 
 - `RELEASE_VERSION_POLICY_OVERRIDE=true`
-- Or task arg override (`create_release[..., ..., true]`)
+- Or task arg override (`release[..., ..., true]`)
 
 ### 3. What the Release Task Does
 
-The `create_release` task automatically:
+The `release` task automatically:
 
 1. **Validates release prerequisites**:
    - Verifies npm authentication
@@ -138,16 +138,16 @@ The task automatically converts Ruby gem format to npm semver format:
 
 ```bash
 # Regular release
-bundle exec rake "create_release[9.1.0]"  # Gem: 9.1.0, npm: 9.1.0
+bundle exec rake "release[9.1.0]"  # Gem: 9.1.0, npm: 9.1.0
 
 # Beta release
-bundle exec rake "create_release[9.2.0.beta.1]"  # Gem: 9.2.0.beta.1, npm: 9.2.0-beta.1
+bundle exec rake "release[9.2.0.beta.1]"  # Gem: 9.2.0.beta.1, npm: 9.2.0-beta.1
 
 # Release candidate
-bundle exec rake "create_release[10.0.0.rc.1]"  # Gem: 10.0.0.rc.1, npm: 10.0.0-rc.1
+bundle exec rake "release[10.0.0.rc.1]"  # Gem: 10.0.0.rc.1, npm: 10.0.0-rc.1
 
-# Prerelease: use /update-changelog rc first, then create_release reads it
-bundle exec rake create_release  # reads v10.0.0-rc.0 from CHANGELOG.md
+# Prerelease: use /update-changelog rc first, then release reads it
+bundle exec rake release  # reads v10.0.0-rc.0 from CHANGELOG.md
 ```
 
 ### 5. During the Release
@@ -157,7 +157,7 @@ If you are running non-interactively, set `AUTO_CONFIRM=true` to skip confirmati
 1. When prompted for **npm OTP**, enter your 2FA code from your authenticator app
 2. Accept defaults for release-it options
 3. When prompted for **RubyGems OTP**, enter your 2FA code
-4. If using `create_release` with no version, confirm the version detected from CHANGELOG.md (or the computed patch version)
+4. If using `release` with no version, confirm the version detected from CHANGELOG.md (or the computed patch version)
 5. The script will automatically commit and push lockfile updates
 6. The script will automatically create a GitHub release (if CHANGELOG.md section exists)
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -511,7 +511,7 @@ def perform_release(
     # Explicitly stage all release-related changes so release-it includes them in its commit.
     # release-it only reliably stages files it modifies (package.json); other working tree
     # changes (version.rb, Gemfile.lock, spec/dummy lockfiles) must be pre-staged.
-    Shakapacker::Utils::Misc.sh_in_dir(release_root, "git add version.rb Gemfile.lock spec/dummy/Gemfile.lock spec/dummy/yarn.lock spec/dummy/package-lock.json")
+    Shakapacker::Utils::Misc.sh_in_dir(release_root, "git add lib/shakapacker/version.rb Gemfile.lock spec/dummy/Gemfile.lock spec/dummy/yarn.lock spec/dummy/package-lock.json")
 
     resolved_gem_version = current_gem_version(release_root)
     released_gem_version = resolved_gem_version
@@ -567,13 +567,13 @@ Arguments:
               Equivalent to setting RELEASE_VERSION_POLICY_OVERRIDE=true.
 
 Examples:
-- rake \"create_release\"                      # uses CHANGELOG.md version or patch bump
-- rake \"create_release[9.6.0]\"
-- rake \"create_release[9.6.0.rc.0]\"
-- rake \"create_release[9.6.0,true]\"
-- rake \"create_release[9.6.0,false,true]\"
+- rake \"release\"                      # uses CHANGELOG.md version or patch bump
+- rake \"release[9.6.0]\"
+- rake \"release[9.6.0.rc.0]\"
+- rake \"release[9.6.0,true]\"
+- rake \"release[9.6.0,false,true]\"
 ")
-task :create_release, %i[gem_version dry_run override_version_policy] do |_t, args|
+task :release, %i[gem_version dry_run override_version_policy] do |_t, args|
   args_hash = args.to_hash
   is_dry_run = Shakapacker::Utils::Misc.object_to_boolean(args_hash[:dry_run])
   allow_override = version_policy_override_enabled?(args_hash[:override_version_policy])


### PR DESCRIPTION
## Summary

- Renames `create_release` task to `release`, replacing Bundler's default `release` task. This matches the react_on_rails naming convention — users just run `rake release`.
- Fixes `git add version.rb` → `git add lib/shakapacker/version.rb` — the path was wrong since the command runs from the repo root, causing `fatal: pathspec 'version.rb' did not match any files`.
- Updates all references in docs/releasing.md and the update-changelog command.

Closes #985 context — the release crashed because `git add version.rb` couldn't find the file at the repo root level.

## Test plan

- [x] `rake release` shows the custom release task (not Bundler's)
- [x] `rake build` and `rake install` still work from bundler/gem_tasks
- [x] `rake -T release` shows correct task name and description
- [x] No remaining `create_release` references in codebase
- [x] RuboCop passes
- [x] All 14 rake_tasks specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guide to reflect new task naming conventions and enhanced workflow
* **Chores**
  * Renamed release task from `create_release` to `release` throughout the system
  * Enhanced release workflow to automatically detect gem version from CHANGELOG.md when not explicitly provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->