### PR TITLE
Fix webpack-dev-server static config: default to false, fix YAML passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
 
 - **Ensured `shakapacker:install` installs the latest `compression-webpack-plugin`**. [PR #1035](https://github.com/shakacode/shakapacker/pull/1035) by [G-Rath](https://github.com/G-Rath).
 
+### Fixed
+
+- **Fixed webpack-dev-server `static` config defaulting to watch `public/` directory unnecessarily**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [ihabadham](https://github.com/ihabadham). Three bugs fixed: (1) `static` now defaults to `false` instead of a misconfigured object that caused webpack-dev-server to watch the `public/` directory, which is already served by Rails via `ActionDispatch::Static`; (2) setting `static: false` in `shakapacker.yml` is no longer silently ignored; (3) the default template no longer includes `static.watch`, which was a v3→v4 migration artifact. Fixes [#1031](https://github.com/shakacode/shakapacker/issues/1031).
+
 ## [v9.7.0] - March 15, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - **Fixed `shakapacker:check_node` reporting "Node.js not installed" in the published gem**. [PR #1120](https://github.com/shakacode/shakapacker/pull/1120) by [justin808](https://github.com/justin808). The gemspec allowlist introduced in [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) dropped the gem-root `package.json` that `check_node.rake` reads for the `engines.node` range, so `Pathname#realpath` raised `Errno::ENOENT` and the outer rescue printed the misleading "Node.js not installed. Exiting!" — most visibly during `rails assets:precompile` via `shakapacker:clean` → `verify_install` → `check_node`. The gemspec now ships `package.json`, and `check_node.rake` skips the engines-range check gracefully if that file is ever missing rather than blaming Node.
+- **Fixed webpack-dev-server `static` config defaulting to watch `public/` directory unnecessarily**. [PR #1032](https://github.com/shakacode/shakapacker/pull/1032) by [ihabadham](https://github.com/ihabadham). Three bugs fixed: (1) `static` now defaults to `false` instead of a misconfigured object that caused webpack-dev-server to watch the `public/` directory, which is already served by Rails via `ActionDispatch::Static`; (2) setting `static: false` in `shakapacker.yml` is no longer silently ignored; (3) the default template no longer includes `static.watch`, which was a v3→v4 migration artifact. Fixes [#1031](https://github.com/shakacode/shakapacker/issues/1031).
 
 ## [v10.1.0-rc.0] - May 20, 2026
 
@@ -70,10 +71,6 @@
 ### Fixed
 
 - **Ensured `shakapacker:install` installs the latest `compression-webpack-plugin`**. [PR #1035](https://github.com/shakacode/shakapacker/pull/1035) by [G-Rath](https://github.com/G-Rath).
-
-### Fixed
-
-- **Fixed webpack-dev-server `static` config defaulting to watch `public/` directory unnecessarily**. [PR #1032](https://github.com/shakacode/shakapacker/pull/1032) by [ihabadham](https://github.com/ihabadham). Three bugs fixed: (1) `static` now defaults to `false` instead of a misconfigured object that caused webpack-dev-server to watch the `public/` directory, which is already served by Rails via `ActionDispatch::Static`; (2) setting `static: false` in `shakapacker.yml` is no longer silently ignored; (3) the default template no longer includes `static.watch`, which was a v3→v4 migration artifact. Fixes [#1031](https://github.com/shakacode/shakapacker/issues/1031).
 
 ## [v9.7.0] - March 15, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 
 ### Fixed
 
-- **Fixed webpack-dev-server `static` config defaulting to watch `public/` directory unnecessarily**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [ihabadham](https://github.com/ihabadham). Three bugs fixed: (1) `static` now defaults to `false` instead of a misconfigured object that caused webpack-dev-server to watch the `public/` directory, which is already served by Rails via `ActionDispatch::Static`; (2) setting `static: false` in `shakapacker.yml` is no longer silently ignored; (3) the default template no longer includes `static.watch`, which was a v3→v4 migration artifact. Fixes [#1031](https://github.com/shakacode/shakapacker/issues/1031).
+- **Fixed webpack-dev-server `static` config defaulting to watch `public/` directory unnecessarily**. [PR #1032](https://github.com/shakacode/shakapacker/pull/1032) by [ihabadham](https://github.com/ihabadham). Three bugs fixed: (1) `static` now defaults to `false` instead of a misconfigured object that caused webpack-dev-server to watch the `public/` directory, which is already served by Rails via `ActionDispatch::Static`; (2) setting `static: false` in `shakapacker.yml` is no longer silently ignored; (3) the default template no longer includes `static.watch`, which was a v3→v4 migration artifact. Fixes [#1031](https://github.com/shakacode/shakapacker/issues/1031).
 
 ## [v9.7.0] - March 15, 2026
 

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -165,9 +165,6 @@ development:
     # port than your Rails server and the browser blocks cross-origin asset requests):
     # headers:
     #   "Access-Control-Allow-Origin": "*"
-    static:
-      watch:
-        ignored: "**/node_modules/**"
 
 test:
   <<: *default

--- a/package/webpackDevServerConfig.ts
+++ b/package/webpackDevServerConfig.ts
@@ -20,7 +20,9 @@ interface WebpackDevServerConfig {
         disableDotRule?: boolean
       }
   static?:
-    | false
+    | boolean
+    | string
+    | string[]
     | {
         publicPath?: string
         [key: string]: unknown
@@ -117,13 +119,13 @@ function createDevServerConfig(): WebpackDevServerConfig {
   }
   delete devServerYamlConfig.hmr
 
-  if (devServerYamlConfig.static !== undefined) {
+  if (
+    devServerYamlConfig.static !== undefined &&
+    devServerYamlConfig.static !== null
+  ) {
     if (devServerYamlConfig.static === false) {
       config.static = false
-    } else if (
-      typeof devServerYamlConfig.static === "object" &&
-      devServerYamlConfig.static !== null
-    ) {
+    } else if (typeof devServerYamlConfig.static === "object") {
       config.static = devServerYamlConfig.static as Record<string, unknown>
     } else {
       config.static =

--- a/package/webpackDevServerConfig.ts
+++ b/package/webpackDevServerConfig.ts
@@ -125,6 +125,9 @@ function createDevServerConfig(): WebpackDevServerConfig {
       devServerYamlConfig.static !== null
     ) {
       config.static = devServerYamlConfig.static as Record<string, unknown>
+    } else {
+      config.static =
+        devServerYamlConfig.static as WebpackDevServerConfig["static"]
     }
     delete devServerYamlConfig.static
   }

--- a/package/webpackDevServerConfig.ts
+++ b/package/webpackDevServerConfig.ts
@@ -22,7 +22,7 @@ interface WebpackDevServerConfig {
   static?:
     | boolean
     | string
-    | string[]
+    | Array<string | Record<string, unknown>>
     | {
         publicPath?: string
         [key: string]: unknown
@@ -125,6 +125,10 @@ function createDevServerConfig(): WebpackDevServerConfig {
   ) {
     if (devServerYamlConfig.static === false) {
       config.static = false
+    } else if (Array.isArray(devServerYamlConfig.static)) {
+      config.static = devServerYamlConfig.static as Array<
+        string | Record<string, unknown>
+      >
     } else if (typeof devServerYamlConfig.static === "object") {
       config.static = devServerYamlConfig.static as Record<string, unknown>
     } else {

--- a/package/webpackDevServerConfig.ts
+++ b/package/webpackDevServerConfig.ts
@@ -4,8 +4,7 @@ const snakeToCamelCase = require("./utils/snakeToCamelCase")
 
 const shakapackerDevServerYamlConfig =
   require("./dev_server") as DevServerConfig
-const { outputPath: contentBase, publicPath } = require("./config") as {
-  outputPath: string
+const { publicPath } = require("./config") as {
   publicPath: string
 }
 
@@ -20,10 +19,12 @@ interface WebpackDevServerConfig {
     | {
         disableDotRule?: boolean
       }
-  static?: {
-    publicPath?: string
-    [key: string]: unknown
-  }
+  static?:
+    | false
+    | {
+        publicPath?: string
+        [key: string]: unknown
+      }
   client?: Record<string, unknown>
   allowedHosts?: string | string[]
   bonjour?: boolean | Record<string, unknown>
@@ -112,18 +113,18 @@ function createDevServerConfig(): WebpackDevServerConfig {
     historyApiFallback: {
       disableDotRule: true
     },
-    static: {
-      publicPath: contentBase
-    }
+    static: false
   }
   delete devServerYamlConfig.hmr
 
-  if (devServerYamlConfig.static) {
-    config.static = {
-      ...config.static,
-      ...(typeof devServerYamlConfig.static === "object"
-        ? (devServerYamlConfig.static as Record<string, unknown>)
-        : {})
+  if (devServerYamlConfig.static !== undefined) {
+    if (devServerYamlConfig.static === false) {
+      config.static = false
+    } else if (
+      typeof devServerYamlConfig.static === "object" &&
+      devServerYamlConfig.static !== null
+    ) {
+      config.static = devServerYamlConfig.static as Record<string, unknown>
     }
     delete devServerYamlConfig.static
   }

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -124,6 +124,16 @@ describe("webpackDevServerConfig", () => {
     expect(config.static).toStrictEqual(["/path1", "/path2"])
   })
 
+  test("treats static: null (YAML ~) as unset, defaulting to false", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = null
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toBe(false)
+  })
+
   test("sets devMiddleware.publicPath to URL path", () => {
     const createDevServerConfig = require("../../package/webpackDevServerConfig")
     const config = createDevServerConfig()

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -88,7 +88,10 @@ describe("webpackDevServerConfig", () => {
     const createDevServerConfig = require("../../package/webpackDevServerConfig")
     const config = createDevServerConfig()
 
-    expect(config.static).toStrictEqual({ directory: "/custom/path", watch: false })
+    expect(config.static).toStrictEqual({
+      directory: "/custom/path",
+      watch: false
+    })
   })
 
   test("sets devMiddleware.publicPath to URL path", () => {

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -114,6 +114,16 @@ describe("webpackDevServerConfig", () => {
     })
   })
 
+  test("passes through static array from YAML config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = ["/path1", "/path2"]
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toStrictEqual(["/path1", "/path2"])
+  })
+
   test("sets devMiddleware.publicPath to URL path", () => {
     const createDevServerConfig = require("../../package/webpackDevServerConfig")
     const config = createDevServerConfig()

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -1,8 +1,19 @@
+const { chdirTestApp, resetEnv } = require("../helpers")
+
+const rootPath = process.cwd()
+chdirTestApp()
+
 describe("webpackDevServerConfig", () => {
   beforeEach(() => {
     jest.resetModules()
     jest.restoreAllMocks()
+    jest.dontMock("../../package/dev_server")
+    jest.dontMock("../../package/config")
+    resetEnv()
+    process.env.NODE_ENV = "development"
+    process.env.RAILS_ENV = "development"
   })
+  afterAll(() => process.chdir(rootPath))
 
   test("warns and ignores removed middleware hooks", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
@@ -51,5 +62,76 @@ describe("webpackDevServerConfig", () => {
     })
 
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  test("defaults static to false", () => {
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toBe(false)
+  })
+
+  test("passes through static: false from YAML config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = false
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toBe(false)
+  })
+
+  test("passes through static object from YAML config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = { directory: "/custom/path", watch: false }
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toStrictEqual({ directory: "/custom/path", watch: false })
+  })
+
+  test("sets devMiddleware.publicPath to URL path", () => {
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.devMiddleware.publicPath).toBe("/packs/")
+  })
+
+  test("maps hmr to hot", () => {
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.hot).toBe(true)
+    expect(config.hmr).toBeUndefined()
+  })
+
+  test("defaults liveReload to inverse of hmr", () => {
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    // Test app has hmr: true, so liveReload should default to false
+    expect(config.liveReload).toBe(false)
+  })
+
+  test("maps snake_case YAML keys to camelCase webpack-dev-server keys", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.allowed_hosts = "auto"
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.allowedHosts).toBe("auto")
+    expect(config.allowed_hosts).toBeUndefined()
+  })
+
+  test("passes through client config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.client = { overlay: true }
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.client).toStrictEqual({ overlay: true })
   })
 })

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -91,6 +91,16 @@ describe("webpackDevServerConfig", () => {
     expect(config.static).toBe(true)
   })
 
+  test("passes through static string path from YAML config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = "/custom/static"
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toBe("/custom/static")
+  })
+
   test("passes through static object from YAML config", () => {
     const devServer = require("../../package/dev_server")
     devServer.static = { directory: "/custom/path", watch: false }

--- a/test/package/webpackDevServerConfig.test.js
+++ b/test/package/webpackDevServerConfig.test.js
@@ -81,6 +81,16 @@ describe("webpackDevServerConfig", () => {
     expect(config.static).toBe(false)
   })
 
+  test("passes through static: true from YAML config", () => {
+    const devServer = require("../../package/dev_server")
+    devServer.static = true
+
+    const createDevServerConfig = require("../../package/webpackDevServerConfig")
+    const config = createDevServerConfig()
+
+    expect(config.static).toBe(true)
+  })
+
   test("passes through static object from YAML config", () => {
     const devServer = require("../../package/dev_server")
     devServer.static = { directory: "/custom/path", watch: false }


### PR DESCRIPTION
## Summary

Fixes three bugs in Shakapacker's webpack-dev-server `static` configuration that cause unnecessary inotify watches and ENOSPC crashes on systems with limited headroom.

- Default `static` from a misconfigured object to `false` — Rails serves `public/` via `ActionDispatch::Static`, webpack-dev-server doesn't need to
- Fix `if (devServerYamlConfig.static)` truthy check so `static: false` in `shakapacker.yml` is no longer silently ignored
- Remove `static.watch` from the default install template — it was a v3→v4 migration artifact that caused webpack-dev-server to watch `public/` via chokidar
- Pass through all valid webpack-dev-server `static` values (`true`, strings, arrays, objects) from YAML — if a user explicitly overrides the default, we respect it

Fixes #1031

## Details

The old default set `static.publicPath` to a filesystem path (`config.outputPath`) instead of a URL path, and never set `static.directory`, causing webpack-dev-server to default to watching the entire `public/` directory. This has been present since v6.0.0-rc.7 but was harmless on most systems. On systems near their inotify watch limit (e.g., Fedora with auto-calculated limits + watch-heavy tools like Warp terminal), it triggers `ENOSPC: System limit for number of file watchers reached`.

Setting `static: false` is safe because:
- `Shakapacker::DevServerProxy` (hardwired in the railtie) proxies `/packs/*` to webpack-dev-server — the browser never accesses webpack-dev-server directly
- Webpack bundles are served through `devMiddleware`, which is independent of `static`
- `ActionDispatch::Static` serves `public/` files in Rails

Users who explicitly set `static` in `shakapacker.yml` (to `true`, an object, a string path, etc.) will have their value passed through to webpack-dev-server as-is. Bare `static:` (YAML null) is treated the same as unset — the default `false` applies.

## Test plan

- [x] Added 11 new tests in `test/package/webpackDevServerConfig.test.js` covering default behavior, `false`/`true`/string/object/array passthrough, and existing key mapping
- [x] All 13 tests in the suite pass (11 new + 2 existing middleware-hook warning tests)
- [x] `yarn lint` — 0 errors
- [x] `yarn type-check` — clean
- [x] Manual integration test against `spec/dummy` — wrote a harness that swaps the dummy app's `shakapacker-webpack.yml` and runs `createDevServerConfig()` against each scenario:

| Scenario | Result |
| --- | --- |
| No `static` key in YAML | `static: false` (new default) |
| `static: false` (regression) | `static: false` (previously silently ignored) |
| `static: true` | `static: true` (passed through) |
| `static: /custom/static` | `"/custom/static"` (string passed through) |
| `static: { directory, watch.ignored }` | object passed through verbatim |
| `static: [/path1, /path2]` | array preserved |
| `static: ~` (YAML null) | falls back to `false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed webpack-dev-server static configuration to correctly default to `false` (previously defaulted to an invalid value that caused unintended watching of `public/`)
- Corrected handling of `static: false` setting from configuration files to be properly respected instead of being silently ignored
- Removed unnecessary watch configuration leftover from previous version migration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
