### PR TITLE
Add Academia.edu webpack-to-rspack testimonial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,17 @@ Here's a testimonial of how ShakaCode can help from [Florian Gößler](https://g
 
 Read the [full review here](https://clutch.co/profile/shakacode#reviews?sort_by=date_DESC#review-2118154).
 
-Here's a testimonial from Jon Rajavuori of [Academia.edu](https://www.academia.edu/) about migrating frontend builds from Webpack to [rspack](https://rspack.rs/) with ShakaCode's help, shared privately in March 2026:
+Here's a testimonial from Jon Rajavuori of [Academia.edu](https://www.academia.edu/) about migrating frontend builds from Webpack to [rspack](https://rspack.rs/) with ShakaCode's help, shared in March 2026:
 
 > We've been running [rspack](https://rspack.rs/) most of the week now for frontend builds! It's a performance-focused drop-in replacement for Webpack that apparently works as advertised. The impact has been between a **2-4x build speed increase** depending on the environment and conditions.
 >
 > The typical case of first startup with a warm cache has gone from roughly 1m with Webpack down to about **20s** — close to the amount of time other dev components take to startup.
 >
-> As for production builds, they now take around 10s when only a few lines in one bundle have changed!
+> As for production **incremental** builds, they now take around 10s when only a few lines in one bundle have changed!
 >
-> Additional reported stats from the same migration:
+> Additional stats from follow-up conversation with Jon:
 >
-> - Warm-cache and incremental builds saw the biggest gains: **2-4x faster** depending on environment and conditions
-> - Dev server warm-cache startup: **1 minute → 20 seconds** (3x faster)
-> - Cold-cache startup: **4m30s → 3m30s** (~22% faster)
+> - Cold-cache startup: **4m30s → 3m30s** (~22% faster; 2-4x gains apply to warm-cache and incremental builds)
 > - Production incremental builds: **~10 seconds**
 > - HMR rebuild time: unchanged at ~8s (bottleneck is orchestration, not compilation)
 


### PR DESCRIPTION
## Summary
- Adds testimonial from Jon Rajavuori of Academia.edu about their rspack migration experience
- Highlights 2-4x build speed improvements across environments
- Placed alongside the existing Blinkist testimonial in the README intro section

## Test plan
- [ ] Verify README renders correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a testimonial; no runtime or API behavior is affected.
> 
> **Overview**
> Adds a new README testimonial from Academia.edu describing a Webpack→`rspack` migration, including reported build-time improvements (warm-cache startup, incremental builds, and cold-cache stats) alongside the existing customer review section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b6479f2932d710401a9f682274f1eb6ec6747be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new testimonial section to the README documenting a migration experience from Webpack to rspack, including performance improvements and key performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->