### PR TITLE
[codex] Fix local-path shakapacker version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - **Widened `@rspack/plugin-react-refresh` peer range to `^1.0.0 || ^2.0.0-0`**. [PR #1091](https://github.com/shakacode/shakapacker/pull/1091) by [ihabadham](https://github.com/ihabadham). Fixes the `ERESOLVE` conflict when installing `@rspack/plugin-react-refresh@^2.0.0` alongside `shakapacker@10.0.0`.
+- **Fixed `NodePackageVersion#find_version` for local-path `shakapacker` installs (e.g. `yalc`, `file:`, relative paths)**. [PR #1086](https://github.com/shakacode/shakapacker/pull/1086) by [justin808](https://github.com/justin808). The version check now consults `package.json` first and short-circuits on `../` or `file:` dependencies, so stale lockfile semvers no longer trigger false gem↔node version mismatches. `package_json_dependency` also consults `devDependencies` in addition to `dependencies`. The `LOCAL_PATH_REGEX` constant replaces a duplicated inline regex and anchors both alternatives to the start of the string, removing a latent false-positive on version strings containing `..` mid-value.
 
 ## [v10.0.0] - April 8, 2026
 

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,7 +67,7 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
-        LOCAL_PATH_REGEX = %r{(\.\.|\Afile:)}.freeze
+        LOCAL_PATH_REGEX = %r{\A(\.\.(/|\z)|file:)}.freeze
 
         attr_reader :package_json
 
@@ -143,8 +143,16 @@ module Shakapacker
             @package_json_contents ||= File.read(package_json)
           end
 
+          def parsed_package_json
+            @parsed_package_json ||= JSON.parse(package_json_contents)
+          end
+
           def package_json_dependency
-            @package_json_dependency ||= JSON.parse(package_json_contents).dig("dependencies", "shakapacker").to_s
+            @package_json_dependency ||= begin
+              dependency = parsed_package_json.dig("dependencies", "shakapacker")
+              dependency ||= parsed_package_json.dig("devDependencies", "shakapacker")
+              dependency.to_s
+            end
           end
 
           def find_version

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -163,7 +163,7 @@ module Shakapacker
             # Prefer the declared package.json source for local path installs so
             # yalc/file dependencies are not mistaken for the stale semver in a lockfile.
             dep = package_json_dependency
-            return dep if dep.match(LOCAL_PATH_REGEX).present?
+            return dep if dep.match?(LOCAL_PATH_REGEX)
 
             if File.exist?(@yarn_lock)
               version = from_yarn_lock

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -141,7 +141,15 @@ module Shakapacker
             @package_json_contents ||= File.read(package_json)
           end
 
+          def package_json_dependency
+            @package_json_dependency ||= JSON.parse(package_json_contents).dig("dependencies", "shakapacker").to_s
+          end
+
           def find_version
+            # Prefer the declared package.json source for local path installs so
+            # yalc/file dependencies are not mistaken for the stale semver in a lockfile.
+            return package_json_dependency if package_json_dependency.match(%r{(\.\.|\Afile:)}).present?
+
             if File.exist?(@yarn_lock)
               version = from_yarn_lock
 
@@ -160,8 +168,7 @@ module Shakapacker
               return version unless version.nil?
             end
 
-            parsed_package_contents = JSON.parse(package_json_contents)
-            parsed_package_contents.dig("dependencies", "shakapacker").to_s
+            package_json_dependency
           end
 
           def from_package_lock

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,6 +67,8 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
+        LOCAL_PATH_REGEX = %r{(\.\.|\Afile:)}.freeze
+
         attr_reader :package_json
 
         def self.build
@@ -126,7 +128,7 @@ module Shakapacker
           end
 
           def relative_path?
-            raw.match(%r{(\.\.|\Afile:)}).present?
+            raw.match(LOCAL_PATH_REGEX).present?
           end
 
           def git_url?
@@ -148,7 +150,8 @@ module Shakapacker
           def find_version
             # Prefer the declared package.json source for local path installs so
             # yalc/file dependencies are not mistaken for the stale semver in a lockfile.
-            return package_json_dependency if package_json_dependency.match(%r{(\.\.|\Afile:)}).present?
+            dep = package_json_dependency
+            return dep if dep.match(LOCAL_PATH_REGEX).present?
 
             if File.exist?(@yarn_lock)
               version = from_yarn_lock

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,6 +67,10 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
+        # Matches package.json values that point at a local path: "../...", bare "..",
+        # or "file:..." at the start of the string. Bare "..foo" (two dots, no slash,
+        # non-empty suffix) is intentionally not matched — package managers don't emit
+        # that form.
         LOCAL_PATH_REGEX = %r{\A(\.\.(/|\z)|file:)}.freeze
 
         attr_reader :package_json
@@ -179,7 +183,7 @@ module Shakapacker
               return version unless version.nil?
             end
 
-            package_json_dependency
+            dep
           end
 
           def from_package_lock

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -748,6 +748,9 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
+    # `raw` reflects the package.json declaration (`"../.."`) rather than the
+    # `"file:../.."` form previously read from package-lock.json v1. Both match
+    # `LOCAL_PATH_REGEX`, so `skip_processing?` stays `true` for local-path installs.
     context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -384,49 +384,45 @@ describe "VersionChecker::NodePackageVersion" do
     # Exercises yarn.lock here; npm and pnpm staleness are implicitly covered because
     # find_version short-circuits on the package.json local-path declaration before any
     # lockfile is consulted.
-    it "prefers a file dependency from package.json over a stale yarn lock version" do
-      Dir.mktmpdir do |dir|
-        package_json_path = File.join(dir, "package.json")
-        yarn_lock_path = File.join(dir, "yarn.lock")
+    %w[dependencies devDependencies].each do |section|
+      it "prefers a file dependency from #{section} over a stale yarn lock version" do
+        Dir.mktmpdir do |dir|
+          package_json_path = File.join(dir, "package.json")
+          yarn_lock_path = File.join(dir, "yarn.lock")
 
-        File.write(package_json_path, JSON.generate({ "dependencies" => { "shakapacker" => "file:.yalc/shakapacker" } }))
-        File.write(yarn_lock_path, <<~LOCK)
-          shakapacker@9.7.0:
-            version "9.7.0"
-        LOCK
+          File.write(package_json_path, JSON.generate({ section => { "shakapacker" => "file:.yalc/shakapacker" } }))
+          File.write(yarn_lock_path, <<~LOCK)
+            shakapacker@9.7.0:
+              version "9.7.0"
+          LOCK
 
-        node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
-          package_json_path,
-          yarn_lock_path,
-          "file/does/not/exist",
-          "file/does/not/exist"
-        )
+          node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
+            package_json_path,
+            yarn_lock_path,
+            "file/does/not/exist",
+            "file/does/not/exist"
+          )
 
