### PR TITLE
docs: update README and guides for Shakapacker v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ You can also change your Babel configuration by removing these lines in your `pa
 
 ### SWC configuration
 
-SWC is the recommended JavaScript transpiler in Shakapacker v10 (20x faster than Babel). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
+SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9; 20x faster than Babel). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
 
 **Note on defaults**: The installation template explicitly sets `javascript_transpiler: "swc"` for new projects. However, for backward compatibility, webpack's runtime default (when no explicit config exists) remains `"babel"`. Rspack always defaults to `"swc"`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Shakapacker (v9)
+# Shakapacker (v10)
 
 ---
 
-_🚀 Shakapacker 9 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
+_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
 
 _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 
@@ -11,7 +11,8 @@ _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 _Official, actively maintained successor to [rails/webpacker](https://github.com/rails/webpacker). ShakaCode stands behind the long-term maintenance and development of this project for the Rails community._
 
 - ⚠️ See the [6-stable](https://github.com/shakacode/shakapacker/tree/6-stable) branch for Shakapacker v6.x code and documentation. :warning:
-- **See [V9 Upgrade](./docs/v9_upgrade.md) for upgrading from the v8 release.**
+- **See the [v10.0.0 release notes](https://github.com/shakacode/shakapacker/releases/tag/v10.0.0) for upgrading from v9 to v10.**
+- **See [V9 Upgrade](./docs/v9_upgrade.md) for upgrading from v8 to v9.**
 - See [V8 Upgrade](./docs/v8_upgrade.md) for upgrading from the v7 release.
 - See [V7 Upgrade](./docs/v7_upgrade.md) for upgrading from the v6 release.
 - See [V6 Upgrade](./docs/v6_upgrade.md) for upgrading from v5 or prior v6 releases.
@@ -238,7 +239,7 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "@babel/core": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
@@ -261,7 +262,7 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "@swc/core": "^1.3.0",
     "swc-loader": "^0.2.0",
     "compression-webpack-plugin": "^9.0.0",
@@ -279,7 +280,7 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "@rspack/core": "^1.0.0",
     "@rspack/cli": "^1.0.0",
     "@swc/core": "^1.3.0",
@@ -923,7 +924,7 @@ You can also change your Babel configuration by removing these lines in your `pa
 
 ### SWC configuration
 
-SWC is the recommended JavaScript transpiler in Shakapacker v9+ (20x faster than Babel). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
+SWC is the recommended JavaScript transpiler in Shakapacker v10 (20x faster than Babel). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
 
 **Note on defaults**: The installation template explicitly sets `javascript_transpiler: "swc"` for new projects. However, for backward compatibility, webpack's runtime default (when no explicit config exists) remains `"babel"`. Rspack always defaults to `"swc"`.
 

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -30,22 +30,22 @@ Shakapacker consists of two components that must be updated together:
 #### 1. Update `Gemfile`
 
 ```ruby
-gem "shakapacker", "9.3.0"  # or the version you want to upgrade to
+gem "shakapacker", "10.0.0"  # or the version you want to upgrade to
 ```
 
-**Pre-release versions:** Ruby gems use dot notation (e.g., `"9.3.0.beta.1"`)
+**Pre-release versions:** Ruby gems use dot notation (e.g., `"10.1.0.beta.1"`)
 
 #### 2. Update `package.json`
 
 ```json
 {
   "dependencies": {
-    "shakapacker": "9.3.0"
+    "shakapacker": "10.0.0"
   }
 }
 ```
 
-**Pre-release versions:** npm uses hyphen notation (e.g., `"9.3.0-beta.1"`)
+**Pre-release versions:** npm uses hyphen notation (e.g., `"10.1.0-beta.1"`)
 
 #### 3. Run bundler and package manager
 
@@ -73,8 +73,8 @@ Note that pre-release versions use different formats:
 
 | Component    | Stable Version | Pre-release Version |
 | ------------ | -------------- | ------------------- |
-| Gemfile      | `"9.3.0"`      | `"9.3.0.beta.1"`    |
-| package.json | `"9.3.0"`      | `"9.3.0-beta.1"`    |
+| Gemfile      | `"10.0.0"`     | `"10.1.0.beta.1"`   |
+| package.json | `"10.0.0"`     | `"10.1.0-beta.1"`   |
 
 ### Finding the Latest Version
 
@@ -86,6 +86,7 @@ Note that pre-release versions use different formats:
 
 For major version upgrades, always consult the version-specific upgrade guides for breaking changes and new features:
 
