### PR TITLE
Update CHANGELOG.md for v10.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
 
 ## [Unreleased]
 
-## [v10.0.0-rc.0] - April 1, 2026
+## [v10.0.0-rc.1] - April 7, 2026
 
 ### Added
 
+- **Added `bin/diff-bundler-config` CLI for semantic bundler configuration diffs**. [PR #973](https://github.com/shakacode/shakapacker/pull/973) by [justin808](https://github.com/justin808). Wraps the extracted [`pack-config-diff`](https://github.com/shakacode/pack-config-diff) package to provide semantic diffing of webpack/rspack configurations with normalized exit codes. Supersedes #961.
 - **Added `bin/shakapacker-watch` binstub for clean Ctrl-C shutdown in Procfile-based workflows**. [PR #1026](https://github.com/shakacode/shakapacker/pull/1026) by [justin808](https://github.com/justin808). The new wrapper script traps INT/TERM signals and forwards TERM to the underlying `bin/shakapacker --watch` process, preventing Ruby interrupt backtraces when stopping `bin/dev`. Use `bin/shakapacker-watch --watch` in Procfiles instead of `bin/shakapacker --watch`.
 - **Allowed `webpack-cli` v7 (`^7.0.0`) in peer dependencies**. [PR #1021](https://github.com/shakacode/shakapacker/pull/1021) by [justin808](https://github.com/justin808). Fixes [#1020](https://github.com/shakacode/shakapacker/issues/1020). Note: `webpack-cli` v7 requires Node.js >= 20.9.0.
 
@@ -908,8 +909,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.0.0-rc.0...main
-[v10.0.0-rc.0]: https://github.com/shakacode/shakapacker/compare/v9.7.0...v10.0.0-rc.0
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.0.0-rc.1...main
+[v10.0.0-rc.1]: https://github.com/shakacode/shakapacker/compare/v9.7.0...v10.0.0-rc.1
 [v9.7.0]: https://github.com/shakacode/shakapacker/compare/v9.6.1...v9.7.0
 [v9.6.1]: https://github.com/shakacode/shakapacker/compare/v9.6.0...v9.6.1
 [v9.6.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Added
 
-- **Added `bin/diff-bundler-config` CLI for semantic bundler configuration diffs**. [PR #973](https://github.com/shakacode/shakapacker/pull/973) by [justin808](https://github.com/justin808). Wraps the extracted [`pack-config-diff`](https://github.com/shakacode/pack-config-diff) package to provide semantic diffing of webpack/rspack configurations with normalized exit codes. Supersedes #961.
+- **Added `bin/diff-bundler-config` CLI for semantic bundler configuration diffs**. [PR #973](https://github.com/shakacode/shakapacker/pull/973) by [justin808](https://github.com/justin808). Wraps the extracted [`pack-config-diff`](https://github.com/shakacode/pack-config-diff) package to provide semantic diffing of webpack/rspack configurations with normalized exit codes. Supersedes [#961](https://github.com/shakacode/shakapacker/pull/961).
 - **Added `bin/shakapacker-watch` binstub for clean Ctrl-C shutdown in Procfile-based workflows**. [PR #1026](https://github.com/shakacode/shakapacker/pull/1026) by [justin808](https://github.com/justin808). The new wrapper script traps INT/TERM signals and forwards TERM to the underlying `bin/shakapacker --watch` process, preventing Ruby interrupt backtraces when stopping `bin/dev`. Use `bin/shakapacker-watch --watch` in Procfiles instead of `bin/shakapacker --watch`.
 - **Allowed `webpack-cli` v7 (`^7.0.0`) in peer dependencies**. [PR #1021](https://github.com/shakacode/shakapacker/pull/1021) by [justin808](https://github.com/justin808). Fixes [#1020](https://github.com/shakacode/shakapacker/issues/1020). Note: `webpack-cli` v7 requires Node.js >= 20.9.0.
 


### PR DESCRIPTION
### Summary

Updates CHANGELOG.md for the v10.0.0-rc.1 release:
- Collapsed the v10.0.0-rc.0 section into v10.0.0-rc.1
- Added new entry for PR #973 (`bin/diff-bundler-config` CLI)
- Updated version diff links at the bottom of the file

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

After merging, run `bundle exec rake release` to publish v10.0.0-rc.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `CHANGELOG.md`; no runtime or build logic is modified.
> 
> **Overview**
> Updates the `CHANGELOG.md` release entry from `v10.0.0-rc.0` to `v10.0.0-rc.1` (dated April 7, 2026) and folds the prior RC notes into the new version section.
> 
> Adds a new changelog item for PR #973 introducing `bin/diff-bundler-config` (semantic bundler config diffs via `pack-config-diff`), and updates the bottom compare links to point `Unreleased` and the RC tag at `v10.0.0-rc.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b93ada3754ea3b203645834f0a57d6becf98f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->