### PR TITLE
Add shakapacker-specific docs references for competitive landscape and templates

### DIFF
--- a/.claude/docs-competitive-landscape.md
+++ b/.claude/docs-competitive-landscape.md
@@ -1,0 +1,56 @@
+# Shakapacker Competitive Landscape
+
+Reference for understanding what competitors offer so we can match or exceed them in documentation quality.
+
+## Shakapacker Competitors
+
+### Vite Ruby (vite-ruby.netlify.app)
+
+The primary alternative to Shakapacker for JS bundling in Rails.
+
+Doc site structure:
+
+- Introduction (motivation, comparison)
+- Getting Started (multi-framework install)
+- Development, Deployment, Advanced, Plugins
+- Rails Integration (tag helpers, asset handling)
+- Configuration Reference (every option in a table)
+- Troubleshooting
+- Overview (internals for curious devs)
+
+Key differentiators:
+
+- Clear framework-specific install paths
+- Recommended plugins page
+- Link to example app on Heroku
+
+### jsbundling-rails (github.com/rails/jsbundling-rails)
+
+- Very short README
+- Relies on official Rails guides for context
+- No dedicated docs site
+- Simple by design (thin wrapper)
+
+### Webpacker (legacy, github.com/rails/webpacker)
+
+- Was the Rails default
+- README plus docs/ directory
+- Now deprecated; Shakapacker is the successor
+
+## Unique Strengths to Highlight in Docs
+
+- Official successor to rails/webpacker
+- Drop-in replacement for webpacker
+- Active maintenance by ShakaCode
+- Webpack 5 with full configuration access
+- Rspack compatibility for faster builds
+
+## Documentation Improvement Targets
+
+Based on competitive analysis:
+
+1. **Configuration Reference page** (Vite Ruby does this well with a table of every option)
+2. **Troubleshooting page** derived from top GitHub Issues
+3. **Comparison page** that honestly compares Shakapacker vs Vite Ruby vs jsbundling-rails
+4. **Upgrade guides** for each major version with before/after code
+5. **LLMs.txt** for AI agent consumption

--- a/.claude/docs-templates.md
+++ b/.claude/docs-templates.md
@@ -1,0 +1,53 @@
+# Shakapacker Documentation Templates
+
+Project-specific template details for Shakapacker documentation. These supplement
+the generic templates in the shared claude-code-commands-skills-agents repo.
+
+## README Hello World
+
+Use a webpack/rspack configuration example rather than a React component example:
+
+```javascript
+// config/webpack/webpack.config.js
+const { generateWebpackConfig } = require("shakapacker")
+module.exports = generateWebpackConfig()
+```
+
+```erb
+<%# In your Rails view %>
+<%= javascript_pack_tag 'application' %>
+<%= stylesheet_pack_tag 'application' %>
+```
+
+## Requirements Section
+
+When documenting requirements, use:
+
+```markdown
+## Requirements
+
+- Ruby >= 3.0
+- Rails >= 6.1
+- Node >= 18
+- Shakapacker >= 8.0 (supports both webpack and rspack)
+```
+
+## Quick Start Steps
+
+Shakapacker-specific installation flow:
+
+```bash
+# 1. Add the gem
+bundle add shakapacker --strict
+
+# 2. Run the installer
+rails shakapacker:install
+
+# 3. Start the dev server
+bin/shakapacker-dev-server
+```
+
+## Configuration Reference
+
+Shakapacker configuration lives in `config/shakapacker.yml`. When documenting
+config options, include both webpack and rspack variants where they differ.


### PR DESCRIPTION
## Summary

- Adds `.claude/docs-competitive-landscape.md` with shakapacker-specific competitor analysis (Vite Ruby, jsbundling-rails, Webpacker) and documentation improvement targets
- Adds `.claude/docs-templates.md` with shakapacker-specific README examples, requirements, and quick start steps

These files receive project-specific content that will be removed from the shared `claude-code-commands-skills-agents` repo's generic `skills/docs/references/` files.

Fixes shakacode/claude-code-commands-skills-agents#19 (shakapacker portion)
Fixes shakacode/claude-code-commands-skills-agents#20 (shakapacker portion)

## Test plan

- [ ] Verify `.claude/docs-competitive-landscape.md` contains only shakapacker-relevant competitors
- [ ] Verify `.claude/docs-templates.md` uses shakapacker examples (not React on Rails)
- [ ] Confirm no React on Rails-specific content leaked into these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new internal documentation/reference files only, with no impact on runtime code paths or build artifacts.
> 
> **Overview**
> Adds Shakapacker-specific Claude docs references under `.claude/`, including a competitive landscape write-up (Vite Ruby, `jsbundling-rails`, legacy Webpacker) and a set of documentation templates for README/requirements/quick-start/config reference examples tailored to Shakapacker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df809bdd4068e60ca15a99cf974e93ca3727b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->