+- [v10.0.0 Release Notes](https://github.com/shakacode/shakapacker/releases/tag/v10.0.0) - Upgrading from v9 to v10 (includes webpack and dev-server minimum version changes)
 - [V9 Upgrade Guide](./v9_upgrade.md) - Upgrading from v8 to v9 (includes CSS Modules changes, SWC defaults, and more)
 - [V8 Upgrade Guide](./v8_upgrade.md) - Upgrading from v7 to v8
 - [V7 Upgrade Guide](./v7_upgrade.md) - Upgrading from v6 to v7

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -33,7 +33,7 @@ Shakapacker consists of two components that must be updated together:
 gem "shakapacker", "10.0.0"  # or the version you want to upgrade to
 ```
 
-**Pre-release versions:** Ruby gems use dot notation (e.g., `"10.1.0.beta.1"`)
+**Pre-release versions:** Ruby gems use dot notation (e.g., `"10.0.0.beta.1"`)
 
 #### 2. Update `package.json`
 
@@ -45,7 +45,7 @@ gem "shakapacker", "10.0.0"  # or the version you want to upgrade to
 }
 ```
 
-**Pre-release versions:** npm uses hyphen notation (e.g., `"10.1.0-beta.1"`)
+**Pre-release versions:** npm uses hyphen notation (e.g., `"10.0.0-beta.1"`)
 
 #### 3. Run bundler and package manager
 
@@ -73,8 +73,8 @@ Note that pre-release versions use different formats:
 
 | Component    | Stable Version | Pre-release Version |
 | ------------ | -------------- | ------------------- |
-| Gemfile      | `"10.0.0"`     | `"10.1.0.beta.1"`   |
-| package.json | `"10.0.0"`     | `"10.1.0-beta.1"`   |
+| Gemfile      | `"10.0.0"`     | `"10.0.0.beta.1"`   |
+| package.json | `"10.0.0"`     | `"10.0.0-beta.1"`   |
 
 ### Finding the Latest Version
 

--- a/docs/css-modules-export-mode.md
+++ b/docs/css-modules-export-mode.md
@@ -100,9 +100,9 @@ import styles from "./Foo.module.css"
 
 ---
 
-## Migrating from v8 to v10
+## Migrating from v8 to v9+ (Named Exports)
 
-When upgrading to Shakapacker v10, you'll need to update your CSS Module imports from default exports to named exports.
+When upgrading from Shakapacker v8 to v9+ (including v10), you'll need to update your CSS Module imports from default exports to named exports.
 
 ### Migration Options
 
@@ -117,7 +117,7 @@ import styles from "./Component.module.css"
   <button className={styles.button}>Click me</button>
 </div>
 
-// After (v10) - JavaScript
+// After (v9+) - JavaScript
 import { container, button } from "./Component.module.css"
 ;<div className={container}>
   <button className={button}>Click me</button>
@@ -133,7 +133,7 @@ import styles from './Component.module.css';
   <button className={styles.button}>Click me</button>
 </div>
 
-// After (v10) - TypeScript
+// After (v9+) - TypeScript
 import * as styles from './Component.module.css';
 <div className={styles.container}>
   <button className={styles.button}>Click me</button>
@@ -150,7 +150,7 @@ If you prefer to keep the v8 default export behavior during migration, you can o
 
 ## Reverting to Default Exports (v8 Behavior)
 
-To use the v8-style default exports instead of v10's named exports, you have several options:
+To use the v8-style default exports instead of v9+'s named exports, you have several options:
 
 ### Option 1: Configuration File (Easiest - Recommended)
 
@@ -272,7 +272,7 @@ const overrideCssModulesConfig = (config) => {
 
 ## Detailed Migration Guide
 
-### Migrating from v8 (Default Exports) to v10 (Named Exports)
+### Migrating from v8 (Default Exports) to v9+ (Named Exports)
 
 #### 1. Update Import Statements
 
@@ -280,7 +280,7 @@ const overrideCssModulesConfig = (config) => {
 // Old (v8 - default export)
 import styles from "./Component.module.css"
 
-// New (v10 - named exports)
+// New (v9+ - named exports)
 import { bright, container, button } from "./Component.module.css"
 ```
 
@@ -293,7 +293,7 @@ import { bright, container, button } from "./Component.module.css"
   <span className={styles.bright}>Highlighted text</span>
 </div>
 
-// New (v10)
+// New (v9+)
 <div className={container}>
   <button className={button}>Click me</button>
   <span className={bright}>Highlighted text</span>

--- a/docs/css-modules-export-mode.md
+++ b/docs/css-modules-export-mode.md
@@ -347,7 +347,7 @@ import { 'my-button': myButton } from './styles.module.css';
 For large codebases, you can create a codemod to automate the migration:
 
 ```js
-// css-modules-v10-migration.js
+// css-modules-v9-migration.js
 module.exports = function (fileInfo, api) {
   const j = api.jscodeshift
   const root = j(fileInfo.source)
@@ -376,14 +376,14 @@ module.exports = function (fileInfo, api) {
 Run with:
 
 ```bash
-npx jscodeshift -t css-modules-v10-migration.js src/
+npx jscodeshift -t css-modules-v9-migration.js src/
 ```
 
 ---
 
 ## Version Comparison
 
-| Feature             | v8 (and earlier)           | v10                               |
+| Feature             | v8 (and earlier)           | v9+                               |
 | ------------------- | -------------------------- | --------------------------------- |
 | Default behavior    | Default export object      | Named exports                     |
 | Import syntax       | `import styles from '...'` | `import { className } from '...'` |

--- a/docs/css-modules-export-mode.md
+++ b/docs/css-modules-export-mode.md
@@ -1,15 +1,15 @@
 # CSS Modules Export Mode
 
-## Version 9.x (Current Default Behavior)
+## Version 10.x (Current Default Behavior)
 
-Starting with Shakapacker v9, CSS Modules are configured with **named exports** (`namedExport: true`) by default to align with Next.js and modern tooling standards.
+In Shakapacker v10, CSS Modules are configured with **named exports** (`namedExport: true`) by default to align with Next.js and modern tooling standards. This default was introduced in v9.
 
 ### JavaScript Usage
 
 In pure JavaScript projects, you can use true named imports:
 
 ```js
-// v9 - named exports in JavaScript
+// v10 - named exports in JavaScript
 import { bright, container } from "./Foo.module.css"
 ;<button className={bright} />
 ```
@@ -19,14 +19,14 @@ import { bright, container } from "./Foo.module.css"
 TypeScript cannot statically analyze CSS files to determine the exact export names at compile time. When css-loader generates individual named exports dynamically from your CSS classes, TypeScript doesn't know what those exports will be. Therefore, you must use namespace imports:
 
 ```typescript
-// v9 - namespace import required for TypeScript
+// v10 - namespace import required for TypeScript
 import * as styles from './Foo.module.css';
 <button className={styles.bright} />
 ```
 
 **Why namespace imports?** While webpack's css-loader generates true named exports at runtime (with `namedExport: true`), TypeScript's type system cannot determine these dynamic exports during compilation. The namespace import pattern allows TypeScript to treat the import as an object with string keys, bypassing the need for static export validation while still benefiting from the runtime optimizations of named exports.
 
-### Benefits of v9 Configuration
+### Benefits of Current Configuration
 
 - Eliminates certain webpack warnings
 - Provides better tree-shaking potential
@@ -35,7 +35,7 @@ import * as styles from './Foo.module.css';
 
 ### Important: exportLocalsConvention with namedExport
 
-When `namedExport: true` is enabled (v9 default), css-loader requires `exportLocalsConvention` to be either `'camelCaseOnly'` or `'dashesOnly'`.
+When `namedExport: true` is enabled (v10 default), css-loader requires `exportLocalsConvention` to be either `'camelCaseOnly'` or `'dashesOnly'`.
 
 **The following will cause a build error:**
 
@@ -52,7 +52,7 @@ modules: {
 "exportLocalsConvention" with "camelCase" value is incompatible with "namedExport: true" option
 ```
 
-**Correct v9 configuration:**
+**Correct v10 configuration:**
 
 ```js
 modules: {
@@ -65,7 +65,7 @@ modules: {
 
 When `namedExport: true`, you can use:
 
-- `'camelCaseOnly'` (v9 default): Exports ONLY the camelCase version (e.g., only `myButton`)
+- `'camelCaseOnly'` (v10 default): Exports ONLY the camelCase version (e.g., only `myButton`)
 - `'dashesOnly'`: Exports ONLY the original kebab-case version (e.g., only `my-button`)
 
 **Not compatible with namedExport: true:**
@@ -100,9 +100,9 @@ import styles from "./Foo.module.css"
 
 ---
 
-## Migrating from v8 to v9
+## Migrating from v8 to v10
 
-When upgrading to Shakapacker v9, you'll need to update your CSS Module imports from default exports to named exports.
+When upgrading to Shakapacker v10, you'll need to update your CSS Module imports from default exports to named exports.
 
 ### Migration Options
 
@@ -117,7 +117,7 @@ import styles from "./Component.module.css"
   <button className={styles.button}>Click me</button>
 </div>
 
-// After (v9) - JavaScript
+// After (v10) - JavaScript
 import { container, button } from "./Component.module.css"
 ;<div className={container}>
   <button className={button}>Click me</button>
@@ -133,7 +133,7 @@ import styles from './Component.module.css';
   <button className={styles.button}>Click me</button>
 </div>
 
-// After (v9) - TypeScript
+// After (v10) - TypeScript
 import * as styles from './Component.module.css';
 <div className={styles.container}>
   <button className={styles.button}>Click me</button>
@@ -150,7 +150,7 @@ If you prefer to keep the v8 default export behavior during migration, you can o
 
 ## Reverting to Default Exports (v8 Behavior)
 
-To use the v8-style default exports instead of v9's named exports, you have several options:
+To use the v8-style default exports instead of v10's named exports, you have several options:
 
 ### Option 1: Configuration File (Easiest - Recommended)
 
@@ -162,7 +162,7 @@ default: &default
   # ... other settings ...
 
   # CSS Modules export mode
-  # named (default) - Use named exports with camelCase conversion (v9 default)
+  # named (default) - Use named exports with camelCase conversion (v10 default)
   # default - Use default export with both original and camelCase names (v8 behavior)
   css_modules_export_mode: default
 ```
@@ -209,7 +209,7 @@ const overrideCssModulesConfig = (config) => {
     )
 
     if (cssLoaderUse && cssLoaderUse.options && cssLoaderUse.options.modules) {
-      // Override v9 default to use v8-style default exports
+      // Override v10 default to use v8-style default exports
       cssLoaderUse.options.modules.namedExport = false
       cssLoaderUse.options.modules.exportLocalsConvention = "camelCase"
     }
@@ -272,7 +272,7 @@ const overrideCssModulesConfig = (config) => {
 
 ## Detailed Migration Guide
 
-### Migrating from v8 (Default Exports) to v9 (Named Exports)
+### Migrating from v8 (Default Exports) to v10 (Named Exports)
 
 #### 1. Update Import Statements
 
@@ -280,7 +280,7 @@ const overrideCssModulesConfig = (config) => {
 // Old (v8 - default export)
 import styles from "./Component.module.css"
 
-// New (v9 - named exports)
+// New (v10 - named exports)
 import { bright, container, button } from "./Component.module.css"
 ```
 
@@ -293,7 +293,7 @@ import { bright, container, button } from "./Component.module.css"
   <span className={styles.bright}>Highlighted text</span>
 </div>
 
-// New (v9)
+// New (v10)
 <div className={container}>
   <button className={button}>Click me</button>
   <span className={bright}>Highlighted text</span>
@@ -302,7 +302,7 @@ import { bright, container, button } from "./Component.module.css"
 
 #### 3. Handle Kebab-Case Class Names
 
-**Option A: Use camelCase (v9 default)**
+**Option A: Use camelCase (v10 default)**
 
 With `exportLocalsConvention: 'camelCaseOnly'`, kebab-case class names are automatically converted:
 
@@ -313,7 +313,7 @@ With `exportLocalsConvention: 'camelCaseOnly'`, kebab-case class names are autom
 ```
 
 ```js
-// v9 default - camelCase conversion
+// v10 default - camelCase conversion
 import { myButton, primaryColor } from "./styles.module.css"
 ;<button className={myButton} />
 ```
@@ -347,7 +347,7 @@ import { 'my-button': myButton } from './styles.module.css';
 For large codebases, you can create a codemod to automate the migration:
 
 ```js
-// css-modules-v9-migration.js
+// css-modules-v10-migration.js
 module.exports = function (fileInfo, api) {
   const j = api.jscodeshift
   const root = j(fileInfo.source)
@@ -376,14 +376,14 @@ module.exports = function (fileInfo, api) {
 Run with:
 
 ```bash
-npx jscodeshift -t css-modules-v9-migration.js src/
+npx jscodeshift -t css-modules-v10-migration.js src/
 ```
 
 ---
 
 ## Version Comparison
 
-| Feature             | v8 (and earlier)           | v9                                |
+| Feature             | v8 (and earlier)           | v10                               |
 | ------------------- | -------------------------- | --------------------------------- |
 | Default behavior    | Default export object      | Named exports                     |
 | Import syntax       | `import styles from '...'` | `import { className } from '...'` |
@@ -394,7 +394,7 @@ npx jscodeshift -t css-modules-v9-migration.js src/
 
 ---
 
-## Benefits of Named Exports (v9 Default)
+## Benefits of Named Exports (v10 Default)
 
 1. **No Build Warnings**: Eliminates webpack/TypeScript warnings about missing exports
 2. **Better Tree-Shaking**: Unused CSS class exports can be eliminated
@@ -430,7 +430,7 @@ bin/shakapacker-dev-server
 Verify your imports work correctly:
 
 ```js
-// v9 default (named exports)
+// v10 default (named exports)
 import { bright } from "./Foo.module.css"
 console.log(bright) // 'Foo_bright__hash'
 
@@ -481,12 +481,12 @@ If your CSS classes aren't applying after the upgrade:
 
 1. **Check import syntax**: Ensure you're using the correct import style for your configuration
 2. **Verify class names**: Use `console.log` to see available classes
-3. **Check camelCase conversion**: Kebab-case names are converted to camelCase in v9 with `'camelCaseOnly'`
+3. **Check camelCase conversion**: Kebab-case names are converted to camelCase in v10 with `'camelCaseOnly'`
 4. **Rebuild webpack**: Clear cache and rebuild: `rm -rf tmp/cache && bin/shakapacker`
 
 ### TypeScript Support
 
-#### For v9 (Named Exports)
+#### For v10 (Named Exports)
 
 ```typescript
 // src/types/css-modules.d.ts
@@ -518,8 +518,8 @@ The configuration changes should not impact build performance significantly. If 
 
 ## Summary
 
-- **v9 default**: Named exports with camelCase conversion
+- **v10 default**: Named exports with camelCase conversion
 - **v8 default**: Default export object with no conversion
 - **Migration path**: Update imports or override configuration
-- **Benefits of v9**: No warnings, better tree-shaking, explicit dependencies
+- **Benefits of v10**: No warnings, better tree-shaking, explicit dependencies
 - **Keeping v8 behavior**: Override css-loader configuration as shown above

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -94,7 +94,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 
 ## Migration Guide
 
-### From v8 to v9 (and v10)
+### From v8 to v9+
 
 If upgrading from Shakapacker v8:
 

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-As of Shakapacker v10, all peer dependencies are marked as optional via `peerDependenciesMeta`. This design provides maximum flexibility while maintaining clear version constraints.
+As of Shakapacker v9 (and continuing in v10), all peer dependencies are marked as optional via `peerDependenciesMeta`. This design provides maximum flexibility while maintaining clear version constraints.
 
 ## Key Benefits
 
@@ -150,7 +150,7 @@ The test suite includes:
 
 ### Still seeing peer dependency warnings?
 
-1. Ensure you're using Shakapacker v10.0.0 or later
+1. Ensure you're using Shakapacker v9.0.0 or later
 2. Clear your package manager cache:
    - npm: `npm cache clean --force`
    - yarn: `yarn cache clean`

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-As of Shakapacker v9, all peer dependencies are marked as optional via `peerDependenciesMeta`. This design provides maximum flexibility while maintaining clear version constraints.
+As of Shakapacker v10, all peer dependencies are marked as optional via `peerDependenciesMeta`. This design provides maximum flexibility while maintaining clear version constraints.
 
 ## Key Benefits
 
@@ -53,7 +53,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "webpack": "^5.101.0",
     "webpack-cli": "^6.0.0",
     "babel-loader": "^8.2.4",
@@ -68,7 +68,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "webpack": "^5.101.0",
     "webpack-cli": "^6.0.0",
     "@swc/core": "^1.3.0",
@@ -84,7 +84,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 ```json
 {
   "dependencies": {
-    "shakapacker": "^9.0.0",
+    "shakapacker": "^10.0.0",
     "@rspack/core": "^1.0.0",
     "@rspack/cli": "^1.0.0",
     "rspack-manifest-plugin": "^5.0.0"
@@ -94,7 +94,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 
 ## Migration Guide
 
-### From v8 to v9
+### From v8 to v10
 
 If upgrading from Shakapacker v8:
 
@@ -150,7 +150,7 @@ The test suite includes:
 
 ### Still seeing peer dependency warnings?
 
-1. Ensure you're using Shakapacker v9.0.0 or later
+1. Ensure you're using Shakapacker v10.0.0 or later
 2. Clear your package manager cache:
    - npm: `npm cache clean --force`
    - yarn: `yarn cache clean`

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -94,7 +94,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 
 ## Migration Guide
 
-### From v8 to v10
+### From v8 to v9 (and v10)
 
 If upgrading from Shakapacker v8:
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -24,7 +24,7 @@ Install React:
 npm install react react-dom
 ```
 
-Shakapacker v9 defaults to SWC for webpack, and Rspack uses SWC natively, so `.jsx` and `.tsx`
+Shakapacker v10 defaults to SWC for webpack, and Rspack uses SWC natively, so `.jsx` and `.tsx`
 entry points work out of the box. You only need extra JSX transpiler setup if you explicitly use
 `javascript_transpiler: "babel"`.
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -24,7 +24,7 @@ Install React:
 npm install react react-dom
 ```
 
-Shakapacker v10 defaults to SWC for webpack, and Rspack uses SWC natively, so `.jsx` and `.tsx`
+Shakapacker v10 defaults to SWC for webpack (this default was introduced in v9), and Rspack uses SWC natively, so `.jsx` and `.tsx`
 entry points work out of the box. You only need extra JSX transpiler setup if you explicitly use
 `javascript_transpiler: "babel"`.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,7 +39,7 @@ This guide is for Shakapacker maintainers who need to publish a new release.
    - Find merged PRs missing from the changelog
    - Add changelog entries under the appropriate category headings
    - Auto-compute the next version based on changes (breaking → major, features → minor, fixes → patch)
-   - Stamp the version header (e.g., `## [v9.6.0] - March 7, 2026`)
+   - Stamp the version header (e.g., `## [v10.0.0] - April 8, 2026`)
 3. Review the changelog entries and verify the computed version
 4. Commit and push CHANGELOG.md
 
@@ -54,28 +54,28 @@ The simplest way to release is with no arguments — the task reads the version 
 bundle exec rake release
 
 # For a specific version (overrides CHANGELOG.md detection)
-bundle exec rake "release[9.1.0]"
+bundle exec rake "release[10.1.0]"
 
 # For a beta release (note: use period, not dash)
-bundle exec rake "release[9.2.0.beta.1]"  # Creates npm package 9.2.0-beta.1
+bundle exec rake "release[10.2.0.beta.1]"  # Creates npm package 10.2.0-beta.1
 
 # For a release candidate
-bundle exec rake "release[9.6.0.rc.0]"
+bundle exec rake "release[10.6.0.rc.0]"
 
 # Dry run to test without publishing
-bundle exec rake "release[9.1.0,true]"
+bundle exec rake "release[10.1.0,true]"
 
 # Skip interactive confirmations (for scripted maintainer runs)
 AUTO_CONFIRM=true bundle exec rake release
 
 # Override version policy checks (monotonic + changelog/bump consistency)
-RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[9.1.0]"
-bundle exec rake "release[9.1.0,false,true]"
+RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[10.1.0]"
+bundle exec rake "release[10.1.0,false,true]"
 ```
 
 When called with no arguments, `release`:
 
-1. Reads the first versioned header from CHANGELOG.md (e.g., `## [v9.6.0]`)
+1. Reads the first versioned header from CHANGELOG.md (e.g., `## [v10.6.0]`)
 2. Compares it to the current gem version
 3. If the changelog version is newer, prompts for confirmation and uses it
 4. If no new version is found, falls back to a patch bump
@@ -125,27 +125,27 @@ The `release` task automatically:
 
 **Important:** Use Ruby gem version format (no dashes):
 
-- ✅ Correct: `9.1.0`, `9.2.0.beta.1`, `9.0.0.rc.2`
-- ❌ Wrong: `9.1.0-beta.1`, `9.0.0-rc.2`
+- ✅ Correct: `10.1.0`, `10.2.0.beta.1`, `10.0.0.rc.2`
+- ❌ Wrong: `10.1.0-beta.1`, `10.0.0-rc.2`
 
 The task automatically converts Ruby gem format to npm semver format:
 
-- Ruby: `9.2.0.beta.1` → npm: `9.2.0-beta.1`
-- Ruby: `9.0.0.rc.2` → npm: `9.0.0-rc.2`
+- Ruby: `10.2.0.beta.1` → npm: `10.2.0-beta.1`
+- Ruby: `10.0.0.rc.2` → npm: `10.0.0-rc.2`
 
 **CHANGELOG.md headers** use npm semver format (with dashes):
 
-- `## [v9.6.0-rc.1]` — correct (matches git tag format)
-- `## [v9.6.0.rc.1]` — wrong (RubyGems format, will not be found by release tasks)
+- `## [v10.6.0-rc.1]` — correct (matches git tag format)
+- `## [v10.6.0.rc.1]` — wrong (RubyGems format, will not be found by release tasks)
 
 **Examples:**
 
 ```bash
 # Regular release
-bundle exec rake "release[9.1.0]"  # Gem: 9.1.0, npm: 9.1.0
+bundle exec rake "release[10.1.0]"  # Gem: 10.1.0, npm: 10.1.0
 
 # Beta release
-bundle exec rake "release[9.2.0.beta.1]"  # Gem: 9.2.0.beta.1, npm: 9.2.0-beta.1
+bundle exec rake "release[10.2.0.beta.1]"  # Gem: 10.2.0.beta.1, npm: 10.2.0-beta.1
 
 # Release candidate
 bundle exec rake "release[10.0.0.rc.1]"  # Gem: 10.0.0.rc.1, npm: 10.0.0-rc.1
@@ -189,16 +189,16 @@ If you are running non-interactively, set `AUTO_CONFIRM=true` to skip confirmati
 If the automatic GitHub release creation was skipped (e.g., CHANGELOG.md section was missing during release), you can create it manually after updating the changelog:
 
 1. Update `CHANGELOG.md` with the published version section
-   - For prerelease entries, use npm semver header format with dashes, for example `## [v9.6.0-rc.1]`
+   - For prerelease entries, use npm semver header format with dashes, for example `## [v10.6.0-rc.1]`
 2. Commit and push `CHANGELOG.md`
 3. Run:
 
 ```bash
 # Stable
-bundle exec rake "sync_github_release[9.6.0]"
+bundle exec rake "sync_github_release[10.6.0]"
 
 # Prerelease
-bundle exec rake "sync_github_release[9.6.0.rc.1]"
+bundle exec rake "sync_github_release[10.6.0.rc.1]"
 ```
 
 `sync_github_release` reads release notes from the matching `CHANGELOG.md` section and creates/updates the GitHub release for the corresponding tag.
@@ -256,14 +256,14 @@ If you need to release manually (not recommended):
 1. **Bump version:**
 
    ```bash
-   gem bump --version 9.1.0
+   gem bump --version 10.1.0
    bundle install
    ```
 
 2. **Publish to npm:**
 
    ```bash
-   npx --yes release-it 9.1.0 --npm.publish
+   npx --yes release-it 10.1.0 --npm.publish
    ```
 
 3. **Publish to RubyGems:**

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -597,12 +597,12 @@ module.exports = merge({}, baseConfig, commonOptions)
 
 Quick reference for the key differences that cause migration issues:
 
-| Area                       | Webpack                                     | Rspack                              | Migration Action                            |
-| -------------------------- | ------------------------------------------- | ----------------------------------- | ------------------------------------------- |
-| CSS Extraction Loader Path | `mini-css-extract-plugin`                   | `cssExtractLoader.js`               | Filter both paths in SSR config             |
-| React Runtime (SSR)        | Works with both                             | Classic required for React on Rails | Use `runtime: 'classic'`                    |
-| ReScript Extensions        | Auto-resolves `.bs.js`                      | Requires explicit config            | Add to `resolve.extensions`                 |
-| CSS Modules Default        | `namedExport: true` (v10, introduced in v9) | Same                                | Preserve with spread operator in SSR config |
+| Area                       | Webpack                   | Rspack                              | Migration Action                            |
+| -------------------------- | ------------------------- | ----------------------------------- | ------------------------------------------- |
+| CSS Extraction Loader Path | `mini-css-extract-plugin` | `cssExtractLoader.js`               | Filter both paths in SSR config             |
+| React Runtime (SSR)        | Works with both           | Classic required for React on Rails | Use `runtime: 'classic'`                    |
+| ReScript Extensions        | Auto-resolves `.bs.js`    | Requires explicit config            | Add to `resolve.extensions`                 |
+| CSS Modules Default        | `namedExport: true` (v9+) | Same                                | Preserve with spread operator in SSR config |
 
 ## Common Issues and Solutions
 

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -53,7 +53,7 @@ When migrating from webpack to Rspack, follow this testing strategy to minimize 
 ⚠️ **If your application uses SSR**, be aware of these critical issues before migrating:
 
 1. **CSS Extraction Differences**: Rspack uses different loader paths than webpack for CSS extraction
-2. **CSS Modules Breaking Change**: Shakapacker 9 changed from default exports to named exports
+2. **CSS Modules Breaking Change**: Shakapacker changed in v9 (and keeps this in v10) from default exports to named exports
 3. **React Runtime Compatibility**: SWC's automatic runtime may not work with React on Rails SSR detection
 
 **SSR Migration Checklist** (complete before migrating):
@@ -419,7 +419,7 @@ baseConfig.module.rules.forEach((rule) => {
 
 ### Handling Breaking Changes
 
-When upgrading to Shakapacker 9 with Rspack:
+When upgrading to Shakapacker v10 with Rspack (or any v9+ app):
 
 1. **CSS Modules default exports → named exports**: This is a breaking change. Either:
    - Update your code to use named imports (recommended for new projects)
@@ -480,7 +480,7 @@ const customConfig = {
 
 ### 2. CSS Modules Configuration for Server Bundles (CRITICAL for SSR + CSS Modules)
 
-**Problem**: When configuring server bundles, you must preserve Shakapacker 9's CSS Modules settings (`namedExport: true`) while adding SSR-specific settings. Simply setting `exportOnlyLocals: true` will override the base configuration and break CSS imports.
+**Problem**: When configuring server bundles, you must preserve Shakapacker's v9+ CSS Modules settings (`namedExport: true`) while adding SSR-specific settings. Simply setting `exportOnlyLocals: true` will override the base configuration and break CSS imports.
 
 **Symptoms**:
 
@@ -505,7 +505,7 @@ if (cssLoader && cssLoader.options && cssLoader.options.modules) {
 }
 ```
 
-**Why this matters**: Shakapacker 9 changed the default CSS Modules configuration to use named exports. If you only set `exportOnlyLocals: true` without preserving the base config, you'll lose the `namedExport: true` setting, causing import/export mismatches between client and server bundles.
+**Why this matters**: Shakapacker changed the default CSS Modules configuration in v9 to use named exports. If you only set `exportOnlyLocals: true` without preserving the base config, you'll lose the `namedExport: true` setting, causing import/export mismatches between client and server bundles.
 
 **Related configuration**: You must also filter out CSS extraction loaders in server bundles:
 
@@ -597,12 +597,12 @@ module.exports = merge({}, baseConfig, commonOptions)
 
 Quick reference for the key differences that cause migration issues:
 
-| Area                       | Webpack                   | Rspack                              | Migration Action                            |
-| -------------------------- | ------------------------- | ----------------------------------- | ------------------------------------------- |
-| CSS Extraction Loader Path | `mini-css-extract-plugin` | `cssExtractLoader.js`               | Filter both paths in SSR config             |
-| React Runtime (SSR)        | Works with both           | Classic required for React on Rails | Use `runtime: 'classic'`                    |
-| ReScript Extensions        | Auto-resolves `.bs.js`    | Requires explicit config            | Add to `resolve.extensions`                 |
-| CSS Modules Default        | `namedExport: true` (v9+) | Same                                | Preserve with spread operator in SSR config |
+| Area                       | Webpack                                     | Rspack                              | Migration Action                            |
+| -------------------------- | ------------------------------------------- | ----------------------------------- | ------------------------------------------- |
+| CSS Extraction Loader Path | `mini-css-extract-plugin`                   | `cssExtractLoader.js`               | Filter both paths in SSR config             |
+| React Runtime (SSR)        | Works with both                             | Classic required for React on Rails | Use `runtime: 'classic'`                    |
+| ReScript Extensions        | Auto-resolves `.bs.js`                      | Requires explicit config            | Add to `resolve.extensions`                 |
+| CSS Modules Default        | `namedExport: true` (v10, introduced in v9) | Same                                | Preserve with spread operator in SSR config |
 
 ## Common Issues and Solutions
 
@@ -610,7 +610,7 @@ Quick reference for the key differences that cause migration issues:
 
 **Error:** `Cannot read properties of undefined (reading 'className')` in SSR or `export 'default' (imported as 'css') was not found`
 
-**Root Cause:** Shakapacker 9 changed the default CSS Modules configuration to use named exports (`namedExport: true`), which is a breaking change from v8's default export behavior.
+**Root Cause:** Shakapacker changed the default CSS Modules configuration in v9 to use named exports (`namedExport: true`), which is a breaking change from v8's default export behavior.
 
 **Solution:** If you want to keep the v8 default export behavior, override the CSS loader configuration:
 

--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -4,9 +4,9 @@
 
 ## Default Transpilers
 
-Shakapacker v9 transpiler defaults depend on the bundler and installation:
+Shakapacker v10 transpiler defaults depend on the bundler and installation:
 
-- **New installations (v9+)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
+- **New installations (v10)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
 - **Webpack runtime default**: `babel` - Used when no explicit config is provided (maintains backward compatibility)
 - **Rspack runtime default**: `swc` - Rspack defaults to SWC as it's a newer bundler with modern defaults
 
@@ -111,7 +111,7 @@ Typical build time improvements when migrating from Babel to SWC:
 - [ ] Back up your current configuration
 - [ ] Install SWC dependencies
 - [ ] Update `shakapacker.yml`
-- [ ] If using Stimulus, ensure `keepClassNames: true` is set in `config/swc.config.js` (automatically included in v9.1.0+)
+- [ ] If using Stimulus, ensure `keepClassNames: true` is set in `config/swc.config.js` (automatically included in v9.1.0+, including v10)
 - [ ] Test your build locally
 - [ ] Run your test suite
 - [ ] Check browser compatibility
@@ -134,7 +134,7 @@ module.exports = {
 }
 ```
 
-Starting with Shakapacker v9.1.0, running `rake shakapacker:migrate_to_swc` automatically creates a configuration with this setting.
+Starting with Shakapacker v9.1.0 (and continuing in v10), running `rake shakapacker:migrate_to_swc` automatically creates a configuration with this setting.
 
 ### Rollback Plan
 

--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -6,7 +6,7 @@
 
 Shakapacker v10 transpiler defaults depend on the bundler and installation:
 
-- **New installations (v10)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
+- **New installations (v9+)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
 - **Webpack runtime default**: `babel` - Used when no explicit config is provided (maintains backward compatibility)
 - **Rspack runtime default**: `swc` - Rspack defaults to SWC as it's a newer bundler with modern defaults
 

--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -6,7 +6,7 @@
 
 Shakapacker v10 transpiler defaults depend on the bundler and installation:
 
-- **New installations (v9+)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
+- **New installations (v9+, including v10)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
 - **Webpack runtime default**: `babel` - Used when no explicit config is provided (maintains backward compatibility)
 - **Rspack runtime default**: `swc` - Rspack defaults to SWC as it's a newer bundler with modern defaults
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,7 +270,7 @@ gem 'shakapacker', '>= 9.1.1'  # or '~> 10.0' for the latest release
 // package.json
 {
   "dependencies": {
-    "shakapacker": "^9.1.1"
+    "shakapacker": ">=9.1.1" // or "^10.0.0" for the latest release
   }
 }
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -263,14 +263,14 @@ This happens when deploying to a custom Rails environment (like `staging`) that 
 
 ```ruby
 # Gemfile
-gem 'shakapacker', '>= 9.1.1'  # or '~> 10.0' for the latest release
+gem 'shakapacker', '~> 10.0'  # or '>= 9.1.1' if still on the v9 line
 ```
 
-```json
+```jsonc
 // package.json
 {
   "dependencies": {
-    "shakapacker": ">=9.1.1" // or "^10.0.0" for the latest release
+    "shakapacker": "^10.0.0" // or ">=9.1.1" if still on the v9 line
   }
 }
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -263,14 +263,14 @@ This happens when deploying to a custom Rails environment (like `staging`) that 
 
 ```ruby
 # Gemfile
-gem 'shakapacker', '~> 10.0'
+gem 'shakapacker', '>= 9.1.1'  # or '~> 10.0' for the latest release
 ```
 
 ```json
 // package.json
 {
   "dependencies": {
-    "shakapacker": "^10.0.0"
+    "shakapacker": "^9.1.1"
   }
 }
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,18 +259,18 @@ NoMethodError: undefined method 'deep_symbolize_keys' for nil:NilClass
 
 This happens when deploying to a custom Rails environment (like `staging`) that isn't explicitly defined in your `config/shakapacker.yml` file.
 
-**Solution:** This was fixed in Shakapacker v9.1.1+. Upgrade both the gem and npm package to the same version:
+**Solution:** This was fixed in Shakapacker v9.1.1+ and is included in v10. Upgrade both the gem and npm package to the same version:
 
 ```ruby
 # Gemfile
-gem 'shakapacker', '~> 9.1.1'
+gem 'shakapacker', '~> 10.0'
 ```
 
 ```json
 // package.json
 {
   "dependencies": {
-    "shakapacker": "^9.1.1"
+    "shakapacker": "^10.0.0"
   }
 }
 ```

--- a/docs/typescript-migration.md
+++ b/docs/typescript-migration.md
@@ -271,7 +271,7 @@ npm run type-check
 
 ### Issue: "Cannot find module 'shakapacker/types'"
 
-**Solution**: Make sure you're using Shakapacker v9.0.0 or later:
+**Solution**: Make sure you're using Shakapacker v10.0.0 or later:
 
 ```bash
 yarn upgrade shakapacker

--- a/docs/typescript-migration.md
+++ b/docs/typescript-migration.md
@@ -271,7 +271,7 @@ npm run type-check
 
 ### Issue: "Cannot find module 'shakapacker/types'"
 
-**Solution**: Make sure you're using Shakapacker v10.0.0 or later:
+**Solution**: Make sure you're using Shakapacker v9.0.0 or later:
 
 ```bash
 yarn upgrade shakapacker

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,6 +1,6 @@
 # TypeScript Support
 
-Shakapacker v9 includes TypeScript support, providing type safety and better IDE experience for your webpack configurations.
+Shakapacker includes TypeScript support, providing type safety and better IDE experience for your webpack configurations.
 
 ## Quick Start
 

--- a/docs/using_swc_loader.md
+++ b/docs/using_swc_loader.md
@@ -1,6 +1,6 @@
 # Using SWC Loader
 
-SWC is the recommended JavaScript transpiler in Shakapacker v9+, and is set as the default in new installations. If you face any issues, please report them at [Shakapacker Issues](https://github.com/shakacode/shakapacker/issues).
+SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9), and is set as the default in new installations. If you face any issues, please report them at [Shakapacker Issues](https://github.com/shakacode/shakapacker/issues).
 
 ## About SWC
 
@@ -14,7 +14,7 @@ For comparison between SWC and Babel, see the docs at https://swc.rs/docs/migrat
 
 ## Using SWC in your Shakapacker project
 
-For new installations of Shakapacker v9+, SWC is automatically configured in the installation template.
+For new installations of Shakapacker v10, SWC is automatically configured in the installation template.
 
 **Note**: While the installation template sets SWC as the default, webpack's runtime fallback (when no explicit config exists) remains Babel for backward compatibility. Rspack always defaults to SWC.
 

--- a/docs/using_swc_loader.md
+++ b/docs/using_swc_loader.md
@@ -14,7 +14,7 @@ For comparison between SWC and Babel, see the docs at https://swc.rs/docs/migrat
 
 ## Using SWC in your Shakapacker project
 
-For new installations of Shakapacker v10, SWC is automatically configured in the installation template.
+For new installations of Shakapacker v9+, SWC is automatically configured in the installation template.
 
 **Note**: While the installation template sets SWC as the default, webpack's runtime fallback (when no explicit config exists) remains Babel for backward compatibility. Rspack always defaults to SWC.
 


### PR DESCRIPTION
### Summary

- Updates README and docs to reflect Shakapacker v10 as the current release line.
- Refreshes versioned examples (`shakapacker` gem/npm snippets) and upgrade references, including adding a v10 release-notes link.
- Keeps historical v8→v9 guidance intact while removing stale v9-as-current wording.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Other Information

- Validated formatting with `npx prettier --check` on all modified Markdown files (with one auto-format pass on `docs/rspack_migration_guide.md`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that re-label v10 as current and refresh versioned examples/links; no runtime or build logic changes.
> 
> **Overview**
> Updates the docs to position **Shakapacker v10** as the current release, including adding a `v10.0.0` upgrade/release-notes link and revising language that previously treated v9 as “current.”
> 
> Refreshes all versioned snippets (Gemfile/package.json examples, peer-deps examples, release commands, and troubleshooting upgrade guidance) to `10.x`, while clarifying that several defaults/breaking changes (e.g., SWC-by-default in templates, CSS Modules named exports) were introduced in v9 and continue in v10.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24f59e17f291d29ce049c02c40381a0fb627996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides and migration docs to reflect Shakapacker v10 as the current release and default behavior where applicable (SWC default, CSS Modules export mode).
  * Revised upgrade paths and release guidance to reference v10 release notes and version formats.
  * Updated dependency examples and troubleshooting steps to target v10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->