-        expect(node_package_version.raw).to eq "file:.yalc/shakapacker"
-        expect(node_package_version.skip_processing?).to be true
+          expect(node_package_version.raw).to eq "file:.yalc/shakapacker"
+          expect(node_package_version.skip_processing?).to be true
+        end
       end
     end
 
-    it "prefers a file dependency from devDependencies over a stale yarn lock version" do
+    it "falls back to devDependencies when shakapacker is not declared in dependencies and no lockfile is present" do
       Dir.mktmpdir do |dir|
         package_json_path = File.join(dir, "package.json")
-        yarn_lock_path = File.join(dir, "yarn.lock")
-
-        File.write(package_json_path, JSON.generate({ "devDependencies" => { "shakapacker" => "file:.yalc/shakapacker" } }))
-        File.write(yarn_lock_path, <<~LOCK)
-          shakapacker@9.7.0:
-            version "9.7.0"
-        LOCK
+        File.write(package_json_path, JSON.generate({ "devDependencies" => { "shakapacker" => "10.0.0" } }))
 
         node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
           package_json_path,
-          yarn_lock_path,
+          "file/does/not/exist",
           "file/does/not/exist",
           "file/does/not/exist"
         )
 
-        expect(node_package_version.raw).to eq "file:.yalc/shakapacker"
-        expect(node_package_version.skip_processing?).to be true
+        expect(node_package_version.raw).to eq "10.0.0"
+        expect(node_package_version.skip_processing?).to be false
       end
     end
 

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -404,6 +404,29 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
+    it "prefers a file dependency from devDependencies over a stale yarn lock version" do
+      Dir.mktmpdir do |dir|
+        package_json_path = File.join(dir, "package.json")
+        yarn_lock_path = File.join(dir, "yarn.lock")
+
+        File.write(package_json_path, JSON.generate({ "devDependencies" => { "shakapacker" => "file:.yalc/shakapacker" } }))
+        File.write(yarn_lock_path, <<~LOCK)
+          shakapacker@9.7.0:
+            version "9.7.0"
+        LOCK
+
+        node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
+          package_json_path,
+          yarn_lock_path,
+          "file/does/not/exist",
+          "file/does/not/exist"
+        )
+
+        expect(node_package_version.raw).to eq "file:.yalc/shakapacker"
+        expect(node_package_version.skip_processing?).to be true
+      end
+    end
+
     context "when using a git url" do
       let(:node_package_version_from_git_url) { node_package_version(fixture_version: "git_url") }
 

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -1,5 +1,6 @@
 require_relative "spec_helper_initializer"
 require "shakapacker/version"
