### PR TITLE
docs: add Dependabot configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,12 @@ npm install shakapacker@next
 
 Also, consult the [CHANGELOG](./CHANGELOG.md) for additional upgrade links.
 
+#### Automating Updates with Dependabot
+
+Shakapacker is shipped as both a Ruby gem and an npm package, so they must be
+upgraded together. See [Dependabot configuration for Shakapacker](./docs/dependabot.md)
+for a `.github/dependabot.yml` example that updates both in a single PR.
+
 #### Common Upgrade Scenarios
 
 For step-by-step guides on common migrations, see the [Common Upgrades Guide](./docs/common-upgrades.md):

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -100,7 +100,7 @@ For major version upgrades, always consult the version-specific upgrade guides f
 ## Automating Updates with Dependabot
 
 Because Shakapacker ships as both a Ruby gem and an npm package, both sides must
-be bumped together. Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-groups--)
+be bumped together. Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#multi-ecosystem-groups-)
 can open a single PR that updates both ecosystems at once.
 
 See [Dependabot configuration for Shakapacker](./dependabot.md) for an example

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -7,6 +7,7 @@ This document provides step-by-step instructions for the most common upgrade sce
 ## Table of Contents
 
 - [Upgrading Shakapacker](#upgrading-shakapacker)
+- [Automating Updates with Dependabot](#automating-updates-with-dependabot)
 - [Migrating Package Managers](#migrating-package-managers)
   - [Yarn to npm](#yarn-to-npm)
   - [npm to Yarn](#npm-to-yarn)
@@ -93,6 +94,17 @@ For major version upgrades, always consult the version-specific upgrade guides f
 - [V6 Upgrade Guide](./v6_upgrade.md) - Upgrading from v5 to v6
 
 > **💡 Note:** Major version upgrades may include breaking changes. The steps above cover the basic gem/package updates that apply to all versions, but you should always review the version-specific guide for additional migration steps.
+
+---
+
+## Automating Updates with Dependabot
+
+Because Shakapacker ships as both a Ruby gem and an npm package, both sides must
+be bumped together. Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-groups--)
+can open a single PR that updates both ecosystems at once.
+
+See [Dependabot configuration for Shakapacker](./dependabot.md) for an example
+`.github/dependabot.yml` that keeps the gem and npm package in sync.
 
 ---
 

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -6,8 +6,11 @@ must stay in lockstep (see [Upgrading Shakapacker](./common-upgrades.md#upgradin
 these updates, but by default it opens a separate pull request for each
 ecosystem — which can land the gem and the npm package in different versions.
 
-Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-groups--)
+Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#multi-ecosystem-groups-)
 let you update the bundler and npm sides in a single PR.
+
+> **Note:** Multi-ecosystem groups are a relatively recent Dependabot feature
+> and may not be available on older versions of GitHub Enterprise Server.
 
 ## Example `.github/dependabot.yml`
 
@@ -21,12 +24,12 @@ multi-ecosystem-groups:
 
 updates:
   - package-ecosystem: bundler
-    directory: /
+    directory: "/"
     patterns: ["shakapacker"]
     multi-ecosystem-group: shakapacker
 
   - package-ecosystem: npm
-    directory: /
+    directory: "/"
     patterns: ["shakapacker"]
     multi-ecosystem-group: shakapacker
 

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -56,7 +56,7 @@ required on `updates` entries that are not bound to a multi-ecosystem group
 
 With this configuration, Dependabot will open a single pull request that bumps
 both the `shakapacker` gem and the `shakapacker` npm package together whenever
-a new release is published.
+it detects a new release during its weekly schedule run.
 
 See [this example `dependabot.yml`](https://gist.github.com/sunny/86adfc54c9e5c54b0bc745b46a0827a8#file-dependabot-yml)
 for a fuller configuration that also groups other bundler/npm updates and

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -48,6 +48,12 @@ updates:
   #     interval: weekly
 ```
 
+Note that the bundler and npm `updates` entries bound to the multi-ecosystem
+group above don't declare their own `schedule:` — they inherit the cadence
+from the `multi-ecosystem-groups` definition. A per-entry `schedule:` is only
+required on `updates` entries that are not bound to a multi-ecosystem group
+(like the commented-out skeleton above).
+
 With this configuration, Dependabot will open a single pull request that bumps
 both the `shakapacker` gem and the `shakapacker` npm package together whenever
 a new release is published.

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -33,8 +33,19 @@ updates:
     patterns: ["shakapacker"]
     multi-ecosystem-group: shakapacker
 
-  # Add additional `updates` entries for the rest of your bundler and npm
-  # dependencies as needed.
+  # To keep the rest of your bundler/npm dependencies updated, add separate
+  # `updates` entries without `multi-ecosystem-group` so they get their own
+  # PRs independent of the Shakapacker group. For example:
+  #
+  # - package-ecosystem: bundler
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
+  #
+  # - package-ecosystem: npm
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
 ```
 
 With this configuration, Dependabot will open a single pull request that bumps

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -1,0 +1,44 @@
+# Keeping Shakapacker Updated with Dependabot
+
+Because Shakapacker ships as both a Ruby gem and an npm package, both components
+must stay in lockstep (see [Upgrading Shakapacker](./common-upgrades.md#upgrading-shakapacker)).
+[Dependabot](https://docs.github.com/en/code-security/dependabot) can automate
+these updates, but by default it opens a separate pull request for each
+ecosystem — which can land the gem and the npm package in different versions.
+
+Dependabot's [multi-ecosystem groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-groups--)
+let you update the bundler and npm sides in a single PR.
+
+## Example `.github/dependabot.yml`
+
+```yml
+version: 2
+
+multi-ecosystem-groups:
+  shakapacker:
+    schedule:
+      interval: weekly
+
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    patterns: ["shakapacker"]
+    multi-ecosystem-group: shakapacker
+
+  - package-ecosystem: npm
+    directory: /
+    patterns: ["shakapacker"]
+    multi-ecosystem-group: shakapacker
+
+  # Add additional `updates` entries for the rest of your bundler and npm
+  # dependencies as needed.
+```
+
+With this configuration, Dependabot will open a single pull request that bumps
+both the `shakapacker` gem and the `shakapacker` npm package together whenever
+a new release is published.
+
+See [this example `dependabot.yml`](https://gist.github.com/sunny/86adfc54c9e5c54b0bc745b46a0827a8#file-dependabot-yml)
+for a fuller configuration that also groups other bundler/npm updates and
+applies cooldowns. Thanks to [@sunny](https://github.com/sunny) for sharing this
+pattern in [discussion #1093](https://github.com/shakacode/shakapacker/discussions/1093).


### PR DESCRIPTION
## Summary

- Adds `docs/dependabot.md` documenting a `.github/dependabot.yml` that uses Dependabot's multi-ecosystem groups to keep the `shakapacker` gem and the `shakapacker` npm package bumped together in a single PR.
- Links the new guide from the README's Upgrading section and from `docs/common-upgrades.md`.

Addresses [discussion #1093](https://github.com/shakacode/shakapacker/discussions/1093), where @sunny shared this configuration and Justin committed to getting it into the docs.

## Test plan

- [ ] Verify the new doc renders on GitHub and the links from `README.md` and `docs/common-upgrades.md` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (new guide and cross-links) with no impact on runtime code or release artifacts.
> 
> **Overview**
> Adds a new `docs/dependabot.md` guide showing how to use Dependabot *multi-ecosystem groups* to keep the `shakapacker` gem and npm package updated in lockstep via a single PR.
> 
> Links this guidance from the `README` upgrade section and adds an "Automating Updates with Dependabot" section (plus TOC entry) to `docs/common-upgrades.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713059e8131fb248a90c277d7d0a84923d29717a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Automating Updates with Dependabot" guidance for coordinating synchronized updates of Shakapacker's Ruby gem and npm package in a single pull request.
  * Included an example Dependabot configuration demonstrating multi-ecosystem grouping and notes on compatibility with older GitHub Enterprise versions.
  * Added links to upgrade guidance and a fuller configuration example. Documentation-only change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->