### PR TITLE
Use npx release-it to avoid mise shim failures

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,7 +9,7 @@ This guide is for Shakapacker maintainers who need to publish a new release.
    ```bash
    bundle install
    gem install gem-release     # Provides `gem bump` and `gem release`
-   yarn global add release-it  # Installs release-it for npm publishing
+   npm --version               # Required because release task uses `npx release-it`
    gh --version                # Required for automatic GitHub release creation
    ```
 
@@ -24,6 +24,9 @@ This guide is for Shakapacker maintainers who need to publish a new release.
 4. **Authenticate GitHub CLI:**
    - Run `gh auth login` and ensure your account/token has write access to this repository
    - Required for automatic GitHub release creation after publishing
+
+5. **No global `release-it` install required:**
+   - The release task runs `npx --yes release-it ...` automatically
 
 ## Release Process
 
@@ -260,7 +263,7 @@ If you need to release manually (not recommended):
 2. **Publish to npm:**
 
    ```bash
-   release-it 9.1.0 --npm.publish
+   npx --yes release-it 9.1.0 --npm.publish
    ```
 
 3. **Publish to RubyGems:**

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -520,7 +520,9 @@ def perform_release(
       abort "❌ Expected gem bump to produce #{resolved_target_gem_version}, but found #{resolved_gem_version}."
     end
 
-    release_it_command = +"release-it #{Shellwords.escape(npm_version)}"
+    # Use npx so maintainers don't need a globally installed `release-it` binary.
+    # This avoids failures from shim managers (e.g. mise) when `release-it` isn't configured.
+    release_it_command = +"npx --yes release-it #{Shellwords.escape(npm_version)}"
     release_it_command << " --npm.publish --no-git.requireCleanWorkingDir"
     release_it_command << " --dry-run --verbose" if dry_run
     npm_dist_tag = npm_dist_tag_for_version(npm_version)


### PR DESCRIPTION
### Summary

- Switch the release task to run `release-it` via `npx --yes`, removing reliance on a globally installed binary and preventing `mise` shim failures during npm publish.
- Keep release commit behavior unchanged (`--npm.publish --no-git.requireCleanWorkingDir`) while documenting the rationale inline.
- Update release docs to reflect `npx` usage for prerequisites and manual npm publishing.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [x] Update documentation
- [ ] Update CHANGELOG file

### Other Information

- Validation run in this branch: `ruby -c rakelib/release.rake`, `bundle exec rake -T | rg '\\brelease\\b'`, and `npx --yes release-it --version`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the automated release/publish path; while behavior should be equivalent, invoking `release-it` via `npx` can change which version runs and could impact npm publishing if environments differ.
> 
> **Overview**
> Updates the release rake task to publish to npm by running `release-it` via `npx --yes` instead of requiring a globally installed `release-it` binary, with inline rationale to avoid shim-manager (e.g. `mise`) failures.
> 
> Refreshes `docs/releasing.md` prerequisites and manual release steps to match the new `npx --yes release-it ...` workflow and clarify that no global install is needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5644462afeacfcaca2df5afa9371b805f01573a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->