### PR TITLE
Add bin/setup to install development deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,12 +174,16 @@ yarn lint --cache
      yalc push # or yalc publish --push
      ```
 
-3. Run the following commands to set up the development environment.
-   ```
-   bundle install
-   yarn install
+3. Run `bin/setup` to install development dependencies.
+   ```bash
+   bin/setup
    # Optional: enable local pre-commit hooks
    npx husky
+   ```
+   Manual equivalent:
+   ```bash
+   bundle install
+   yarn install
    ```
 
 ## Understanding Optional Peer Dependencies

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+run_cmd() {
+  if [[ -x "$ROOT_DIR/bin/conductor-exec" ]]; then
+    "$ROOT_DIR/bin/conductor-exec" "$@"
+  else
+    "$@"
+  fi
+}
+
+ensure_tool() {
+  local tool="$1"
+  if ! run_cmd "$tool" --version >/dev/null 2>&1; then
+    echo "Error: $tool is not available. Install it and run bin/setup again." >&2
+    exit 1
+  fi
+}
+
+echo "Checking required tools..."
+ensure_tool ruby
+ensure_tool bundle
+ensure_tool node
+ensure_tool yarn
+
+echo "Installing Ruby dependencies..."
+run_cmd bundle install
+
+echo "Installing JavaScript dependencies..."
+run_cmd yarn install
+
+echo "Development dependencies installed."
+echo "Optional: run 'npx husky' to enable local git hooks."


### PR DESCRIPTION
### Summary

- Add a new executable `bin/setup` script for local development setup.
- The script validates `ruby`, `bundle`, `node`, and `yarn`, then runs `bundle install` and `yarn install`.
- Commands are routed through `bin/conductor-exec` when available to respect workspace-managed tool versions.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

- `bash -n bin/setup` was run to validate script syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small dev-only setup script and a documentation update; no runtime or production code paths are affected.
> 
> **Overview**
> Adds a new `bin/setup` script to bootstrap local development by verifying `ruby`, `bundle`, `node`, and `yarn` are available, then running `bundle install` and `yarn install` (routing commands through `bin/conductor-exec` when present).
> 
> Updates `CONTRIBUTING.md` to prefer `bin/setup` for installing dev dependencies, while still documenting the manual `bundle install`/`yarn install` equivalent and the optional `npx husky` hooks step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56bfa4766ed2a957330923708163ebac44bea0c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->