### PR TITLE
fix: align rspack v2 peer deps and installer defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Changed `shakapacker:install` to default fresh Rspack installs to v2 (`^2.0.0-0`)**. [PR #1091](https://github.com/shakacode/shakapacker/pull/1091) by [ihabadham](https://github.com/ihabadham). `lib/install/package.json` now declares `@rspack/core` and `@rspack/cli` as `^1.0.0 || ^2.0.0-0`; fresh installs pick the v2 range. Existing apps are unaffected. Note: Rspack v2 requires Node.js 20.19.0+.
+
+### Fixed
+
+- **Widened `@rspack/plugin-react-refresh` peer range to `^1.0.0 || ^2.0.0-0`**. [PR #1091](https://github.com/shakacode/shakapacker/pull/1091) by [ihabadham](https://github.com/ihabadham). Fixes the `ERESOLVE` conflict when installing `@rspack/plugin-react-refresh@^2.0.0` alongside `shakapacker@10.0.0`.
+
 ## [v10.0.0] - April 8, 2026
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 {
   "dependencies": {
     "shakapacker": "^10.0.0",
-    "@rspack/core": "^1.0.0",
-    "@rspack/cli": "^1.0.0",
+    "@rspack/core": "^2.0.0-0",
+    "@rspack/cli": "^2.0.0-0",
     "@swc/core": "^1.3.0",
     "swc-loader": "^0.2.0",
     "rspack-manifest-plugin": "^5.0.0"

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -24,7 +24,7 @@ As of Shakapacker v9 (and continuing in v10), all peer dependencies are marked a
   },
   "peerDependencies": {
     "webpack": "^5.101.0",
-    "@rspack/core": "^1.0.0"
+    "@rspack/core": "^1.0.0 || ^2.0.0-0"
     // ... all build tools
   },
   "peerDependenciesMeta": {
@@ -85,8 +85,8 @@ Type-only imports are erased during compilation and don't trigger module resolut
 {
   "dependencies": {
     "shakapacker": "^10.0.0",
-    "@rspack/core": "^1.0.0",
-    "@rspack/cli": "^1.0.0",
+    "@rspack/core": "^2.0.0-0",
+    "@rspack/cli": "^2.0.0-0",
     "rspack-manifest-plugin": "^5.0.0"
   }
 }

--- a/docs/peer-dependencies.md
+++ b/docs/peer-dependencies.md
@@ -35,7 +35,7 @@ releases support.
 ```text
 "@rspack/cli": "^1.0.0 || ^2.0.0-0"
 "@rspack/core": "^1.0.0 || ^2.0.0-0"
-"@rspack/plugin-react-refresh": "^1.0.0"
+"@rspack/plugin-react-refresh": "^1.0.0 || ^2.0.0-0"
 "rspack-manifest-plugin": "^5.0.0"
 ```
 

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -8,6 +8,8 @@ Shakapacker supports [Rspack](https://rspack.rs) as an alternative assets bundle
 
 Shakapacker supports both Rspack v1 (`^1.0.0`) and Rspack v2 (`^2.0.0-0`). No configuration changes are needed when upgrading between rspack versions — shakapacker's generated config works with both.
 
+Fresh installs default to the latest supported Rspack range from `lib/install/package.json`, which is currently the Rspack v2 prerelease line (`^2.0.0-0`).
+
 **Rspack v2 note:** Rspack v2 ships as a pure ESM package and requires **Node.js 20.19.0+**.
 
 **Rspack v1 note:** Rspack v1 itself supports older Node versions, but Shakapacker requires Node 20+.

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -12,8 +12,6 @@ Shakapacker supports both Rspack v1 (`^1.0.0`) and Rspack v2 (`^2.0.0-0`). No co
 
 **Rspack v1 note:** Rspack v1 itself supports older Node versions, but Shakapacker requires Node 20+.
 
-**React refresh plugin note:** `@rspack/plugin-react-refresh` currently remains on the v1 line in Shakapacker peer deps.
-
 **Current CI coverage note:** Shakapacker currently validates rspack v2 using `2.0.0-rc.0`. The rspack v2 dev dependencies are intentionally pinned while v2 is pre-release and should be revisited when stable `2.0.0` is released.
 
 ### Why upgrade to Rspack v2?

--- a/lib/install/package.json
+++ b/lib/install/package.json
@@ -1,7 +1,7 @@
 {
   "rspack": {
-    "@rspack/cli": "^1.0.0",
-    "@rspack/core": "^1.0.0",
+    "@rspack/cli": "^1.0.0 || ^2.0.0-0",
+    "@rspack/core": "^1.0.0 || ^2.0.0-0",
     "rspack-manifest-plugin": "^5.0.0"
   },
   "webpack": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@babel/runtime": "^7.17.9",
     "@rspack/cli": "^1.0.0 || ^2.0.0-0",
     "@rspack/core": "^1.0.0 || ^2.0.0-0",
-    "@rspack/plugin-react-refresh": "^1.0.0",
+    "@rspack/plugin-react-refresh": "^1.0.0 || ^2.0.0-0",
     "@swc/core": "^1.3.0",
     "@types/babel__core": "^7.0.0",
     "@types/webpack": "^5.0.0",


### PR DESCRIPTION
## Summary

Make Shakapacker's Rspack v2 support self-consistent by:

- widening `@rspack/plugin-react-refresh` peer support to `^1.0.0 || ^2.0.0-0`
- widening `lib/install/package.json` so `shakapacker:install` selects Rspack v2 for `@rspack/core` and `@rspack/cli`
- updating the Rspack docs/examples to match the new default install path

## Why

PR #975 widened the root peer ranges for `@rspack/core` and `@rspack/cli`, but `shakapacker:install` still read `lib/install/package.json` and installed the v1 line:

- `@rspack/core: ^1.0.0`
- `@rspack/cli: ^1.0.0`

At the same time, `@rspack/plugin-react-refresh` stayed pinned to `^1.0.0` in `package.json`.

That left Rspack v2 support in an inconsistent state:

1. fresh installs still started on Rspack v1
2. downstream projects that intentionally upgraded to Rspack v2 could end up in install / reinstall conflicts because Shakapacker still advertised plugin v1-only peer support

This surfaced directly in the downstream React on Rails Rspack v2 work: shakacode/react_on_rails#3084.

## What this changes

- `package.json`
  - `@rspack/plugin-react-refresh`: `^1.0.0` → `^1.0.0 || ^2.0.0-0`
- `lib/install/package.json`
  - `@rspack/core`: `^1.0.0` → `^1.0.0 || ^2.0.0-0`
  - `@rspack/cli`: `^1.0.0` → `^1.0.0 || ^2.0.0-0`
- docs
  - remove the stale plugin-v1 note
  - update peer-deps docs and dependency examples to match the new supported/default path

Because `lib/install/template.rb` already selects `constraints.last`, widening those installer ranges makes fresh Rspack installs choose the v2 prerelease line automatically.

## Verification

I verified this with real fresh Rails apps, not just isolated package-manager commands.

### 1) Shakapacker alone
Using a local path gem plus a locally packed npm tarball from this branch:

- `bundle exec rails shakapacker:install` with `SHAKAPACKER_ASSETS_BUNDLER=rspack` wrote:
  - `@rspack/core: ^2.0.0-0`
  - `@rspack/cli: ^2.0.0-0`
- `npm install --save-dev @rspack/cli@^2.0.0-0 @rspack/plugin-react-refresh@^2.0.0 react-refresh` succeeded
- clean later `npm install` succeeded
- `bundle exec rails shakapacker:compile` succeeded with Rspack `2.0.0-rc.1`

### 2) Full React on Rails install flow
Using this Shakapacker branch plus the downstream React on Rails PR branch locally:

- `bundle exec rails generate react_on_rails:install --rspack --ignore-warnings` succeeded
- resulting app had:
  - `@rspack/core: ^2.0.0-0`
  - `@rspack/cli: ^2.0.0-0`
  - `@rspack/plugin-react-refresh: 2.0.0`
- clean later `npm install` succeeded
- `bundle exec rails shakapacker:compile` succeeded

So this removes the need for downstream generator-time workarounds and gives React on Rails a clean path to ship Rspack v2.

## Pull Request checklist

- [x] Update documentation
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and examples to reference the Rspack v2 prerelease ranges and Shakapacker v10, and removed an outdated note about plugin versioning.

* **Chores**
  * Broadened dependency/peer ranges to support both the stable v1 line and the v2 prerelease line and adjusted install defaults to use the latest supported Rspack range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
