### PR TITLE
Sync address-review command with upstream PR #14

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -16,7 +16,9 @@ If this command fails, ensure `gh` CLI is installed and authenticated (`gh auth 
 
 ## Step 2: Parse User Input
 
-Extract the PR number and optional review/comment ID from the user's message:
+The user's input is: $ARGUMENTS
+
+Extract the PR number and optional review/comment ID from the input above:
 
 **Supported formats:**
 
@@ -42,21 +44,40 @@ gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .use
 **If a specific review ID is provided (`#pullrequestreview-...`):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq '[.[] | {id: .id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login}]'
+# Review body (often contains summary feedback)
+gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, html_url: .html_url}'
+
+# Inline comments for this review
+gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
 ```
 
-**If only PR number is provided (fetch all PR review comments):**
+Include the review body as a general comment when it contains actionable feedback. When the review body contains actionable feedback, note that it cannot be replied to via the `/replies` endpoint — responses to review summary bodies must be posted as general PR comments (see Step 7).
+
+**If only PR number is provided (fetch all PR comments):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments | jq '[.[] | {id: .id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
+# Inline code review comments
+gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
+
+# General PR discussion comments (not tied to specific lines)
+gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, html_url: .html_url}]'
+```
+
+**For all paths that fetch review comments (both specific review and full PR), fetch review thread metadata and attach `thread_id` by matching each review comment's `node_id`:**
+
+```bash
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER} -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'
 ```
 
 **Filtering comments:**
 
+- Skip comments belonging to already-resolved threads (match via `thread_id` and `is_resolved` from the GraphQL response)
 - Skip comments where `in_reply_to_id` is set (these are replies, not top-level comments)
 - Do not skip bot-generated comments by default. Many actionable review comments in this repository come from bots.
 - Deduplicate repeated bot comments and skip bot status posts, summaries, and acknowledgments that do not require a code or documentation change
-- Treat as actionable by default only: correctness bugs, regressions, missing tests, and clear inconsistencies with adjacent code
+- Treat as actionable by default only: correctness bugs, regressions, security issues, missing tests, and clear inconsistencies with adjacent code
 - Treat as non-actionable by default: style nits, speculative suggestions, changelog wording, duplicate bot comments, and "could consider" feedback unless the user explicitly asks for polish work
 - Focus on actionable feedback, not acknowledgments or thank-you messages
 
@@ -83,31 +104,33 @@ Triage rules:
 
 ## Step 5: Create Todo List
 
-Create a todo list with TodoWrite containing **only the `MUST-FIX` items**:
+Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
 
-- One todo per must-fix comment or deduplicated issue
-- For file-specific comments: `"{file}:{line} - {comment_summary} (@{username})"` (content)
-- For general comments: Parse the comment body and extract the must-fix action
-- Format activeForm: `"Addressing {brief description}"`
-- All todos should start with status: `"pending"`
+- One task per must-fix comment or deduplicated issue
+- Subject: `"{file}:{line} - {comment_summary} (@{username})"`
+- For general comments: Parse the comment body and extract the must-fix action as the subject
+- Description: Include the full review comment text and any relevant context
+- All tasks should start with status: `"pending"`
 
 ## Step 6: Present Triage to User
 
 Present the triage to the user - **DO NOT automatically start addressing items**:
 
+- Use a single sequential numbering across all categories (1, 2, 3, ...) so every item has a unique number the user can reference. Do not restart numbering at 1 for each category.
 - `MUST-FIX ({count})`: list the todos created
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
 - `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions
 - Wait for the user to tell you which items to address
 - Always offer an explicit optional follow-up to post rationale replies on selected `SKIPPED` or declined `DISCUSS` items
 - Never post those rationale replies unless the user explicitly selects which items to reply to
-- Ask two things when relevant:
+- Ask two things when there are `SKIPPED` or declined `DISCUSS` items:
   - Which items to address in code/tests/docs
   - Which skipped/declined items (if any) should receive a rationale reply
 
 ## Step 7: Address Items, Reply, and Resolve
 
-When addressing items, after completing each selected todo item, reply to the original review comment explaining how it was addressed.
+When addressing items, after completing each selected item (whether `MUST-FIX` or `DISCUSS`), reply to the original review comment explaining how it was addressed.
+If the user selects `DISCUSS` items to address, treat them the same as `MUST-FIX`: make the code change, reply, and resolve the thread.
 If the user selects skipped/declined items for rationale replies, post those replies too.
 
 **For issue comments (general PR comments):**
@@ -122,13 +145,15 @@ gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
 gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"
 ```
 
-**For standalone review comments (not in a thread):**
+Use the `/replies` endpoint for all existing review comments, including standalone top-level comments.
+
+**For review summary bodies (from `/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}`):**
+
+Review summary bodies do not have a `comment_id` and cannot be replied to via the `/replies` endpoint. Instead, post a general PR comment referencing the review:
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments -X POST -f body="<response>" -f commit_id="<COMMIT_SHA>" -f path="<FILE_PATH>" -f line=<LINE_NUMBER> -f side="RIGHT"
+gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
 ```
-
-Note: `side` is required when using `line`. Use `"RIGHT"` for the PR commit side (most common) or `"LEFT"` for the base commit side.
 
 The response should briefly explain:
 
@@ -184,6 +209,8 @@ Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
 Optional: I can also post rationale replies for skipped/declined items (e.g., "reply 3,5" or "reply all skipped").
 ```
 
+Note: Only show the "Optional: rationale replies" line when there are `SKIPPED` or declined `DISCUSS` items. Omit it when every item is `MUST-FIX`.
+
 # Important Notes
 
 - Automatically detect the repository using `gh repo view` for the current working directory
@@ -204,3 +231,4 @@ Optional: I can also post rationale replies for skipped/declined items (e.g., "r
 
 - Rate limiting: GitHub API has rate limits; if you hit them, wait a few minutes
 - Private repos: Requires appropriate `gh` authentication scope
+- GraphQL inner pagination: The `comments(first:100)` inside each review thread is hardcoded. Threads with >100 comments (rare) will have older comments truncated. The outer `reviewThreads` pagination is handled by `--paginate`.


### PR DESCRIPTION
Syncs the address-review command with improvements from https://github.com/shakacode/claude-code-commands-skills-agents/pull/14.

**Key changes:**
- Add `node_id` fields to all comment fetches for thread resolution
- Add `jq -s` (slurp) to paginated `gh api` calls for proper multi-page aggregation
- Add GraphQL query to fetch review thread metadata and `thread_id`
- Add filtering for already-resolved threads
- Document review summary body reply path via general PR comments
- Document GraphQL pagination limitation for review threads with >100 comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes, but they alter the prescribed GitHub API/GraphQL workflows for fetching/replying/resolving review threads and could affect anyone automating this process if followed incorrectly.
> 
> **Overview**
> Updates the `address-review` command instructions to fetch richer PR feedback data and better support thread resolution. It adds `node_id` and proper `--paginate` aggregation (`jq -s`) to comment fetches, introduces a GraphQL lookup to map comments to `thread_id`/`isResolved`, and documents skipping already-resolved threads.
> 
> Clarifies reply behavior by distinguishing inline review comments (reply via `/replies`) from review summary bodies (reply via general PR issue comments), tightens triage/task formatting guidance, and notes the GraphQL inner-pagination limitation for threads with >100 comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 614a78e0af78adc77687b9a07ed34966efb5e901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->