### PR TITLE
Add link to shakapacker.com documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 _🚀 Shakapacker 9 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
 
+_📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
+
 ---
 
 _Official, actively maintained successor to [rails/webpacker](https://github.com/rails/webpacker). ShakaCode stands behind the long-term maintenance and development of this project for the Rails community._


### PR DESCRIPTION
## Summary
- Adds a prominent link to the new [shakapacker.com](https://shakapacker.com) documentation site in the README, placed right below the Rspack announcement for high visibility

## Test plan
- [x] Verify the markdown renders correctly with the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Highlights the new documentation site by adding a prominent `shakapacker.com` link near the top of `README.md` for higher visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34823b1420af01bcb4e32a26e97f98f47ac20a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->