### PR TITLE
Update CHANGELOG.md for v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## [Unreleased]
 
-## [v10.0.0-rc.1] - April 7, 2026
+## [v10.0.0] - April 8, 2026
 
 ### Added
 
@@ -909,8 +909,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.0.0-rc.1...main
-[v10.0.0-rc.1]: https://github.com/shakacode/shakapacker/compare/v9.7.0...v10.0.0-rc.1
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.0.0...main
+[v10.0.0]: https://github.com/shakacode/shakapacker/compare/v9.7.0...v10.0.0
 [v9.7.0]: https://github.com/shakacode/shakapacker/compare/v9.6.1...v9.7.0
 [v9.6.1]: https://github.com/shakacode/shakapacker/compare/v9.6.0...v9.6.1
 [v9.6.0]: https://github.com/shakacode/shakapacker/compare/v9.5.0...v9.6.0


### PR DESCRIPTION
## Summary
- Promote `v10.0.0-rc.1` changelog section to stable `v10.0.0` release
- Update version diff links at the bottom of the file

## Notes
After merge, run `bundle exec rake release` (no args) to publish the gem and auto-create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update promoting the v10.0.0 release candidate section to a stable release and adjusting compare links; no runtime code changes.
> 
> **Overview**
> Promotes the `v10.0.0-rc.1` changelog entry to the final **`v10.0.0`** release (including the release date).
> 
> Updates the bottom-of-file compare links so `[Unreleased]` now compares from `v10.0.0` to `main`, and adds the finalized `[v10.0.0]` link (removing the RC link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b0ce170e8956634166802ab28ae78b56f8e8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->