### PR TITLE
Trigger shakapacker.com docs rebuild on docs changes

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -1,0 +1,24 @@
+name: Trigger docs site rebuild
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+
+jobs:
+  notify-docs-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.DOCS_DISPATCH_APP_KEY }}
+          owner: shakacode
+          repositories: shakapacker.com
+
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: shakacode/shakapacker.com
+          event-type: docs-updated


### PR DESCRIPTION
## Summary
- add a workflow that triggers on `push` to `main` when `docs/**` changes
- mint a GitHub App token using `DOCS_DISPATCH_APP_ID` and `DOCS_DISPATCH_APP_KEY`
- dispatch `docs-updated` to `shakacode/shakapacker.com`

## Why
This mirrors the `react_on_rails -> reactonrails.com` docs auto-publish flow for Shakapacker.

## Required repo secrets (in `shakacode/shakapacker`)
- `DOCS_DISPATCH_APP_ID`
- `DOCS_DISPATCH_APP_KEY`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal CI/CD pipeline to streamline documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->