+require "tmpdir"
 
 class NodePackageVersionDouble
   attr_reader :raw, :major_minor_patch
@@ -363,20 +364,43 @@ describe "VersionChecker::NodePackageVersion" do
     context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns the raw version" do
-        expect(node_package_version_from_relative_path.raw).to eq "6.5.0"
+      it "#raw returns the relative path" do
+        expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
-      it "#major_minor_patch returns an array" do
-        expect(node_package_version_from_relative_path.major_minor_patch).to eq ["6", "5", "0"]
+      it "#major_minor_patch returns nil" do
+        expect(node_package_version_from_relative_path.major_minor_patch).to be nil
       end
 
-      it "#skip_processing? returns false" do
-        expect(node_package_version_from_relative_path.skip_processing?).to be false
+      it "#skip_processing? returns true" do
+        expect(node_package_version_from_relative_path.skip_processing?).to be true
       end
 
       it "#semver_wildcard? returns false" do
         expect(node_package_version_from_relative_path.semver_wildcard?).to be false
+      end
+    end
+
+    it "prefers a file dependency from package.json over a stale yarn lock version" do
+      Dir.mktmpdir do |dir|
+        package_json_path = File.join(dir, "package.json")
+        yarn_lock_path = File.join(dir, "yarn.lock")
+
+        File.write(package_json_path, JSON.generate({ "dependencies" => { "shakapacker" => "file:.yalc/shakapacker" } }))
+        File.write(yarn_lock_path, <<~LOCK)
+          shakapacker@9.7.0:
+            version "9.7.0"
+        LOCK
+
+        node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
+          package_json_path,
+          yarn_lock_path,
+          "file/does/not/exist",
+          "file/does/not/exist"
+        )
+
+        expect(node_package_version.raw).to eq "file:.yalc/shakapacker"
+        expect(node_package_version.skip_processing?).to be true
       end
     end
 
@@ -534,16 +558,16 @@ describe "VersionChecker::NodePackageVersion" do
     context "when using a relative path" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
-      it "#raw returns the raw version" do
-        expect(node_package_version_from_relative_path.raw).to eq "6.5.0"
+      it "#raw returns the relative path" do
+        expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
-      it "#major_minor_patch returns an array" do
-        expect(node_package_version_from_relative_path.major_minor_patch).to eq ["6", "5", "0"]
+      it "#major_minor_patch returns nil" do
+        expect(node_package_version_from_relative_path.major_minor_patch).to be nil
       end
 
-      it "#skip_processing? returns false" do
-        expect(node_package_version_from_relative_path.skip_processing?).to be false
+      it "#skip_processing? returns true" do
+        expect(node_package_version_from_relative_path.skip_processing?).to be true
       end
 
       it "#semver_wildcard? returns false" do
@@ -706,7 +730,7 @@ describe "VersionChecker::NodePackageVersion" do
       let(:node_package_version_from_relative_path) { node_package_version(fixture_version: "relative_path") }
 
       it "#raw returns the relative path" do
-        expect(node_package_version_from_relative_path.raw).to eq "file:../.."
+        expect(node_package_version_from_relative_path.raw).to eq "../.."
       end
 
       it "#major_minor_patch returns nil" do

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -381,6 +381,9 @@ describe "VersionChecker::NodePackageVersion" do
       end
     end
 
+    # Exercises yarn.lock here; npm and pnpm staleness are implicitly covered because
+    # find_version short-circuits on the package.json local-path declaration before any
+    # lockfile is consulted.
     it "prefers a file dependency from package.json over a stale yarn lock version" do
       Dir.mktmpdir do |dir|
         package_json_path = File.join(dir, "package.json")


### PR DESCRIPTION
## Summary
- prefer the `package.json` dependency declaration when `shakapacker` is installed from a local path (`../..` or `file:...`)
- keep existing lockfile-based semver parsing for published package installs
- add regression coverage for relative-path fixtures and the CI-shaped `file:.yalc/shakapacker` case

## Root cause
The dummy app CI flow uses `yalc add shakapacker`, which rewrites `package.json` to a local file dependency. `NodePackageVersion#find_version` was consulting `yarn.lock` first, so it read the stale published semver (`9.7.0`) instead of the local-path declaration and raised a version mismatch against the gem (`10.0.0.rc.0`).

## Behavior changes worth calling out
- **`devDependencies` is now consulted in the fallback path.** Previously `find_version` only read `parsed_package_contents.dig("dependencies", "shakapacker")` as a last resort. The replacement `package_json_dependency` digs both `dependencies` and `devDependencies`. For projects that list `shakapacker` only under `devDependencies`, the fallback now resolves to the declared version instead of returning `""`. Covered by the new `"falls back to devDependencies when shakapacker is not declared in dependencies and no lockfile is present"` spec.
- **`LOCAL_PATH_REGEX` (bonus fix).** The old inline regex `%r{(\.\.|\Afile:)}` used in `relative_path?` had an unanchored `\.\.` branch, so a version string containing `..` mid-value (e.g. `"1.2..3"`) would be incorrectly flagged as a local path. The new `%r{\A(\.\.(/|\z)|file:)}` anchors both alternatives to position zero and is reused by `find_version`'s early-return.
- **`package.json` is now always read and JSON-parsed** at the top of `find_version`, even for published installs where a lockfile provides the authoritative version. Memoization keeps this O(1) per instance; the only user-visible change is that a malformed `package.json` surfaces `JSON::ParserError` earlier than before (acceptable tradeoff for the local-path short-circuit).

## Validation
- `bundle exec rspec spec/shakapacker/version_checker_spec.rb`
- `bundle exec rubocop lib/shakapacker/version_checker.rb spec/shakapacker/version_checker_spec.rb`
- `mise exec node@22.12.0 -- yarn install --frozen-lockfile --production=false`
- `mise exec node@22.12.0 -- yarn build`
- dummy app validation with both bundlers after `yalc publish` / `yalc add shakapacker`
- `mise exec node@22.12.0 -- bin/test-bundler webpack`
- `NODE_ENV=test RAILS_ENV=test mise exec node@22.12.0 -- bin/shakapacker`
- `bundle exec rspec`
- `mise exec node@22.12.0 -- bin/test-bundler rspack`
- `NODE_ENV=test RAILS_ENV=test mise exec node@22.12.0 -- bin/shakapacker`
- `bundle exec rspec`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Shakapacker determines the installed node package version, which can affect version-mismatch errors across different package manager setups. Risk is moderate due to new precedence rules and earlier `package.json` JSON parsing, but scope is limited and covered by added specs.
> 
> **Overview**
> **Fixes false gem↔node version mismatches for local-path installs of `shakapacker`.** `NodePackageVersion#find_version` now checks the `package.json` dependency first and short-circuits when it detects a local path (`../` or `file:`), instead of trusting potentially stale versions in `yarn.lock`/`package-lock.json`/`pnpm-lock.yaml`.
> 
> It also broadens `package.json` lookup to include `devDependencies`, centralizes/anchors local-path detection via `LOCAL_PATH_REGEX`, and adds regression specs (including a `file:.yalc/shakapacker` case) to ensure local-path deps skip version processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81a42e31534c37ef568f4cb57c3b3d2d0904bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version resolution for local-path package installations to prioritize package.json declarations over lockfile data.
  * Enhanced dependency resolution to check devDependencies when needed.
  * Fixed regex pattern to prevent false matches in version detection.

* **Tests**
  * Expanded test coverage for local-path installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->