### PR TITLE
Doctor: detect disabled Rspack cache & surface doctor tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Added
 
 - **Added supplemental npm packages `shakapacker-webpack` and `shakapacker-rspack`**. [PR #1096](https://github.com/shakacode/shakapacker/pull/1096) by [justin808](https://github.com/justin808). Optional packages that lockstep with core and bundle the managed-build stack as direct `dependencies` (so a single `yarn add shakapacker-webpack` pulls in `shakapacker`, `webpack`, `webpack-cli`, and `webpack-assets-manifest`; the rspack package bundles `shakapacker`, `@rspack/core`, `@rspack/cli`, and `rspack-manifest-plugin`). Optional features (transpilers, dev-server, CSS preprocessors, react-refresh) remain as opt-in `peerDependencies` so SCSS/native-binding bloat isn't forced on every install. The wrappers emit structured warnings (`SHAKAPACKER_BUNDLER_MISMATCH`, `SHAKAPACKER_NO_TRANSPILER`) when `config.assets_bundler` or `javascript_transpiler` doesn't match the installed peers. See the [v10.1 migration guide](docs/migration/v10.1-supplemental-packages.md) for adoption steps and [`docs/dependency-strategy.md`](docs/dependency-strategy.md) for the design rationale and v11 roadmap.
+- **Added `shakapacker:doctor` check for disabled Rspack cache**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
+- **Added a `shakapacker:doctor` hint to compiler output**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` after a failed compilation, so healthy build loops stay quiet.
 
 ### Migration Notes
 
@@ -26,11 +28,6 @@
 ### ⚠️ Breaking Changes
 
 - **Breaking: tightened `package.json` `engines.node` to `^20.19.0 || >=22.12.0`**. [PR #1099](https://github.com/shakacode/shakapacker/pull/1099) by [justin808](https://github.com/justin808). Raised from `>= 20`, dropping support for Node 20.0.0–20.18.x and Node 21.x to match `@rspack/core@2.0.0-rc.0`. Consumers on those versions will hit an engine error with `--engine-strict` or yarn workspaces and need to upgrade. The PR also bumps `.node-version` to `22.20.0` and updates `conductor-setup.sh` to enforce the same disjoint range up front, so contributors get a clear error before `yarn install` fails with a confusing engine mismatch.
-
-### Added
-
-- **Added `shakapacker:doctor` check for disabled Rspack cache**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
-- **Added a `shakapacker:doctor` hint to compiler output**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` after a failed compilation, so healthy build loops stay quiet.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
 
 - **Breaking: tightened `package.json` `engines.node` to `^20.19.0 || >=22.12.0`**. [PR #1099](https://github.com/shakacode/shakapacker/pull/1099) by [justin808](https://github.com/justin808). Raised from `>= 20`, dropping support for Node 20.0.0–20.18.x and Node 21.x to match `@rspack/core@2.0.0-rc.0`. Consumers on those versions will hit an engine error with `--engine-strict` or yarn workspaces and need to upgrade. The PR also bumps `.node-version` to `22.20.0` and updates `conductor-setup.sh` to enforce the same disjoint range up front, so contributors get a clear error before `yarn install` fails with a confusing engine mismatch.
 
+### Added
+
+- **Added `shakapacker:doctor` check for disabled Rspack cache**. The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
+- **Added a `shakapacker:doctor` hint to compiler output**. The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` when compilation starts in a process, and repeats the tip on compilation failure so users can diagnose configuration issues.
+
 ### Changed
 
 - **Changed `shakapacker:install` to default fresh Rspack installs to v2 (`^2.0.0-0`)**. [PR #1091](https://github.com/shakacode/shakapacker/pull/1091) by [ihabadham](https://github.com/ihabadham). `lib/install/package.json` now declares `@rspack/core` and `@rspack/cli` as `^1.0.0 || ^2.0.0-0`; fresh installs pick the v2 range. Existing apps are unaffected. Note: Rspack v2 requires Node.js 20.19.0+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
 
 ### Added
 
-- **Added `shakapacker:doctor` check for disabled Rspack cache**. The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
-- **Added a `shakapacker:doctor` hint to compiler output**. The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` when compilation starts in a process, and repeats the tip on compilation failure so users can diagnose configuration issues.
+- **Added `shakapacker:doctor` check for disabled Rspack cache**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
+- **Added a `shakapacker:doctor` hint to compiler output**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` when compilation starts in a process.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 ### Added
 
 - **Added `shakapacker:doctor` check for disabled Rspack cache**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The doctor now inspects the Rspack config file for an explicit `cache: false`, warns when found (disabling cache causes significantly slower builds), and also flags Rspack v1 installs (where persistent cache is experimental) with a recommendation to upgrade to v2.
-- **Added a `shakapacker:doctor` hint to compiler output**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` when compilation starts in a process.
+- **Added a `shakapacker:doctor` hint to compiler output**. [PR #1100](https://github.com/shakacode/shakapacker/pull/1100) by [justin808](https://github.com/justin808). The compiler now logs a one-time tip suggesting `bundle exec rake shakapacker:doctor` after a failed compilation, so healthy build loops stay quiet.
 
 ### Changed
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -211,6 +211,10 @@ class Shakapacker::Compiler
       config.root_path.join("bin/shakapacker")
     end
 
+    # Logs the doctor tip once per process. Called from `run_webpack`, which
+    # only runs when `compile` finds the build stale, so users whose bundle is
+    # already up-to-date won't see the tip in that process — by design, since
+    # the hint is most useful when an actual build is happening.
     def show_doctor_hint_once
       return if self.class.doctor_hint_shown
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -221,10 +221,14 @@ class Shakapacker::Compiler
       self.class.doctor_hint_mutex.synchronize do
         return if self.class.doctor_hint_shown
 
-        logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
+        begin
+          logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
+        rescue StandardError
+          # Non-critical tip; never abort a build because the logger failed.
+          return
+        end
+
         self.class.send(:doctor_hint_shown=, true)
-      rescue StandardError
-        # Non-critical tip; never abort a build because the logger failed.
       end
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -220,8 +220,9 @@ class Shakapacker::Compiler
 
         begin
           logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
-        rescue StandardError
+        rescue StandardError => _e
           # Non-critical tip; never abort a build because the logger failed.
+          # Named (but unused) variable makes the deliberate swallow explicit.
           return
         end
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -11,11 +11,10 @@ class Shakapacker::Compiler
 
   # Class-level state keeps the compile-time doctor hint once-per-process.
   @doctor_hint_shown = false
-  @doctor_hint_mutex = Mutex.new
+  DOCTOR_HINT_MUTEX = Mutex.new
 
   class << self
-    attr_reader :doctor_hint_shown, :doctor_hint_mutex
-    attr_writer :doctor_hint_shown
+    attr_accessor :doctor_hint_shown
   end
 
   delegate :config, :logger, :strategy, to: :instance
@@ -216,7 +215,7 @@ class Shakapacker::Compiler
     def show_doctor_hint_once
       return if self.class.doctor_hint_shown
 
-      self.class.doctor_hint_mutex.synchronize do
+      DOCTOR_HINT_MUTEX.synchronize do
         return if self.class.doctor_hint_shown
 
         begin

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -222,8 +222,8 @@ class Shakapacker::Compiler
       self.class.doctor_hint_mutex.synchronize do
         return if self.class.doctor_hint_shown
 
-        self.class.doctor_hint_shown = true
         logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
+        self.class.doctor_hint_shown = true
       end
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -212,10 +212,7 @@ class Shakapacker::Compiler
       config.root_path.join("bin/shakapacker")
     end
 
-    # Logs the doctor tip once per process. Called from `run_webpack`, which
-    # only runs when `compile` finds the build stale, so users whose bundle is
-    # already up-to-date won't see the tip in that process — by design, since
-    # the hint is most useful when an actual build is happening.
+    # Cache hits skip this tip because it is most useful when a build actually runs.
     def show_doctor_hint_once
       return if self.class.doctor_hint_shown
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -10,7 +10,11 @@ class Shakapacker::Compiler
   cattr_accessor(:env) { {} }
 
   # Tracks whether the first-compile doctor tip has been shown in this process.
-  @@doctor_hint_shown = false
+  @doctor_hint_shown = false
+
+  class << self
+    attr_accessor :doctor_hint_shown
+  end
 
   delegate :config, :logger, :strategy, to: :instance
   delegate :fresh?, :stale?, :after_compile_hook, to: :strategy
@@ -207,9 +211,9 @@ class Shakapacker::Compiler
     end
 
     def show_doctor_hint_once
-      return if @@doctor_hint_shown
+      return if self.class.doctor_hint_shown
 
-      @@doctor_hint_shown = true
+      self.class.doctor_hint_shown = true
       logger.info "💡 Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -14,8 +14,10 @@ class Shakapacker::Compiler
   @doctor_hint_mutex = Mutex.new
 
   class << self
-    attr_accessor :doctor_hint_shown
-    attr_reader :doctor_hint_mutex
+    attr_reader :doctor_hint_shown, :doctor_hint_mutex
+    # Internal: tests reset this flag via `send(:doctor_hint_shown=, false)`.
+    attr_writer :doctor_hint_shown
+    private :doctor_hint_shown=
   end
 
   delegate :config, :logger, :strategy, to: :instance
@@ -176,7 +178,6 @@ class Shakapacker::Compiler
 
     def run_webpack
       logger.info "Compiling..."
-      show_doctor_hint_once
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
@@ -194,6 +195,7 @@ class Shakapacker::Compiler
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
         logger.error "\nCOMPILATION FAILED:\nEXIT STATUS: #{status}\nOUTPUTS:\n#{non_empty_streams.join("\n\n")}"
+        show_doctor_hint_once
       end
 
       status.success?
@@ -212,7 +214,7 @@ class Shakapacker::Compiler
       config.root_path.join("bin/shakapacker")
     end
 
-    # Cache hits skip this tip because it is most useful when a build actually runs.
+    # Fires only after a failed compile, so users in a healthy loop never see the tip.
     def show_doctor_hint_once
       return if self.class.doctor_hint_shown
 
@@ -220,7 +222,9 @@ class Shakapacker::Compiler
         return if self.class.doctor_hint_shown
 
         logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
-        self.class.doctor_hint_shown = true
+        self.class.send(:doctor_hint_shown=, true)
+      rescue StandardError
+        # Non-critical tip; never abort a build because the logger failed.
       end
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -9,6 +9,9 @@ class Shakapacker::Compiler
   # Shakapacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
   cattr_accessor(:env) { {} }
 
+  # Tracks whether the first-compile doctor tip has been shown in this process.
+  @@doctor_hint_shown = false
+
   delegate :config, :logger, :strategy, to: :instance
   delegate :fresh?, :stale?, :after_compile_hook, to: :strategy
 
@@ -167,6 +170,7 @@ class Shakapacker::Compiler
 
     def run_webpack
       logger.info "Compiling..."
+      show_doctor_hint_once
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
@@ -200,5 +204,12 @@ class Shakapacker::Compiler
 
     def bin_shakapacker_path
       config.root_path.join("bin/shakapacker")
+    end
+
+    def show_doctor_hint_once
+      return if @@doctor_hint_shown
+
+      @@doctor_hint_shown = true
+      logger.info "💡 Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -11,9 +11,11 @@ class Shakapacker::Compiler
 
   # Tracks whether the first-compile doctor tip has been shown in this process.
   @doctor_hint_shown = false
+  @doctor_hint_mutex = Mutex.new
 
   class << self
     attr_accessor :doctor_hint_shown
+    attr_reader :doctor_hint_mutex
   end
 
   delegate :config, :logger, :strategy, to: :instance
@@ -213,7 +215,11 @@ class Shakapacker::Compiler
     def show_doctor_hint_once
       return if self.class.doctor_hint_shown
 
-      self.class.doctor_hint_shown = true
-      logger.info "💡 Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
+      self.class.doctor_hint_mutex.synchronize do
+        return if self.class.doctor_hint_shown
+
+        self.class.doctor_hint_shown = true
+        logger.info "Tip: run 'bundle exec rake shakapacker:doctor' to diagnose configuration issues."
+      end
     end
 end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -9,6 +9,7 @@ class Shakapacker::Compiler
   # Shakapacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
   cattr_accessor(:env) { {} }
 
+  # Class-level state keeps the compile-time doctor hint once-per-process.
   @doctor_hint_shown = false
   @doctor_hint_mutex = Mutex.new
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -9,7 +9,6 @@ class Shakapacker::Compiler
   # Shakapacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
   cattr_accessor(:env) { {} }
 
-  # Tracks whether the first-compile doctor tip has been shown in this process.
   @doctor_hint_shown = false
   @doctor_hint_mutex = Mutex.new
 

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -225,6 +225,7 @@ class Shakapacker::Compiler
           return
         end
 
+        # Assignment is outside the rescue so a flag-setter failure propagates rather than being silenced.
         self.class.doctor_hint_shown = true
       end
     end

--- a/lib/shakapacker/compiler.rb
+++ b/lib/shakapacker/compiler.rb
@@ -15,9 +15,7 @@ class Shakapacker::Compiler
 
   class << self
     attr_reader :doctor_hint_shown, :doctor_hint_mutex
-    # Internal: tests reset this flag via `send(:doctor_hint_shown=, false)`.
     attr_writer :doctor_hint_shown
-    private :doctor_hint_shown=
   end
 
   delegate :config, :logger, :strategy, to: :instance
@@ -228,7 +226,7 @@ class Shakapacker::Compiler
           return
         end
 
-        self.class.send(:doctor_hint_shown=, true)
+        self.class.doctor_hint_shown = true
       end
     end
 end

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -60,9 +60,9 @@ module Shakapacker
         add_warning(message, CATEGORY_INFO)
       end
 
-      # "Fix: ..." hints render as indented sub-items under the preceding warning.
+      # Marks the warning as a Fix sub-item; the renderer owns the "Fix: " prefix and indentation.
       def add_fix_hint(message, category = CATEGORY_RECOMMENDED)
-        add_warning("  Fix: #{message}", category)
+        @warnings << { category: category, message: message, fix: true }
       end
 
       def print_help
@@ -206,7 +206,7 @@ module Shakapacker
         # Match "bundler:" at start of line or preceded by non-underscore character
         if config_file.match?(/^\s*bundler:/m) || config_file.match?(/[^_]bundler:/)
           add_action_required("Deprecated config: 'bundler' should be renamed to 'assets_bundler' in #{config_relative_path}.")
-          add_action_required("  Fix: Open #{config_relative_path} and change 'bundler:' to 'assets_bundler:'.")
+          add_fix_hint("Open #{config_relative_path} and change 'bundler:' to 'assets_bundler:'.", CATEGORY_ACTION_REQUIRED)
         end
       rescue => e
         # Ignore read errors as config file check already handles missing file
@@ -413,7 +413,7 @@ module Shakapacker
 
         unless missing_binstubs.empty?
           add_action_required("Missing binstubs: #{missing_binstubs.join(', ')}.")
-          add_action_required("  Fix: Run 'bundle exec rake shakapacker:binstubs' to create them.")
+          add_fix_hint("Run 'bundle exec rake shakapacker:binstubs' to create them.", CATEGORY_ACTION_REQUIRED)
         end
       end
 
@@ -762,7 +762,10 @@ module Shakapacker
       def stripped_rspack_config_content(content)
         # Normalize quoted property keys before stripping string literals; otherwise
         # `'cache'` and `"cache"` collapse to `""` and the match below misses them.
-        stripped = content.gsub(/(['"])(\w+)\1(?=\s*:)/, '\2')
+        # Lookahead is restricted to horizontal whitespace so a multiline ternary
+        # like `condition ? "cache"\n  : false` doesn't fold across the newline
+        # and produce a spurious cache: false match.
+        stripped = content.gsub(/(['"])(\w+)\1(?=[ \t]*:)/, '\2')
 
         stripped = stripped
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
@@ -773,7 +776,9 @@ module Shakapacker
 
         # Regex literal stripping runs after comment removal. The line-comment
         # pass above ignores escaped slashes so /https?:\/\/host/ stays intact
-        # until this pass removes the whole regex literal.
+        # until this pass removes the whole regex literal. The heuristic can
+        # false-match bare division like `a / b / c`, but rspack config files
+        # rarely contain arithmetic near `cache:`, so the risk is low.
         stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
       end
 
@@ -786,10 +791,16 @@ module Shakapacker
           next false unless (pre.count("{") - pre.count("}")) == 1
 
           statement_prefix = pre[(pre.rindex(";") || -1) + 1..]
+          # generateRspackConfig is Shakapacker's own helper; user-defined wrappers
+          # like makeRspackConfig/createConfig are a known false-negative gap.
           statement_prefix.match?(/\bmodule\.exports\b|\bexport\s+default\b|\bgenerateRspackConfig\b/)
         end
       end
 
+      # Catches the `const cfg = { cache: false }; module.exports = cfg` pattern.
+      # Composition via merge (`module.exports = merge(cfg, …)`) is a known
+      # false-negative since the variable is never referenced by name in the
+      # export statement.
       def exported_variable_cache_disabled?(stripped)
         variable_declaration = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:\s*[^=;]+)?\s*=\s*\{/
 
@@ -1264,15 +1275,14 @@ module Shakapacker
           end
 
           def print_warnings
-            # Count only main items (not sub-items)
-            main_item_count = doctor.warnings.count { |w| !w[:message].start_with?("  ") }
+            main_item_count = doctor.warnings.count { |w| !subitem?(w) }
             puts "⚠️  Warnings (#{main_item_count}):"
             puts ""
 
             item_number = 0
             doctor.warnings.each do |warning|
-              if subitem?(warning[:message])
-                print_subitem(warning[:message])
+              if subitem?(warning)
+                print_subitem(warning)
               else
                 item_number += 1
                 print_main_item(item_number, warning)
@@ -1281,15 +1291,16 @@ module Shakapacker
             puts ""
           end
 
-          def subitem?(message)
-            message.start_with?("  ")
+          def subitem?(warning)
+            warning[:fix] || warning[:message].start_with?("  ")
           end
 
-          def print_subitem(message)
+          def print_subitem(warning)
             # Fix instructions align at column 16 (length of "N. [RECOMMENDED]  ")
-            # This ensures all Fix lines align vertically regardless of category
+            # This keeps every Fix line aligned regardless of category.
             subitem_prefix = " " * 15
-            wrapped = wrap_text(message, 100, subitem_prefix)
+            text = warning[:fix] ? "Fix: #{warning[:message]}" : warning[:message]
+            wrapped = wrap_text(text, 100, subitem_prefix)
             puts wrapped
           end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -740,14 +740,18 @@ module Shakapacker
         # the disabled cache.
         stripped = content.gsub(/(['"])(\w+)\1(?=\s*:)/, '\2')
 
-        # Strip string literals and comments so examples inside strings or comments
-        # don't trigger a false positive. Single/double-quoted JS strings cannot span
-        # newlines, so the exclusion class includes \n to prevent a runaway match when
-        # an unmatched quote appears in a comment (e.g. `// don't disable cache`).
+        # Strip string literals, regex literals, and comments so examples inside
+        # them don't trigger a false positive. Single/double-quoted JS strings cannot
+        # span newlines, so the exclusion class includes \n to prevent a runaway
+        # match when an unmatched quote appears in a comment (e.g. `// don't disable
+        # cache`). Regex literals are stripped before block comments so that `/* */`
+        # inside a regex isn't misread as a comment delimiter; the non-greedy body
+        # avoids spanning multiple slashes (e.g. division operators) on the same line.
         stripped = stripped
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
           .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
           .gsub(/"(?:\\.|[^"\\\n])*"/, '""')
+          .gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
           .gsub(%r{/\*.*?\*/}m, "")
           .gsub(%r{//[^\n]*}, "")
 
@@ -786,12 +790,14 @@ module Shakapacker
 
         # Only trust specifiers starting with a digit or ^/~ prefix followed by a digit.
         # Skip git+, file:, npm: aliases, "latest", "*", or ranges like ">=1.5 <2".
+        # Accept shorthand forms (e.g. `^1`, `~1`, `1`, `1.x`) so we still emit the
+        # v1 advisory when node_modules isn't populated yet.
         cleaned = version.strip
         return nil unless cleaned.match?(/\A[\^~]?\d/)
         return nil if cleaned.match?(/(\s|\|\||[<>=:]|\A(?:git|file|link|workspace|npm):)/)
-        return nil unless cleaned.match?(/\A[\^~]?\d+(?:\.\d+){1,2}(?:-[0-9A-Za-z.-]+)?\z/)
+        return nil unless cleaned.match?(/\A[\^~]?\d+(?:\.(?:\d+|x|\*)){0,2}(?:-[0-9A-Za-z.-]+)?\z/i)
 
-        match = cleaned.sub(/\A[\^~]/, "").match(/\A(\d+)\./)
+        match = cleaned.sub(/\A[\^~]/, "").match(/\A(\d+)/)
         match && match[1].to_i
       end
 
@@ -810,7 +816,9 @@ module Shakapacker
         return nil unless package_json_exists?
 
         pkg = read_package_json
-        deps = (pkg["dependencies"] || {}).merge(pkg["devDependencies"] || {})
+        # Production dependencies take precedence on key conflict so the version
+        # actually shipped in production wins over a devDependencies override.
+        deps = (pkg["devDependencies"] || {}).merge(pkg["dependencies"] || {})
         deps[name]
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -874,6 +874,16 @@ module Shakapacker
         # Match `cache: false` only near an exported config object at brace depth
         # 1. This avoids warning on local base config objects while still
         # catching the common direct export and generateRspackConfig patterns.
+        #
+        # Known false-positive gaps (rare; the "appears to be disabled" wording
+        # is the user-visible mitigation):
+        #   * Named intermediate export — `export const helper = { cache: false }`
+        #     at depth 1 is flagged even when `helper` is not the final config and
+        #     a separate `export default { … }` provides the real configuration.
+        #   * ASI + prior `module.exports` — in semicolon-free code, an earlier
+        #     `module.exports = merge(…)` followed by a local helper literal can
+        #     leak into `statement_prefix` because `pre.rindex(";")` returns nil
+        #     and the prefix spans back to the start of the file.
         stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
           pre = Regexp.last_match.pre_match
           next false unless (pre.count("{") - pre.count("}")) == 1
@@ -915,7 +925,8 @@ module Shakapacker
       def exported_config_variable?(stripped, name)
         escaped_name = Regexp.escape(name)
         stripped.match?(/\bmodule\.exports\s*=\s*#{escaped_name}\b/) ||
-          stripped.match?(/\bexport\s+default\s+#{escaped_name}\b/)
+          stripped.match?(/\bexport\s+default\s+#{escaped_name}\b/) ||
+          stripped.match?(/\bexport\s*\{[^}]*\b#{escaped_name}\s+as\s+default\b/)
       end
 
       def matching_closing_brace(content, open_index)

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -61,8 +61,8 @@ module Shakapacker
       end
 
       # Marks the warning as a Fix sub-item; the renderer owns the "Fix: " prefix and indentation.
-      def add_fix_hint(message, category = CATEGORY_RECOMMENDED)
-        @warnings << { category: category, message: message, fix: true }
+      def add_fix_hint(message)
+        @warnings << { category: CATEGORY_RECOMMENDED, message: message, fix: true }
       end
 
       def print_help
@@ -206,7 +206,7 @@ module Shakapacker
         # Match "bundler:" at start of line or preceded by non-underscore character
         if config_file.match?(/^\s*bundler:/m) || config_file.match?(/[^_]bundler:/)
           add_action_required("Deprecated config: 'bundler' should be renamed to 'assets_bundler' in #{config_relative_path}.")
-          add_fix_hint("Open #{config_relative_path} and change 'bundler:' to 'assets_bundler:'.", CATEGORY_ACTION_REQUIRED)
+          add_fix_hint("Open #{config_relative_path} and change 'bundler:' to 'assets_bundler:'.")
         end
       rescue => e
         # Ignore read errors as config file check already handles missing file
@@ -413,7 +413,7 @@ module Shakapacker
 
         unless missing_binstubs.empty?
           add_action_required("Missing binstubs: #{missing_binstubs.join(', ')}.")
-          add_fix_hint("Run 'bundle exec rake shakapacker:binstubs' to create them.", CATEGORY_ACTION_REQUIRED)
+          add_fix_hint("Run 'bundle exec rake shakapacker:binstubs' to create them.")
         end
       end
 
@@ -738,7 +738,7 @@ module Shakapacker
       end
 
       def default_rspack_config_dir?(config_dir)
-        Pathname.new(config_dir).cleanpath.to_s == "config/rspack"
+        config_dir == "config/rspack"
       end
 
       def config_path_for_warning(path)
@@ -793,7 +793,7 @@ module Shakapacker
           statement_prefix = pre[(pre.rindex(";") || -1) + 1..]
           # generateRspackConfig is Shakapacker's own helper; user-defined wrappers
           # like makeRspackConfig/createConfig are a known false-negative gap.
-          statement_prefix.match?(/\bmodule\.exports\b|\bexport\s+default\b|\bgenerateRspackConfig\b/)
+          statement_prefix.match?(/\bmodule\.exports\b|\bexport\s+default\b|\bexport\s+(?:const|let|var)\b|\bgenerateRspackConfig\b/)
         end
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -869,7 +869,7 @@ module Shakapacker
         version = JSON.parse(File.read(rspack_pkg))["version"]
         match = version.to_s.match(/\A(\d+)\./)
         match && match[1].to_i
-      rescue JSON::ParserError, Errno::ENOENT
+      rescue JSON::ParserError, SystemCallError
         nil
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -488,7 +488,7 @@ module Shakapacker
                         else "npm uninstall swc-loader"
             end
             add_warning("swc-loader is not needed with Rspack (SWC is built-in). Rspack includes SWC transpilation natively, so this package is redundant.")
-            add_warning("  Fix: Remove it with: #{remove_cmd}.")
+            add_fix_hint("Remove it with: #{remove_cmd}.")
           end
         end
       end
@@ -528,7 +528,7 @@ module Shakapacker
           babel_files << "package.json" if babel_in_package_json
           babel_files_str = babel_files.join(", ")
           add_warning("Babel configuration files found (#{babel_files_str}) but javascript_transpiler is '#{transpiler}'. These Babel configs are ignored by Shakapacker (though they may still be used by ESLint or other tools).")
-          add_warning("  Fix: Remove Babel config files if not needed, or set javascript_transpiler: 'babel' in shakapacker.yml to use Babel for transpilation.")
+          add_fix_hint("Remove Babel config files if not needed, or set javascript_transpiler: 'babel' in shakapacker.yml to use Babel for transpilation.")
         end
 
         # Check for redundant dependencies
@@ -733,20 +733,10 @@ module Shakapacker
       end
 
       def rspack_cache_disabled?(content)
-        # Preserve quoted property keys (`'cache': false` / `"cache": false`) by
-        # replacing them with the bare identifier form before stripping general
-        # string literals. Without this step the surrounding string-strip would
-        # collapse `'cache'` and `"cache"` to `""` and the regex below would miss
-        # the disabled cache.
+        # Normalize quoted property keys before stripping string literals; otherwise
+        # `'cache'` and `"cache"` collapse to `""` and the match below misses them.
         stripped = content.gsub(/(['"])(\w+)\1(?=\s*:)/, '\2')
 
-        # Strip string literals, regex literals, and comments so examples inside
-        # them don't trigger a false positive. Single/double-quoted JS strings cannot
-        # span newlines, so the exclusion class includes \n to prevent a runaway
-        # match when an unmatched quote appears in a comment (e.g. `// don't disable
-        # cache`). Regex literals are stripped before block comments so that `/* */`
-        # inside a regex isn't misread as a comment delimiter; the non-greedy body
-        # avoids spanning multiple slashes (e.g. division operators) on the same line.
         stripped = stripped
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
           .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
@@ -755,23 +745,11 @@ module Shakapacker
           .gsub(%r{/\*.*?\*/}m, "")
           .gsub(%r{//[^\n]*}, "")
 
-        # Only match `cache: false` at brace depth 1 (the top level of the exported
-        # config object). This avoids false positives from nested loader options like
-        # `{ loader: 'babel-loader', options: { cache: false } }`.
-        #
-        # The heuristic also flags depth-1 objects that aren't the literal
-        # `module.exports = { ... }` object — e.g. an intermediate variable or a
-        # function-argument object:
-        #   const opts = { cache: false };
-        #   module.exports = merge(base, opts);
-        #
-        #   module.exports = merge(base, { cache: false });
-        # In typical use these still disable the build's cache (so the warning is
-        # appropriate), but if `opts` is unused or the merge function ignores
-        # `cache`, the warning could fire when caching is not actually disabled.
-        # The "appears to be disabled" wording is the mitigation. Distinguishing
-        # these cases would require a real JS parser; the conservative depth-1
-        # heuristic is intentional.
+        # Match `cache: false` only at brace depth 1. This is intentionally
+        # conservative: a real JS parser would be needed to distinguish the
+        # exported config object from an intermediate variable or merge argument,
+        # so the warning is phrased as "appears to be disabled" to mitigate the
+        # rare false positive.
         stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
           pre = Regexp.last_match.pre_match
           (pre.count("{") - pre.count("}")) == 1

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -693,44 +693,57 @@ module Shakapacker
           add_warning("  Fix: Bump @rspack/core and @rspack/cli to ^2.0.0-0 in package.json. See https://rspack.rs/config/cache and docs/rspack.md for details.")
         end
 
-        rspack_config_paths.each do |path|
-          content = File.read(path)
-          relative = path.relative_path_from(root_path)
-          next unless rspack_cache_disabled?(content)
+        path = active_assets_bundler_config_path
+        return unless path
 
-          add_warning("Rspack cache appears to be disabled in #{relative} (found 'cache: false'). Disabling cache " \
-                      "causes significantly slower builds, especially on rebuilds. Rspack v2 promotes filesystem " \
-                      "caching from experimental to stable.")
-          add_warning("  Fix: Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
-                      "See https://rspack.rs/config/cache for options.")
-        end
+        content = File.read(path)
+        return unless rspack_cache_disabled?(content)
+
+        relative = path.relative_path_from(root_path)
+        add_warning("Rspack cache appears to be disabled in #{relative} (found 'cache: false'). Disabling cache " \
+                    "causes significantly slower builds, especially on rebuilds. Rspack v2 promotes filesystem " \
+                    "caching from experimental to stable.")
+        add_warning("  Fix: Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
+                    "See https://rspack.rs/config/cache for options.")
       rescue Errno::ENOENT => e
         add_warning("Unable to validate rspack cache configuration: #{e.message}")
       end
 
-      def rspack_config_paths
+      # Returns the single active config path the runner would load, or nil. Mirrors the
+      # resolution order in Shakapacker::Runner#find_rspack_config_with_fallback so the
+      # doctor inspects the same file the build will actually use (and so unused sibling
+      # configs in the same directory don't trigger spurious warnings).
+      def active_assets_bundler_config_path
         config_dir = config.assets_bundler_config_path
-        %w[js ts mjs cjs].filter_map do |ext|
-          path = root_path.join(config_dir, "rspack.config.#{ext}")
-          path if path.exist?
+
+        candidates = %w[ts js mjs cjs].map { |ext| root_path.join(config_dir, "rspack.config.#{ext}") }
+        candidates += %w[ts js].map { |ext| root_path.join(config_dir, "webpack.config.#{ext}") }
+        if config_dir == "config/rspack"
+          candidates += %w[ts js].map { |ext| root_path.join("config/webpack", "webpack.config.#{ext}") }
         end
+
+        candidates.find(&:exist?)
       end
 
       def rspack_cache_disabled?(content)
-        # Strip block comments, line comments, and string literals (single/double quoted
-        # and backtick template literals) so examples inside strings or comments don't
-        # trigger a false positive.
+        # Strip string literals and comments so examples inside strings or comments
+        # don't trigger a false positive. Single/double-quoted JS strings cannot span
+        # newlines, so the exclusion class includes \n to prevent a runaway match when
+        # an unmatched quote appears in a comment (e.g. `// don't disable cache`).
         stripped = content
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
-          .gsub(/'(?:\\.|[^'\\])*'/, '""')
-          .gsub(/"(?:\\.|[^"\\])*"/, '""')
+          .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
+          .gsub(/"(?:\\.|[^"\\\n])*"/, '""')
           .gsub(%r{/\*.*?\*/}m, "")
           .gsub(%r{//[^\n]*}, "")
 
-        # Match `cache: false` at a position that looks like a top-level or object property
-        # key: preceded by `{`, `,`, or a newline. This avoids false positives like
-        # `cacheDirectory: false` in loader options.
-        stripped.match?(/(?:\{|,|\n)\s*cache\s*:\s*false\b/m)
+        # Only match `cache: false` at brace depth 1 (the top level of the exported
+        # config object). This avoids false positives from nested loader options like
+        # `{ loader: 'babel-loader', options: { cache: false } }`.
+        stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
+          pre = Regexp.last_match.pre_match
+          (pre.count("{") - pre.count("}")) == 1
+        end
       end
 
       def rspack_major_version

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -758,10 +758,11 @@ module Shakapacker
           .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
           .gsub(/"(?:\\.|[^"\\\n])*"/, '""')
           .gsub(%r{/\*.*?\*/}m, "")
-          .gsub(%r{//[^\n]*}, "")
+          .gsub(%r{(?<!\\)//[^\n]*}, "")
 
-        # Regex literal stripping is order-sensitive: strings and comments must
-        # be removed first so their slash characters cannot expose cache hints.
+        # Regex literal stripping runs after comment removal. The line-comment
+        # pass above ignores escaped slashes so /https?:\/\/host/ stays intact
+        # until this pass removes the whole regex literal.
         stripped = stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
 
         # Match `cache: false` only near an exported config object at brace depth
@@ -782,14 +783,21 @@ module Shakapacker
         resolved = installed_rspack_major_version
         return resolved unless resolved.nil?
 
-        version = package_json_dependency_version("@rspack/core") ||
-                  package_json_dependency_version("@rspack/cli")
+        %w[@rspack/core @rspack/cli].each do |package_name|
+          major = rspack_major_from_specifier(package_json_dependency_version(package_name))
+          return major unless major.nil?
+        end
+
+        nil
+      end
+
+      def rspack_major_from_specifier(version)
         return nil unless version
 
-        # Only trust specifiers starting with a digit or ^/~ prefix followed by a digit.
-        # Skip git+, file:, npm: aliases, "latest", "*", or ranges like ">=1.5 <2".
-        # Accept shorthand forms (e.g. `^1`, `~1`, `1`, `1.x`) so we still emit the
-        # v1 advisory when node_modules isn't populated yet.
+        # Only trust specifiers starting with a digit or ^/~ prefix followed by
+        # a digit. Skip git+, file:, npm: aliases, "latest", "*", or ranges like
+        # ">=1.5 <2". Accept shorthand forms (e.g. `^1`, `~1`, `1`, `1.x`) so
+        # we still emit the v1 advisory when node_modules isn't populated yet.
         cleaned = version.strip
         return nil unless cleaned.match?(/\A[\^~]?\d/)
         return nil if cleaned.match?(/(\s|\|\||[<>=:]|\A(?:git|file|link|workspace|npm):)/)

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -733,7 +733,7 @@ module Shakapacker
       def read_active_assets_bundler_config(path)
         File.read(path)
       rescue SystemCallError => e
-        add_warning("Unable to validate rspack cache configuration: #{e.message}")
+        add_info_warning("Unable to validate rspack cache configuration: #{e.message}")
         nil
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -683,7 +683,7 @@ module Shakapacker
       end
 
       def check_rspack_cache_configuration
-        return unless config.assets_bundler == "rspack"
+        return unless config.rspack?
 
         rspack_major = rspack_major_version
 
@@ -747,6 +747,18 @@ module Shakapacker
         # Only match `cache: false` at brace depth 1 (the top level of the exported
         # config object). This avoids false positives from nested loader options like
         # `{ loader: 'babel-loader', options: { cache: false } }`.
+        #
+        # Known false-positive patterns that this heuristic does not filter (the
+        # "appears to be disabled" wording in the warning is the mitigation):
+        #   - Intermediate variable assignment, where the depth-1 object is not
+        #     the exported config:
+        #       const opts = { cache: false };
+        #       module.exports = merge(base, opts);
+        #   - Function-argument objects whose `{` is at depth 1 in the pre-match,
+        #     because parentheses are not counted:
+        #       module.exports = merge(base, { cache: false });
+        # Restricting the scan to the exported object would require a real JS
+        # parser; the conservative depth-1 heuristic is intentional.
         stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
           pre = Regexp.last_match.pre_match
           (pre.count("{") - pre.count("}")) == 1

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -61,8 +61,13 @@ module Shakapacker
       end
 
       # Marks the warning as a Fix sub-item; the renderer owns the "Fix: " prefix and indentation.
+      # The stored category mirrors the parent warning so a fix attached to an action-required
+      # item is itself action-required (it's only rendered alongside its parent, but the data
+      # stays consistent for any downstream consumer).
       def add_fix_hint(message)
-        @warnings << { category: CATEGORY_RECOMMENDED, message: message, fix: true }
+        parent = @warnings.reverse_each.find { |w| !w[:fix] }
+        category = parent ? parent[:category] : CATEGORY_RECOMMENDED
+        @warnings << { category: category, message: message, fix: true }
       end
 
       def print_help
@@ -795,7 +800,7 @@ module Shakapacker
               stripped << content[index..].gsub(/[^\n]/, " ")
               break
             end
-          elsif pair == "//" && (index.zero? || content[index - 1] != "\\")
+          elsif pair == "//"
             line_end = content.index("\n", index + 2) || content.length
             stripped << content[index...line_end].gsub(/[^\n]/, " ")
             index = line_end

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -60,6 +60,13 @@ module Shakapacker
         add_warning(message, CATEGORY_INFO)
       end
 
+      # Records a "Fix: ..." hint as an indented sub-item attached to the
+      # preceding warning. The doctor's printer treats messages starting with
+      # two spaces as subitems and renders them aligned under the parent.
+      def add_fix_hint(message)
+        add_warning("  Fix: #{message}")
+      end
+
       def print_help
         puts <<~HELP
           Shakapacker Doctor - Diagnostic tool for Shakapacker configuration
@@ -690,7 +697,7 @@ module Shakapacker
         if rspack_major == 1
           add_warning("Rspack v1 detected: persistent caching is experimental in v1 and requires manual opt-in. " \
                       "Upgrading to Rspack v2 enables stable persistent caching out of the box for significantly faster rebuilds.")
-          add_warning("  Fix: Bump @rspack/core and @rspack/cli to ^2.0.0-0 in package.json. See https://rspack.rs/config/cache and docs/rspack.md for details.")
+          add_fix_hint("Bump @rspack/core and @rspack/cli to ^2.0.0-0 in package.json. See https://rspack.rs/config/cache and docs/rspack.md for details.")
         end
 
         path = active_assets_bundler_config_path
@@ -703,8 +710,8 @@ module Shakapacker
         add_warning("Rspack cache appears to be disabled in #{relative} (found 'cache: false'). Disabling cache " \
                     "causes significantly slower builds, especially on rebuilds. Rspack v2 promotes filesystem " \
                     "caching from experimental to stable.")
-        add_warning("  Fix: Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
-                    "See https://rspack.rs/config/cache for options.")
+        add_fix_hint("Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
+                     "See https://rspack.rs/config/cache for options.")
       rescue Errno::ENOENT => e
         add_warning("Unable to validate rspack cache configuration: #{e.message}")
       end
@@ -748,17 +755,19 @@ module Shakapacker
         # config object). This avoids false positives from nested loader options like
         # `{ loader: 'babel-loader', options: { cache: false } }`.
         #
-        # Known false-positive patterns that this heuristic does not filter (the
-        # "appears to be disabled" wording in the warning is the mitigation):
-        #   - Intermediate variable assignment, where the depth-1 object is not
-        #     the exported config:
-        #       const opts = { cache: false };
-        #       module.exports = merge(base, opts);
-        #   - Function-argument objects whose `{` is at depth 1 in the pre-match,
-        #     because parentheses are not counted:
-        #       module.exports = merge(base, { cache: false });
-        # Restricting the scan to the exported object would require a real JS
-        # parser; the conservative depth-1 heuristic is intentional.
+        # The heuristic also flags depth-1 objects that aren't the literal
+        # `module.exports = { ... }` object — e.g. an intermediate variable or a
+        # function-argument object:
+        #   const opts = { cache: false };
+        #   module.exports = merge(base, opts);
+        #
+        #   module.exports = merge(base, { cache: false });
+        # In typical use these still disable the build's cache (so the warning is
+        # appropriate), but if `opts` is unused or the merge function ignores
+        # `cache`, the warning could fire when caching is not actually disabled.
+        # The "appears to be disabled" wording is the mitigation. Distinguishing
+        # these cases would require a real JS parser; the conservative depth-1
+        # heuristic is intentional.
         stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
           pre = Regexp.last_match.pre_match
           (pre.count("{") - pre.count("}")) == 1

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -888,7 +888,9 @@ module Shakapacker
       # Catches the `const cfg = { cache: false }; module.exports = cfg` pattern.
       # Composition via merge (`module.exports = merge(cfg, …)`) is a known
       # false-negative since the variable is never referenced by name in the
-      # export statement.
+      # export statement. The `[^=;]+` type-annotation clause also stops at the
+      # first `=`, so TypeScript generics with default type parameters such as
+      # `Configuration<Opts = DefaultOpts>` are another known false-negative gap.
       def exported_variable_cache_disabled?(stripped)
         variable_declaration = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:\s*[^=;]+)?\s*=\s*\{/
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -716,7 +716,7 @@ module Shakapacker
       def active_assets_bundler_config_path
         config_dir = config.assets_bundler_config_path
 
-        candidates = %w[ts js mjs cjs].map { |ext| root_path.join(config_dir, "rspack.config.#{ext}") }
+        candidates = %w[ts js].map { |ext| root_path.join(config_dir, "rspack.config.#{ext}") }
         candidates += %w[ts js].map { |ext| root_path.join(config_dir, "webpack.config.#{ext}") }
         if config_dir == "config/rspack"
           candidates += %w[ts js].map { |ext| root_path.join("config/webpack", "webpack.config.#{ext}") }
@@ -726,11 +726,18 @@ module Shakapacker
       end
 
       def rspack_cache_disabled?(content)
+        # Preserve quoted property keys (`'cache': false` / `"cache": false`) by
+        # replacing them with the bare identifier form before stripping general
+        # string literals. Without this step the surrounding string-strip would
+        # collapse `'cache'` and `"cache"` to `""` and the regex below would miss
+        # the disabled cache.
+        stripped = content.gsub(/(['"])(\w+)\1(?=\s*:)/, '\2')
+
         # Strip string literals and comments so examples inside strings or comments
         # don't trigger a false positive. Single/double-quoted JS strings cannot span
         # newlines, so the exclusion class includes \n to prevent a runaway match when
         # an unmatched quote appears in a comment (e.g. `// don't disable cache`).
-        stripped = content
+        stripped = stripped
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
           .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
           .gsub(/"(?:\\.|[^"\\\n])*"/, '""')

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -723,6 +723,7 @@ module Shakapacker
       # resolution order in Shakapacker::Runner#find_rspack_config_with_fallback so the
       # doctor inspects the same file the build will actually use (and so unused sibling
       # configs in the same directory don't trigger spurious warnings).
+      # NOTE: keep this candidate list in sync with Runner#find_rspack_config_with_fallback.
       def active_assets_bundler_config_path
         config_dir = config.assets_bundler_config_path.to_s
 
@@ -743,6 +744,8 @@ module Shakapacker
       end
 
       def default_rspack_config_dir?(config_dir)
+        # Intentionally exact-string match: mirrors the runner's own comparison,
+        # so a trailing slash or Pathname argument won't spuriously add the config/webpack fallback.
         config_dir == "config/rspack"
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -723,10 +723,10 @@ module Shakapacker
       def active_assets_bundler_config_path
         config_dir = config.assets_bundler_config_path
 
-        candidates = %w[ts js].map { |ext| root_path.join(config_dir, "rspack.config.#{ext}") }
-        candidates += %w[ts js].map { |ext| root_path.join(config_dir, "webpack.config.#{ext}") }
+        candidates = %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, config_dir, "rspack.config.#{ext}")) }
+        candidates += %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, config_dir, "webpack.config.#{ext}")) }
         if config_dir == "config/rspack"
-          candidates += %w[ts js].map { |ext| root_path.join("config/webpack", "webpack.config.#{ext}") }
+          candidates += %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, "config/webpack", "webpack.config.#{ext}")) }
         end
 
         candidates.find(&:exist?)

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -767,12 +767,7 @@ module Shakapacker
         # and produce a spurious cache: false match.
         stripped = content.gsub(/(['"])(\w+)\1(?=[ \t]*:)/, '\2')
 
-        stripped = stripped
-          .gsub(/`(?:\\.|[^`\\])*`/m, '""')
-          .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
-          .gsub(/"(?:\\.|[^"\\\n])*"/, '""')
-          .gsub(%r{/\*.*?\*/}m, "")
-          .gsub(%r{(?<!\\)//[^\n]*}, "")
+        stripped = strip_rspack_config_comments_and_literals(stripped)
 
         # Regex literal stripping runs after comment removal. The line-comment
         # pass above ignores escaped slashes so /https?:\/\/host/ stays intact
@@ -780,6 +775,91 @@ module Shakapacker
         # false-match bare division like `a / b / c`, but rspack config files
         # rarely contain arithmetic near `cache:`, so the risk is low.
         stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
+      end
+
+      def strip_rspack_config_comments_and_literals(content)
+        stripped = +""
+        index = 0
+
+        while index < content.length
+          char = content[index]
+          pair = content[index, 2]
+
+          if pair == "/*"
+            comment_end = content.index("*/", index + 2)
+            if comment_end
+              comment = content[index..comment_end + 1]
+              stripped << comment.gsub(/[^\n]/, " ")
+              index = comment_end + 2
+            else
+              stripped << content[index..].gsub(/[^\n]/, " ")
+              break
+            end
+          elsif pair == "//" && (index.zero? || content[index - 1] != "\\")
+            line_end = content.index("\n", index + 2) || content.length
+            stripped << content[index...line_end].gsub(/[^\n]/, " ")
+            index = line_end
+          elsif char == "'" || char == '"'
+            literal_end = index + 1
+            escaped = false
+
+            while literal_end < content.length
+              current = content[literal_end]
+              break if current == "\n"
+
+              if escaped
+                escaped = false
+              elsif current == "\\"
+                escaped = true
+              elsif current == char
+                literal_end += 1
+                break
+              end
+
+              literal_end += 1
+            end
+
+            literal = content[index...literal_end]
+            stripped << '""'
+            stripped << literal.gsub(/[^\n]/, "")
+            index = literal_end
+          elsif char == "`"
+            literal_end = index + 1
+            escaped = false
+            closed = false
+
+            while literal_end < content.length
+              current = content[literal_end]
+
+              if escaped
+                escaped = false
+              elsif current == "\\"
+                escaped = true
+              elsif current == "`"
+                literal_end += 1
+                closed = true
+                break
+              end
+
+              literal_end += 1
+            end
+
+            if closed
+              literal = content[index...literal_end]
+              stripped << '""'
+              stripped << literal.gsub(/[^\n]/, "")
+              index = literal_end
+            else
+              stripped << char
+              index += 1
+            end
+          else
+            stripped << char
+            index += 1
+          end
+        end
+
+        stripped
       end
 
       def direct_export_cache_disabled?(stripped)

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -704,12 +704,12 @@ module Shakapacker
           add_warning("  Fix: Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
                       "See https://rspack.rs/config/cache for options.")
         end
-      rescue Errno::ENOENT, JSON::ParserError => e
+      rescue Errno::ENOENT => e
         add_warning("Unable to validate rspack cache configuration: #{e.message}")
       end
 
       def rspack_config_paths
-        config_dir = config.respond_to?(:assets_bundler_config_path) ? config.assets_bundler_config_path : "config/rspack"
+        config_dir = config.assets_bundler_config_path
         %w[js ts mjs cjs].filter_map do |ext|
           path = root_path.join(config_dir, "rspack.config.#{ext}")
           path if path.exist?
@@ -721,11 +721,11 @@ module Shakapacker
         # and backtick template literals) so examples inside strings or comments don't
         # trigger a false positive.
         stripped = content
-          .gsub(%r{/\*.*?\*/}m, "")
-          .gsub(%r{//[^\n]*}, "")
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
           .gsub(/'(?:\\.|[^'\\])*'/, '""')
           .gsub(/"(?:\\.|[^"\\])*"/, '""')
+          .gsub(%r{/\*.*?\*/}m, "")
+          .gsub(%r{//[^\n]*}, "")
 
         # Match `cache: false` at a position that looks like a top-level or object property
         # key: preceded by `{`, `,`, or a newline. This avoids false positives like
@@ -747,6 +747,8 @@ module Shakapacker
         # Skip git+, file:, npm: aliases, "latest", "*", or ranges like ">=1.5 <2".
         cleaned = version.strip
         return nil unless cleaned.match?(/\A[\^~]?\d/)
+        return nil if cleaned.match?(/(\s|\|\||[<>=:]|\A(?:git|file|link|workspace|npm):)/)
+        return nil unless cleaned.match?(/\A[\^~]?\d+(?:\.\d+){1,2}(?:-[0-9A-Za-z.-]+)?\z/)
 
         match = cleaned.sub(/\A[\^~]/, "").match(/\A(\d+)\./)
         match && match[1].to_i
@@ -766,7 +768,8 @@ module Shakapacker
       def package_json_dependency_version(name)
         return nil unless package_json_exists?
 
-        deps = (read_package_json["dependencies"] || {}).merge(read_package_json["devDependencies"] || {})
+        pkg = read_package_json
+        deps = (pkg["dependencies"] || {}).merge(pkg["devDependencies"] || {})
         deps[name]
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -110,6 +110,7 @@ module Shakapacker
         check_css_dependencies
         check_css_modules_configuration
         check_bundler_dependencies if config_exists?
+        check_rspack_cache_configuration if config_exists?
         check_file_type_dependencies if config_exists?
         check_sri_dependencies if config_exists?
         check_peer_dependencies
@@ -679,6 +680,94 @@ module Shakapacker
           check_dependency("@rspack/core", @issues, "Rspack")
           check_dependency("@rspack/cli", @issues, "Rspack CLI")
         end
+      end
+
+      def check_rspack_cache_configuration
+        return unless config.assets_bundler == "rspack"
+
+        rspack_major = rspack_major_version
+
+        if rspack_major == 1
+          add_warning("Rspack v1 detected: persistent caching is experimental in v1 and requires manual opt-in. " \
+                      "Upgrading to Rspack v2 enables stable persistent caching out of the box for significantly faster rebuilds.")
+          add_warning("  Fix: Bump @rspack/core and @rspack/cli to ^2.0.0-0 in package.json. See https://rspack.rs/config/cache and docs/rspack.md for details.")
+        end
+
+        rspack_config_paths.each do |path|
+          content = File.read(path)
+          relative = path.relative_path_from(root_path)
+          next unless rspack_cache_disabled?(content)
+
+          add_warning("Rspack cache appears to be disabled in #{relative} (found 'cache: false'). Disabling cache " \
+                      "causes significantly slower builds, especially on rebuilds. Rspack v2 promotes filesystem " \
+                      "caching from experimental to stable.")
+          add_warning("  Fix: Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
+                      "See https://rspack.rs/config/cache for options.")
+        end
+      rescue Errno::ENOENT, JSON::ParserError => e
+        add_warning("Unable to validate rspack cache configuration: #{e.message}")
+      end
+
+      def rspack_config_paths
+        config_dir = config.respond_to?(:assets_bundler_config_path) ? config.assets_bundler_config_path : "config/rspack"
+        %w[js ts mjs cjs].filter_map do |ext|
+          path = root_path.join(config_dir, "rspack.config.#{ext}")
+          path if path.exist?
+        end
+      end
+
+      def rspack_cache_disabled?(content)
+        # Strip block comments, line comments, and string literals (single/double quoted
+        # and backtick template literals) so examples inside strings or comments don't
+        # trigger a false positive.
+        stripped = content
+          .gsub(%r{/\*.*?\*/}m, "")
+          .gsub(%r{//[^\n]*}, "")
+          .gsub(/`(?:\\.|[^`\\])*`/m, '""')
+          .gsub(/'(?:\\.|[^'\\])*'/, '""')
+          .gsub(/"(?:\\.|[^"\\])*"/, '""')
+
+        # Match `cache: false` at a position that looks like a top-level or object property
+        # key: preceded by `{`, `,`, or a newline. This avoids false positives like
+        # `cacheDirectory: false` in loader options.
+        stripped.match?(/(?:\{|,|\n)\s*cache\s*:\s*false\b/m)
+      end
+
+      def rspack_major_version
+        # Prefer the resolved version from node_modules, since package.json specifiers
+        # (ranges, git refs, file paths) often don't parse to a clean major number.
+        resolved = installed_rspack_major_version
+        return resolved if resolved
+
+        version = package_json_dependency_version("@rspack/core") ||
+                  package_json_dependency_version("@rspack/cli")
+        return nil unless version
+
+        # Only trust specifiers starting with a digit or ^/~ prefix followed by a digit.
+        # Skip git+, file:, npm: aliases, "latest", "*", or ranges like ">=1.5 <2".
+        cleaned = version.strip
+        return nil unless cleaned.match?(/\A[\^~]?\d/)
+
+        match = cleaned.sub(/\A[\^~]/, "").match(/\A(\d+)\./)
+        match && match[1].to_i
+      end
+
+      def installed_rspack_major_version
+        rspack_pkg = root_path.join("node_modules/@rspack/core/package.json")
+        return nil unless rspack_pkg.exist?
+
+        version = JSON.parse(File.read(rspack_pkg))["version"]
+        match = version.to_s.match(/\A(\d+)\./)
+        match && match[1].to_i
+      rescue JSON::ParserError, Errno::ENOENT
+        nil
+      end
+
+      def package_json_dependency_version(name)
+        return nil unless package_json_exists?
+
+        deps = (read_package_json["dependencies"] || {}).merge(read_package_json["devDependencies"] || {})
+        deps[name]
       end
 
       def check_file_type_dependencies

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -721,15 +721,19 @@ module Shakapacker
       # doctor inspects the same file the build will actually use (and so unused sibling
       # configs in the same directory don't trigger spurious warnings).
       def active_assets_bundler_config_path
-        config_dir = config.assets_bundler_config_path
+        config_dir = config.assets_bundler_config_path.to_s
 
         candidates = %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, config_dir, "rspack.config.#{ext}")) }
         candidates += %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, config_dir, "webpack.config.#{ext}")) }
-        if config_dir == "config/rspack"
+        if default_rspack_config_dir?(config_dir)
           candidates += %w[ts js].map { |ext| Pathname.new(File.join(root_path.to_s, "config/webpack", "webpack.config.#{ext}")) }
         end
 
         candidates.find(&:exist?)
+      end
+
+      def default_rspack_config_dir?(config_dir)
+        Pathname.new(config_dir).cleanpath.to_s == "config/rspack"
       end
 
       def config_path_for_warning(path)
@@ -760,14 +764,15 @@ module Shakapacker
         # be removed first so their slash characters cannot expose cache hints.
         stripped = stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
 
-        # Match `cache: false` only at brace depth 1. This is intentionally
-        # conservative: a real JS parser would be needed to distinguish the
-        # exported config object from an intermediate variable or merge argument,
-        # so the warning is phrased as "appears to be disabled" to mitigate the
-        # rare false positive.
+        # Match `cache: false` only near an exported config object at brace depth
+        # 1. This avoids warning on local base config objects while still
+        # catching the common direct export and generateRspackConfig patterns.
         stripped.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
           pre = Regexp.last_match.pre_match
-          (pre.count("{") - pre.count("}")) == 1
+          next false unless (pre.count("{") - pre.count("}")) == 1
+
+          statement_prefix = pre[(pre.rindex(";") || -1) + 1..]
+          statement_prefix.match?(/\bmodule\.exports\b|\bexport\s+default\b|\bgenerateRspackConfig\b/)
         end
       end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -703,7 +703,9 @@ module Shakapacker
         path = active_assets_bundler_config_path
         return unless path
 
-        content = File.read(path)
+        content = read_active_assets_bundler_config(path)
+        return unless content
+
         return unless rspack_cache_disabled?(content)
 
         relative = config_path_for_warning(path)
@@ -712,8 +714,6 @@ module Shakapacker
                     "caching from experimental to stable.")
         add_fix_hint("Remove the 'cache: false' setting, or use 'cache: { type: \"filesystem\" }' for persistent caching. " \
                      "See https://rspack.rs/config/cache for options.")
-      rescue Errno::ENOENT => e
-        add_warning("Unable to validate rspack cache configuration: #{e.message}")
       end
 
       # Returns the single active config path the runner would load, or nil. Mirrors the
@@ -730,6 +730,13 @@ module Shakapacker
         end
 
         candidates.find(&:exist?)
+      end
+
+      def read_active_assets_bundler_config(path)
+        File.read(path)
+      rescue SystemCallError => e
+        add_warning("Unable to validate rspack cache configuration: #{e.message}")
+        nil
       end
 
       def default_rspack_config_dir?(config_dir)
@@ -749,6 +756,12 @@ module Shakapacker
       end
 
       def rspack_cache_disabled?(content)
+        stripped = stripped_rspack_config_content(content)
+
+        direct_export_cache_disabled?(stripped) || exported_variable_cache_disabled?(stripped)
+      end
+
+      def stripped_rspack_config_content(content)
         # Normalize quoted property keys before stripping string literals; otherwise
         # `'cache'` and `"cache"` collapse to `""` and the match below misses them.
         stripped = content.gsub(/(['"])(\w+)\1(?=\s*:)/, '\2')
@@ -763,8 +776,10 @@ module Shakapacker
         # Regex literal stripping runs after comment removal. The line-comment
         # pass above ignores escaped slashes so /https?:\/\/host/ stays intact
         # until this pass removes the whole regex literal.
-        stripped = stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
+        stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
+      end
 
+      def direct_export_cache_disabled?(stripped)
         # Match `cache: false` only near an exported config object at brace depth
         # 1. This avoids warning on local base config objects while still
         # catching the common direct export and generateRspackConfig patterns.
@@ -775,6 +790,46 @@ module Shakapacker
           statement_prefix = pre[(pre.rindex(";") || -1) + 1..]
           statement_prefix.match?(/\bmodule\.exports\b|\bexport\s+default\b|\bgenerateRspackConfig\b/)
         end
+      end
+
+      def exported_variable_cache_disabled?(stripped)
+        variable_declaration = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:\s*[^=;]+)?\s*=\s*\{/
+
+        stripped.to_enum(:scan, variable_declaration).any? do
+          name = Regexp.last_match[1]
+          open_index = Regexp.last_match.end(0) - 1
+          close_index = matching_closing_brace(stripped, open_index)
+          next false unless close_index
+
+          object_source = stripped[open_index..close_index]
+          top_level_cache_false?(object_source) && exported_config_variable?(stripped, name)
+        end
+      end
+
+      def top_level_cache_false?(object_source)
+        object_source.to_enum(:scan, /\bcache\s*:\s*false\b/).any? do
+          pre = Regexp.last_match.pre_match
+          (pre.count("{") - pre.count("}")) == 1
+        end
+      end
+
+      def exported_config_variable?(stripped, name)
+        escaped_name = Regexp.escape(name)
+        stripped.match?(/\bmodule\.exports\s*=\s*#{escaped_name}\b/) ||
+          stripped.match?(/\bexport\s+default\s+#{escaped_name}\b/)
+      end
+
+      def matching_closing_brace(content, open_index)
+        depth = 0
+
+        content[open_index..].each_char.with_index do |char, offset|
+          depth += 1 if char == "{"
+          depth -= 1 if char == "}"
+
+          return open_index + offset if depth.zero?
+        end
+
+        nil
       end
 
       def rspack_major_version

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -60,9 +60,7 @@ module Shakapacker
         add_warning(message, CATEGORY_INFO)
       end
 
-      # Records a "Fix: ..." hint as an indented sub-item attached to the
-      # preceding warning. The doctor's printer treats messages starting with
-      # two spaces as subitems and renders them aligned under the parent.
+      # "Fix: ..." hints render as indented sub-items under the preceding warning.
       def add_fix_hint(message, category = CATEGORY_RECOMMENDED)
         add_warning("  Fix: #{message}", category)
       end

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -63,8 +63,8 @@ module Shakapacker
       # Records a "Fix: ..." hint as an indented sub-item attached to the
       # preceding warning. The doctor's printer treats messages starting with
       # two spaces as subitems and renders them aligned under the parent.
-      def add_fix_hint(message)
-        add_warning("  Fix: #{message}")
+      def add_fix_hint(message, category = CATEGORY_RECOMMENDED)
+        add_warning("  Fix: #{message}", category)
       end
 
       def print_help
@@ -706,7 +706,7 @@ module Shakapacker
         content = File.read(path)
         return unless rspack_cache_disabled?(content)
 
-        relative = path.relative_path_from(root_path)
+        relative = config_path_for_warning(path)
         add_warning("Rspack cache appears to be disabled in #{relative} (found 'cache: false'). Disabling cache " \
                     "causes significantly slower builds, especially on rebuilds. Rspack v2 promotes filesystem " \
                     "caching from experimental to stable.")
@@ -732,6 +732,18 @@ module Shakapacker
         candidates.find(&:exist?)
       end
 
+      def config_path_for_warning(path)
+        expanded_root = root_path.expand_path
+        expanded_path = path.expand_path
+
+        return path.to_s unless expanded_path.to_s == expanded_root.to_s ||
+                                expanded_path.to_s.start_with?("#{expanded_root}#{File::SEPARATOR}")
+
+        path.relative_path_from(root_path)
+      rescue ArgumentError
+        path.to_s
+      end
+
       def rspack_cache_disabled?(content)
         # Normalize quoted property keys before stripping string literals; otherwise
         # `'cache'` and `"cache"` collapse to `""` and the match below misses them.
@@ -741,9 +753,12 @@ module Shakapacker
           .gsub(/`(?:\\.|[^`\\])*`/m, '""')
           .gsub(/'(?:\\.|[^'\\\n])*'/, '""')
           .gsub(/"(?:\\.|[^"\\\n])*"/, '""')
-          .gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
           .gsub(%r{/\*.*?\*/}m, "")
           .gsub(%r{//[^\n]*}, "")
+
+        # Regex literal stripping is order-sensitive: strings and comments must
+        # be removed first so their slash characters cannot expose cache hints.
+        stripped = stripped.gsub(%r{/(?:\\.|\[[^\]\n]*\]|[^/\n\\\[])+?/[gimsuy]*}, "")
 
         # Match `cache: false` only at brace depth 1. This is intentionally
         # conservative: a real JS parser would be needed to distinguish the
@@ -760,7 +775,7 @@ module Shakapacker
         # Prefer the resolved version from node_modules, since package.json specifiers
         # (ranges, git refs, file paths) often don't parse to a clean major number.
         resolved = installed_rspack_major_version
-        return resolved if resolved
+        return resolved unless resolved.nil?
 
         version = package_json_dependency_version("@rspack/core") ||
                   package_json_dependency_version("@rspack/cli")

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -47,6 +47,53 @@ describe "Shakapacker::Compiler" do
     expect(mocked_strategy).to have_received(:after_compile_hook)
   end
 
+  describe "doctor hint messages" do
+    let(:mocked_strategy) do
+      spy("Strategy").tap do |s|
+        allow(s).to receive(:stale?).and_return(true)
+        allow(s).to receive(:after_compile_hook)
+      end
+    end
+
+    before do
+      allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
+      # Reset the once-per-process flag so each test starts fresh.
+      Shakapacker::Compiler.class_variable_set(:@@doctor_hint_shown, false)
+    end
+
+    it "logs a doctor hint once per process when compilation starts" do
+      status = OpenStruct.new(success?: true)
+      allow(Open3).to receive(:capture3).and_return(["", "", status])
+      allow(Shakapacker.logger).to receive(:info)
+
+      Shakapacker.compiler.compile
+
+      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+    end
+
+    it "does not repeat the doctor hint on subsequent compiles in the same process" do
+      status = OpenStruct.new(success?: true)
+      allow(Open3).to receive(:capture3).and_return(["", "", status])
+      allow(Shakapacker.logger).to receive(:info)
+
+      Shakapacker.compiler.compile
+      Shakapacker.compiler.compile
+
+      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+    end
+
+    it "logs the doctor hint before compilation output even when compilation fails" do
+      status = OpenStruct.new(success?: false)
+      allow(Open3).to receive(:capture3).and_return(["", "build error", status])
+      allow(Shakapacker.logger).to receive(:error)
+      allow(Shakapacker.logger).to receive(:info)
+
+      Shakapacker.compiler.compile
+
+      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+    end
+  end
+
   it "accepts external env variables" do
     expect(Shakapacker.compiler.send(:webpack_env)["SHAKAPACKER_ASSET_HOST"]).to be nil
 

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -1,5 +1,4 @@
 require_relative "spec_helper_initializer"
-require "ostruct"
 
 describe "Shakapacker::Compiler" do
   it "accepts custom environment variables" do
@@ -26,7 +25,7 @@ describe "Shakapacker::Compiler" do
 
     allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-    status = OpenStruct.new(success?: true)
+    status = instance_double(Process::Status, success?: true)
     allow(Open3).to receive(:capture3).and_return([:stderr, :stdout, status])
 
     expect(Shakapacker.compiler.compile).to be true
@@ -40,7 +39,7 @@ describe "Shakapacker::Compiler" do
 
     allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-    status = OpenStruct.new(success?: false)
+    status = instance_double(Process::Status, success?: false)
     allow(Open3).to receive(:capture3).and_return([:stderr, :stdout, status])
 
     expect(Shakapacker.compiler.compile).to be false
@@ -61,7 +60,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "does not log the doctor hint when compilation succeeds" do
-      status = OpenStruct.new(success?: true)
+      status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture3).and_return(["", "", status])
       allow(Shakapacker.logger).to receive(:info)
 
@@ -71,7 +70,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "logs the doctor hint after a failed compilation" do
-      status = OpenStruct.new(success?: false)
+      status = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       allow(Shakapacker.logger).to receive(:info)
@@ -82,7 +81,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "sets the doctor hint flag without bypassing method visibility" do
-      status = OpenStruct.new(success?: false)
+      status = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       allow(Shakapacker.logger).to receive(:info)
@@ -95,7 +94,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "does not repeat the doctor hint on subsequent failed compiles" do
-      status = OpenStruct.new(success?: false)
+      status = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       allow(Shakapacker.logger).to receive(:info)
@@ -107,7 +106,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "does not abort the build when the hint logger raises" do
-      status = OpenStruct.new(success?: false)
+      status = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       # Generic stub first so the more specific stub below wins for matching args.
@@ -120,7 +119,7 @@ describe "Shakapacker::Compiler" do
     end
 
     it "does not swallow failures outside the hint logger call" do
-      status = OpenStruct.new(success?: false)
+      status = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       allow(Shakapacker.logger).to receive(:info)
@@ -145,8 +144,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/test-hook"
 
       allow(Open3).to receive(:capture3) do |env, *args|
@@ -168,7 +167,7 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      webpack_status = OpenStruct.new(success?: true)
+      webpack_status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture3).and_return(["", "", webpack_status])
 
       # Config returns nil for precompile_hook (default)
@@ -184,7 +183,7 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: false, exitstatus: 1)
+      hook_status = instance_double(Process::Status, success?: false, exitstatus: 1)
       allow(Open3).to receive(:capture3).and_return(["", "Error output", hook_status])
 
       # Temporarily stub config to return failing hook
@@ -198,8 +197,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/verbose-hook"
       hook_executable = hook_command
 
@@ -255,8 +254,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "'bin/my script' --arg1 --arg2"
       hook_executable = "bin/my script"
 
@@ -282,8 +281,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/nonexistent-hook"
       hook_executable = hook_command
 
@@ -330,8 +329,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/prepare && rm -rf /"
       hook_executable = "bin/prepare"
 
@@ -363,8 +362,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "FOO=bar BAZ=qux bin/hook --arg"
       hook_executable = "bin/hook"
 
@@ -393,7 +392,7 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      webpack_status = OpenStruct.new(success?: true)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/test-hook"
       allow(Open3).to receive(:capture3).and_return(["", "", webpack_status])
 
@@ -416,8 +415,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/test-hook"
 
       allow(Open3).to receive(:capture3) do |env, *args|
@@ -444,8 +443,8 @@ describe "Shakapacker::Compiler" do
       allow(mocked_strategy).to receive(:stale?).and_return(true)
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
 
-      hook_status = OpenStruct.new(success?: true, exitstatus: 0)
-      webpack_status = OpenStruct.new(success?: true)
+      hook_status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      webpack_status = instance_double(Process::Status, success?: true)
       hook_command = "bin/test-hook"
 
       allow(Open3).to receive(:capture3) do |env, *args|

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -57,32 +57,20 @@ describe "Shakapacker::Compiler" do
 
     before do
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
-      # Reset the once-per-process flag so each test starts fresh.
-      Shakapacker::Compiler.doctor_hint_shown = false
+      Shakapacker::Compiler.send(:doctor_hint_shown=, false)
     end
 
-    it "logs a doctor hint once per process when compilation starts" do
+    it "does not log the doctor hint when compilation succeeds" do
       status = OpenStruct.new(success?: true)
       allow(Open3).to receive(:capture3).and_return(["", "", status])
       allow(Shakapacker.logger).to receive(:info)
 
       Shakapacker.compiler.compile
 
-      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+      expect(Shakapacker.logger).not_to have_received(:info).with(/shakapacker:doctor/)
     end
 
-    it "does not repeat the doctor hint on subsequent compiles in the same process" do
-      status = OpenStruct.new(success?: true)
-      allow(Open3).to receive(:capture3).and_return(["", "", status])
-      allow(Shakapacker.logger).to receive(:info)
-
-      Shakapacker.compiler.compile
-      Shakapacker.compiler.compile
-
-      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
-    end
-
-    it "logs the doctor hint before compilation output even when compilation fails" do
+    it "logs the doctor hint after a failed compilation" do
       status = OpenStruct.new(success?: false)
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
@@ -93,13 +81,28 @@ describe "Shakapacker::Compiler" do
       expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
     end
 
-    it "does not mark the doctor hint as shown when doctor hint logging fails during compile" do
-      allow(Shakapacker.logger).to receive(:info) do |message|
-        raise "doctor hint logger failed" if message.match?(/shakapacker:doctor/)
-      end
+    it "does not repeat the doctor hint on subsequent failed compiles" do
+      status = OpenStruct.new(success?: false)
+      allow(Open3).to receive(:capture3).and_return(["", "build error", status])
+      allow(Shakapacker.logger).to receive(:error)
+      allow(Shakapacker.logger).to receive(:info)
 
-      expect { Shakapacker.compiler.compile }.to raise_error("doctor hint logger failed")
-      expect(Shakapacker.logger).to have_received(:info).with("Compiling...").once
+      Shakapacker.compiler.compile
+      Shakapacker.compiler.compile
+
+      expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+    end
+
+    it "does not abort the build when the hint logger raises" do
+      status = OpenStruct.new(success?: false)
+      allow(Open3).to receive(:capture3).and_return(["", "build error", status])
+      allow(Shakapacker.logger).to receive(:error)
+      # Generic stub first so the more specific stub below wins for matching args.
+      allow(Shakapacker.logger).to receive(:info)
+      allow(Shakapacker.logger).to receive(:info).with(/shakapacker:doctor/).and_raise("logger boom")
+
+      expect { Shakapacker.compiler.compile }.not_to raise_error
+      # Flag stays false so a future compile can still surface the tip when the logger recovers.
       expect(Shakapacker::Compiler.doctor_hint_shown).to be false
     end
   end

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -93,10 +93,13 @@ describe "Shakapacker::Compiler" do
       expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
     end
 
-    it "does not mark the doctor hint as shown when logging fails" do
-      allow(Shakapacker.logger).to receive(:info).and_raise("logger failed")
+    it "does not mark the doctor hint as shown when doctor hint logging fails during compile" do
+      allow(Shakapacker.logger).to receive(:info) do |message|
+        raise "doctor hint logger failed" if message.match?(/shakapacker:doctor/)
+      end
 
-      expect { Shakapacker.compiler.compile }.to raise_error("logger failed")
+      expect { Shakapacker.compiler.compile }.to raise_error("doctor hint logger failed")
+      expect(Shakapacker.logger).to have_received(:info).with("Compiling...").once
       expect(Shakapacker::Compiler.doctor_hint_shown).to be false
     end
   end

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -92,6 +92,13 @@ describe "Shakapacker::Compiler" do
 
       expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
     end
+
+    it "does not mark the doctor hint as shown when logging fails" do
+      allow(Shakapacker.logger).to receive(:info).and_raise("logger failed")
+
+      expect { Shakapacker.compiler.compile }.to raise_error("logger failed")
+      expect(Shakapacker::Compiler.doctor_hint_shown).to be false
+    end
   end
 
   it "accepts external env variables" do

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -58,7 +58,7 @@ describe "Shakapacker::Compiler" do
     before do
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
       # Reset the once-per-process flag so each test starts fresh.
-      Shakapacker::Compiler.class_variable_set(:@@doctor_hint_shown, false)
+      Shakapacker::Compiler.doctor_hint_shown = false
     end
 
     it "logs a doctor hint once per process when compilation starts" do

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -105,6 +105,17 @@ describe "Shakapacker::Compiler" do
       # Flag stays false so a future compile can still surface the tip when the logger recovers.
       expect(Shakapacker::Compiler.doctor_hint_shown).to be false
     end
+
+    it "does not swallow failures outside the hint logger call" do
+      status = OpenStruct.new(success?: false)
+      allow(Open3).to receive(:capture3).and_return(["", "build error", status])
+      allow(Shakapacker.logger).to receive(:error)
+      allow(Shakapacker.logger).to receive(:info)
+      allow(Shakapacker::Compiler).to receive(:send).and_call_original
+      allow(Shakapacker::Compiler).to receive(:send).with(:doctor_hint_shown=, true).and_raise("flag boom")
+
+      expect { Shakapacker.compiler.compile }.to raise_error("flag boom")
+    end
   end
 
   it "accepts external env variables" do

--- a/spec/shakapacker/compiler_spec.rb
+++ b/spec/shakapacker/compiler_spec.rb
@@ -57,7 +57,7 @@ describe "Shakapacker::Compiler" do
 
     before do
       allow(Shakapacker.compiler).to receive(:strategy).and_return(mocked_strategy)
-      Shakapacker::Compiler.send(:doctor_hint_shown=, false)
+      Shakapacker::Compiler.doctor_hint_shown = false
     end
 
     it "does not log the doctor hint when compilation succeeds" do
@@ -79,6 +79,19 @@ describe "Shakapacker::Compiler" do
       Shakapacker.compiler.compile
 
       expect(Shakapacker.logger).to have_received(:info).with(/shakapacker:doctor/).once
+    end
+
+    it "sets the doctor hint flag without bypassing method visibility" do
+      status = OpenStruct.new(success?: false)
+      allow(Open3).to receive(:capture3).and_return(["", "build error", status])
+      allow(Shakapacker.logger).to receive(:error)
+      allow(Shakapacker.logger).to receive(:info)
+      allow(Shakapacker::Compiler).to receive(:send).and_call_original
+
+      Shakapacker.compiler.compile
+
+      expect(Shakapacker::Compiler).not_to have_received(:send).with(:doctor_hint_shown=, true)
+      expect(Shakapacker::Compiler.doctor_hint_shown).to be true
     end
 
     it "does not repeat the doctor hint on subsequent failed compiles" do
@@ -111,8 +124,8 @@ describe "Shakapacker::Compiler" do
       allow(Open3).to receive(:capture3).and_return(["", "build error", status])
       allow(Shakapacker.logger).to receive(:error)
       allow(Shakapacker.logger).to receive(:info)
-      allow(Shakapacker::Compiler).to receive(:send).and_call_original
-      allow(Shakapacker::Compiler).to receive(:send).with(:doctor_hint_shown=, true).and_raise("flag boom")
+      allow(Shakapacker::Compiler).to receive(:doctor_hint_shown=).and_call_original
+      allow(Shakapacker::Compiler).to receive(:doctor_hint_shown=).with(true).and_raise("flag boom")
 
       expect { Shakapacker.compiler.compile }.to raise_error("flag boom")
     end

--- a/spec/shakapacker/doctor_optional_peer_spec.rb
+++ b/spec/shakapacker/doctor_optional_peer_spec.rb
@@ -31,6 +31,7 @@ describe "Shakapacker::Doctor with optional peer dependencies" do
            cache_path: cache_path,
            javascript_transpiler: javascript_transpiler,
            assets_bundler: assets_bundler,
+           rspack?: assets_bundler == "rspack",
            data: config_data,
            nested_entries?: false,
            ensure_consistent_versioning?: false,

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -521,6 +521,28 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when rspack config uses a single-quoted cache key" do
+      before do
+        File.write(rspack_config_path, "module.exports = { 'cache': false }")
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when rspack config uses a double-quoted cache key" do
+      before do
+        File.write(rspack_config_path, 'module.exports = { "cache": false }')
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when rspack config has no explicit cache setting" do
       before do
         File.write(rspack_config_path, <<~JS)
@@ -699,6 +721,22 @@ describe Shakapacker::Doctor do
       end
 
       it "checks the webpack fallback config and warns when cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*webpack\.config\.js/))
+      end
+    end
+
+    context "when only rspack.config.mjs exists alongside a webpack.config.js fallback" do
+      let(:rspack_config_mjs_path) { rspack_config_dir.join("rspack.config.mjs") }
+      let(:webpack_config_path) { rspack_config_dir.join("webpack.config.js") }
+
+      before do
+        FileUtils.rm_f(rspack_config_path)
+        File.write(rspack_config_mjs_path, "export default { cache: { type: 'filesystem' } }")
+        File.write(webpack_config_path, "module.exports = { cache: false }")
+      end
+
+      it "inspects the webpack fallback (matching the runner) instead of the unsupported .mjs" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*webpack\.config\.js/))
       end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -76,7 +76,7 @@ describe Shakapacker::Doctor do
       )
     end
 
-    it "does not accept a category override for fix hints" do
+    it "raises ArgumentError when add_fix_hint is called with wrong number of arguments" do
       expect do
         doctor.send(:add_fix_hint, "Test fix instruction", described_class::CATEGORY_ACTION_REQUIRED)
       end.to raise_error(ArgumentError)
@@ -1135,6 +1135,86 @@ describe Shakapacker::Doctor do
       it "does not fold the quote-key normalization across the newline (no false positive)" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+  end
+
+  # Contract spec: doctor and runner must resolve to the same active config file.
+  # If Runner#find_rspack_config_with_fallback gains a new extension or reorders
+  # candidates, this spec will fail loudly so Doctor#active_assets_bundler_config_path
+  # can be updated to match. Without this, the doctor could silently inspect a
+  # different file than the build actually loads.
+  describe "rspack config resolution contract with Runner" do
+    let(:rspack_config_dir) { root_path.join("config/rspack") }
+
+    before do
+      require "shakapacker/runner"
+      allow(config).to receive(:assets_bundler).and_return("rspack")
+      allow(config).to receive(:rspack?).and_return(true)
+      allow(config).to receive(:assets_bundler_config_path).and_return("config/rspack")
+      FileUtils.mkdir_p(rspack_config_dir)
+      FileUtils.mkdir_p(root_path.join("config/webpack"))
+    end
+
+    def runner_resolved_path
+      runner = Shakapacker::Runner.allocate
+      runner.instance_variable_set(:@app_path, root_path.to_s)
+      runner.instance_variable_set(:@config, config)
+      allow(runner).to receive(:log_output).and_return(StringIO.new)
+
+      original_stderr = $stderr
+      $stderr = StringIO.new
+      runner.send(:find_rspack_config_with_fallback)
+    ensure
+      $stderr = original_stderr
+    end
+
+    def expect_paths_to_agree
+      doctor_path = doctor.send(:active_assets_bundler_config_path)
+      runner_path = runner_resolved_path
+      expect(File.expand_path(doctor_path.to_s)).to eq(File.expand_path(runner_path.to_s))
+    end
+
+    context "with rspack.config.js in config/rspack" do
+      before { File.write(rspack_config_dir.join("rspack.config.js"), "module.exports = {}") }
+
+      it "doctor and runner pick the same file" do
+        expect_paths_to_agree
+      end
+    end
+
+    context "with rspack.config.ts in config/rspack" do
+      before { File.write(rspack_config_dir.join("rspack.config.ts"), "export default {}") }
+
+      it "doctor and runner pick the same file" do
+        expect_paths_to_agree
+      end
+    end
+
+    context "with both rspack.config.ts and rspack.config.js present" do
+      before do
+        File.write(rspack_config_dir.join("rspack.config.ts"), "export default {}")
+        File.write(rspack_config_dir.join("rspack.config.js"), "module.exports = {}")
+      end
+
+      it "doctor and runner agree on the .ts variant taking precedence" do
+        expect_paths_to_agree
+      end
+    end
+
+    context "with only webpack.config.js fallback in config/rspack" do
+      before { File.write(rspack_config_dir.join("webpack.config.js"), "module.exports = {}") }
+
+      it "doctor and runner pick the same fallback file" do
+        expect_paths_to_agree
+      end
+    end
+
+    context "with only webpack.config.js in config/webpack (backward-compat fallback)" do
+      before { File.write(root_path.join("config/webpack/webpack.config.js"), "module.exports = {}") }
+
+      it "doctor and runner pick the same fallback file" do
+        expect_paths_to_agree
       end
     end
   end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -82,6 +82,28 @@ describe Shakapacker::Doctor do
       end.to raise_error(ArgumentError)
     end
 
+    it "inherits the parent warning's category" do
+      doctor.send(:add_action_required, "Parent action-required warning")
+      doctor.send(:add_fix_hint, "Fix for action-required parent")
+
+      expect(doctor.warnings.last).to eq(
+        category: described_class::CATEGORY_ACTION_REQUIRED,
+        message: "Fix for action-required parent",
+        fix: true
+      )
+    end
+
+    it "inherits the parent category even when an earlier fix hint sits between" do
+      doctor.send(:add_action_required, "Parent action-required warning")
+      doctor.send(:add_fix_hint, "Earlier fix hint")
+      doctor.send(:add_fix_hint, "Later fix hint")
+
+      expect(doctor.warnings.last).to include(
+        category: described_class::CATEGORY_ACTION_REQUIRED,
+        fix: true
+      )
+    end
+
     it "formats warnings with correct indentation and spacing" do
       # Create a test scenario with warnings
       doctor.instance_variable_get(:@warnings) << { category: :action_required, message: "Test required warning" }

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -66,6 +66,24 @@ describe Shakapacker::Doctor do
   end
 
   describe "warning formatting" do
+    it "stores fix hints as recommended warnings by default" do
+      doctor.send(:add_fix_hint, "Test fix instruction")
+
+      expect(doctor.warnings.last).to eq(
+        category: described_class::CATEGORY_RECOMMENDED,
+        message: "  Fix: Test fix instruction"
+      )
+    end
+
+    it "stores fix hints with an explicit category" do
+      doctor.send(:add_fix_hint, "Test fix instruction", described_class::CATEGORY_ACTION_REQUIRED)
+
+      expect(doctor.warnings.last).to eq(
+        category: described_class::CATEGORY_ACTION_REQUIRED,
+        message: "  Fix: Test fix instruction"
+      )
+    end
+
     it "formats warnings with correct indentation and spacing" do
       # Create a test scenario with warnings
       doctor.instance_variable_get(:@warnings) << { category: :action_required, message: "Test required warning" }
@@ -591,6 +609,22 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when a line comment contains division before cache: false" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          module.exports = {
+            // Example: 1 / 2, cache: false
+            cache: { type: 'filesystem' }
+          }
+        JS
+      end
+
+      it "does not expose the commented cache setting while stripping regex literals" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when using rspack v1" do
       before do
         File.write(package_json_path, JSON.generate({
@@ -755,6 +789,21 @@ describe Shakapacker::Doctor do
       it "silently skips the unsupported .mjs file and emits no cache warning" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when the active rspack config path is outside the project root" do
+      it "uses the absolute config path in the warning" do
+        external_config_dir = Pathname.new(Dir.mktmpdir)
+        external_config_path = external_config_dir.join("rspack.config.js")
+        allow(config).to receive(:assets_bundler_config_path).and_return(external_config_dir.to_s)
+        File.write(external_config_path, "module.exports = { cache: false }")
+
+        doctor.send(:check_rspack_cache_configuration)
+
+        expect(warning_messages).to include(match(/#{Regexp.escape(external_config_path.to_s)}/))
+      ensure
+        FileUtils.rm_rf(external_config_dir) if external_config_dir
       end
     end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -899,6 +899,29 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when the installed rspack package file is unreadable" do
+      before do
+        node_modules_pkg = root_path.join("node_modules/@rspack/core/package.json")
+        FileUtils.mkdir_p(node_modules_pkg.dirname)
+        File.write(node_modules_pkg, "")
+
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(node_modules_pkg).and_raise(Errno::EACCES.new(node_modules_pkg.to_s))
+
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "workspace:*",
+            "@rspack/cli" => "^1.0.0"
+          }
+        }))
+      end
+
+      it "falls back to package.json specifiers instead of raising" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack v1 detected/))
+      end
+    end
+
     context "when the rspack version specifier is a git ref" do
       before do
         File.write(package_json_path, JSON.generate({

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -726,6 +726,23 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when a block comment contains an unmatched backtick before a real cache: false" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          /** Do not set `cache: false here. */
+          module.exports = {
+            cache: false,
+            banner: `built by shakapacker`
+          }
+        JS
+      end
+
+      it "still detects cache: false after the block comment" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when cache: false is nested inside a loader's options" do
       before do
         File.write(rspack_config_path, <<~JS)

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -792,18 +792,14 @@ describe Shakapacker::Doctor do
       end
     end
 
-    context "when the active rspack config path is outside the project root" do
-      it "uses the absolute config path in the warning" do
-        external_config_dir = Pathname.new(Dir.mktmpdir)
-        external_config_path = external_config_dir.join("rspack.config.js")
-        allow(config).to receive(:assets_bundler_config_path).and_return(external_config_dir.to_s)
-        File.write(external_config_path, "module.exports = { cache: false }")
+    context "when the configured rspack config directory starts with a slash" do
+      it "matches the runner's File.join path semantics" do
+        allow(config).to receive(:assets_bundler_config_path).and_return("/config/rspack")
+        File.write(rspack_config_path, "module.exports = { cache: false }")
 
         doctor.send(:check_rspack_cache_configuration)
 
-        expect(warning_messages).to include(match(/#{Regexp.escape(external_config_path.to_s)}/))
-      ensure
-        FileUtils.rm_rf(external_config_dir) if external_config_dir
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*config\/rspack\/rspack\.config\.js/))
       end
     end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -807,6 +807,76 @@ describe Shakapacker::Doctor do
         expect(warning_messages).not_to include(match(/Rspack v1 detected/))
       end
     end
+
+    context "when the rspack version specifier uses a major-only shorthand" do
+      ["^1", "~1", "1", "1.x", "^1.x", "^1.x.x", "1.X"].each do |specifier|
+        context "with specifier #{specifier.inspect}" do
+          before do
+            File.write(package_json_path, JSON.generate({
+              "devDependencies" => {
+                "@rspack/core" => specifier,
+                "@rspack/cli" => specifier
+              }
+            }))
+          end
+
+          it "still emits the v1 advisory" do
+            doctor.send(:check_rspack_cache_configuration)
+            expect(warning_messages).to include(match(/Rspack v1 detected/))
+          end
+        end
+      end
+
+      context "with a v2 major-only shorthand" do
+        before do
+          File.write(package_json_path, JSON.generate({
+            "devDependencies" => {
+              "@rspack/core" => "^2",
+              "@rspack/cli" => "^2"
+            }
+          }))
+        end
+
+        it "does not warn about v1" do
+          doctor.send(:check_rspack_cache_configuration)
+          expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+        end
+      end
+    end
+
+    context "when a regex literal contains an unbalanced brace inside a character class" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          module.exports = {
+            module: { rules: [{ test: /[{]/, use: 'raw-loader' }] },
+            cache: false
+          }
+        JS
+      end
+
+      it "still detects the top-level cache: false" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when @rspack/core appears in both dependencies and devDependencies" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "dependencies" => {
+            "@rspack/core" => "^2.0.0-rc.0"
+          },
+          "devDependencies" => {
+            "@rspack/core" => "^1.0.0"
+          }
+        }))
+      end
+
+      it "uses the dependencies version (production wins) and does not warn about v1" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
   end
 
   describe "Windows platform checks" do

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -460,6 +460,221 @@ describe Shakapacker::Doctor do
     end
   end
 
+  describe "rspack cache configuration checks" do
+    let(:rspack_config_dir) { root_path.join("config/rspack") }
+    let(:rspack_config_path) { rspack_config_dir.join("rspack.config.js") }
+
+    before do
+      allow(config).to receive(:assets_bundler).and_return("rspack")
+      allow(config).to receive(:assets_bundler_config_path).and_return("config/rspack")
+      FileUtils.mkdir_p(rspack_config_dir)
+      File.write(package_json_path, JSON.generate({
+        "devDependencies" => {
+          "@rspack/core" => "^2.0.0-rc.0",
+          "@rspack/cli" => "^2.0.0-rc.0"
+        }
+      }))
+    end
+
+    context "when bundler is webpack" do
+      before do
+        allow(config).to receive(:assets_bundler).and_return("webpack")
+        File.write(rspack_config_path, "module.exports = { cache: false }")
+      end
+
+      it "does not warn about rspack cache" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache/))
+      end
+    end
+
+    context "when rspack config has cache: false" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const { generateRspackConfig } = require('shakapacker/rspack')
+          module.exports = generateRspackConfig({ cache: false })
+        JS
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*config\/rspack\/rspack\.config\.js/))
+      end
+
+      it "suggests a filesystem cache fix" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/cache: \{ type: "filesystem" \}/))
+      end
+    end
+
+    context "when rspack config has cache enabled" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const { generateRspackConfig } = require('shakapacker/rspack')
+          module.exports = generateRspackConfig({ cache: { type: 'filesystem' } })
+        JS
+      end
+
+      it "does not warn about cache" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when rspack config has no explicit cache setting" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const { generateRspackConfig } = require('shakapacker/rspack')
+          module.exports = generateRspackConfig()
+        JS
+      end
+
+      it "does not warn about cache" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when rspack config has cacheDirectory (not top-level cache)" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          module.exports = {
+            module: {
+              rules: [{ loader: 'babel-loader', options: { cacheDirectory: false } }]
+            }
+          }
+        JS
+      end
+
+      it "does not flag cacheDirectory as disabled cache" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when cache: false appears only inside a comment" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          // To opt out of caching, set cache: false below.
+          /* Previous config: cache: false */
+          module.exports = { cache: { type: 'filesystem' } }
+        JS
+      end
+
+      it "does not flag commented-out cache: false" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when using rspack v1" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "^1.0.0",
+            "@rspack/cli" => "^1.0.0"
+          }
+        }))
+      end
+
+      it "warns that v1 cache is experimental and recommends upgrading" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack v1 detected/))
+        expect(warning_messages).to include(match(/Bump @rspack\/core and @rspack\/cli/))
+      end
+    end
+
+    context "when using rspack v2" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "^2.0.0-rc.0",
+            "@rspack/cli" => "^2.0.0-rc.0"
+          }
+        }))
+      end
+
+      it "does not warn about v1" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
+
+    context "when no rspack config file exists" do
+      it "does not raise and does not warn about cache" do
+        FileUtils.rm_rf(rspack_config_dir)
+        expect { doctor.send(:check_rspack_cache_configuration) }.not_to raise_error
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when the rspack config is a TypeScript file" do
+      let(:rspack_config_ts_path) { rspack_config_dir.join("rspack.config.ts") }
+
+      before do
+        FileUtils.rm_f(rspack_config_path)
+        File.write(rspack_config_ts_path, <<~TS)
+          import { generateRspackConfig } from 'shakapacker/rspack'
+          export default generateRspackConfig({ cache: false })
+        TS
+      end
+
+      it "detects cache: false in the TypeScript config" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*rspack\.config\.ts/))
+      end
+    end
+
+    context "when cache: false appears only inside a template literal string" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const message = `Set cache: false to opt out`
+          module.exports = { cache: { type: 'filesystem' } }
+        JS
+      end
+
+      it "does not flag string-literal mentions of cache: false" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when node_modules reports a v2 install even though package.json pins v1" do
+      before do
+        node_modules_pkg = root_path.join("node_modules/@rspack/core/package.json")
+        FileUtils.mkdir_p(node_modules_pkg.dirname)
+        File.write(node_modules_pkg, JSON.generate({ "name" => "@rspack/core", "version" => "2.0.0-rc.0" }))
+
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "^1.0.0 || ^2.0.0-0",
+            "@rspack/cli" => "^1.0.0 || ^2.0.0-0"
+          }
+        }))
+      end
+
+      it "prefers the installed version and does not warn about v1" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
+
+    context "when the rspack version specifier is a git ref" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "git+https://github.com/web-infra-dev/rspack.git#v2.0.0"
+          }
+        }))
+      end
+
+      it "does not falsely classify it as v1" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
+  end
+
   describe "Windows platform checks" do
     context "on Windows" do
       before do

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -673,6 +673,21 @@ describe Shakapacker::Doctor do
         expect(warning_messages).not_to include(match(/Rspack v1 detected/))
       end
     end
+
+    context "when the rspack version specifier is a compound range" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "^1.0.0 || ^2.0.0-0"
+          }
+        }))
+      end
+
+      it "does not falsely classify it as v1" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
   end
 
   describe "Windows platform checks" do

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -76,14 +76,10 @@ describe Shakapacker::Doctor do
       )
     end
 
-    it "stores fix hints with an explicit category" do
-      doctor.send(:add_fix_hint, "Test fix instruction", described_class::CATEGORY_ACTION_REQUIRED)
-
-      expect(doctor.warnings.last).to eq(
-        category: described_class::CATEGORY_ACTION_REQUIRED,
-        message: "Test fix instruction",
-        fix: true
-      )
+    it "does not accept a category override for fix hints" do
+      expect do
+        doctor.send(:add_fix_hint, "Test fix instruction", described_class::CATEGORY_ACTION_REQUIRED)
+      end.to raise_error(ArgumentError)
     end
 
     it "formats warnings with correct indentation and spacing" do
@@ -784,6 +780,21 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when cache: false belongs to a named ES module export" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          export const rspackConfig = {
+            cache: false
+          }
+        JS
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when the active rspack config cannot be read" do
       before do
         File.write(rspack_config_path, "module.exports = { cache: false }")
@@ -868,7 +879,7 @@ describe Shakapacker::Doctor do
     end
 
     context "when the configured rspack config directory is an equivalent Pathname" do
-      it "still checks the config/webpack fallback" do
+      it "does not check the config/webpack fallback because the runner does an exact string check" do
         allow(config).to receive(:assets_bundler_config_path).and_return(Pathname.new("config/rspack/"))
         FileUtils.rm_f(rspack_config_path)
         webpack_config_path = root_path.join("config/webpack/webpack.config.js")
@@ -877,7 +888,7 @@ describe Shakapacker::Doctor do
 
         doctor.send(:check_rspack_cache_configuration)
 
-        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*config\/webpack\/webpack\.config\.js/))
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
       end
     end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -765,6 +765,36 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when cache: false belongs to the exported config variable" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const rspackConfig = {
+            cache: false
+          }
+
+          module.exports = rspackConfig
+        JS
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when the active rspack config cannot be read" do
+      before do
+        File.write(rspack_config_path, "module.exports = { cache: false }")
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(rspack_config_path).and_raise(Errno::EACCES.new(rspack_config_path.to_s))
+      end
+
+      it "warns instead of raising" do
+        expect { doctor.send(:check_rspack_cache_configuration) }.not_to raise_error
+        expect(warning_messages).to include(match(/Unable to validate rspack cache configuration/))
+      end
+    end
+
     context "when both rspack.config.js and rspack.config.ts exist" do
       let(:rspack_config_ts_path) { rspack_config_dir.join("rspack.config.ts") }
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -639,6 +639,71 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when a comment contains an unmatched quote before a real cache: false" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          // don't disable cache here
+          const path = require('path')
+          module.exports = { cache: false }
+        JS
+      end
+
+      it "still detects cache: false on a later line" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when cache: false is nested inside a loader's options" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          module.exports = {
+            cache: { type: 'filesystem' },
+            module: {
+              rules: [{
+                loader: 'babel-loader',
+                options: { cache: false }
+              }]
+            }
+          }
+        JS
+      end
+
+      it "does not flag nested loader cache: false as a top-level disabled cache" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when both rspack.config.js and rspack.config.ts exist" do
+      let(:rspack_config_ts_path) { rspack_config_dir.join("rspack.config.ts") }
+
+      before do
+        File.write(rspack_config_path, "module.exports = { cache: false }")
+        File.write(rspack_config_ts_path, "export default { cache: { type: 'filesystem' } }")
+      end
+
+      it "inspects only the active config (matching the runner's resolution)" do
+        doctor.send(:check_rspack_cache_configuration)
+        # Runner prefers .ts, which has cache enabled — no warning expected.
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when only webpack.config.js exists in rspack mode (webpack fallback)" do
+      let(:webpack_config_path) { rspack_config_dir.join("webpack.config.js") }
+
+      before do
+        FileUtils.rm_f(rspack_config_path)
+        File.write(webpack_config_path, "module.exports = { cache: false }")
+      end
+
+      it "checks the webpack fallback config and warns when cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*webpack\.config\.js/))
+      end
+    end
+
     context "when node_modules reports a v2 install even though package.json pins v1" do
       before do
         node_modules_pkg = root_path.join("node_modules/@rspack/core/package.json")

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -625,6 +625,22 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when a regex literal contains escaped slashes before cache: false" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          module.exports = {
+            output: { publicPath: /https?:\\/\\/cdn\\.example\\.com\\/assets/.source },
+            cache: false
+          }
+        JS
+      end
+
+      it "does not let the regex look like a line comment" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when using rspack v1" do
       before do
         File.write(package_json_path, JSON.generate({
@@ -880,6 +896,22 @@ describe Shakapacker::Doctor do
       it "does not falsely classify it as v1" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
+
+    context "when @rspack/core is unparseable but @rspack/cli pins v1" do
+      before do
+        File.write(package_json_path, JSON.generate({
+          "devDependencies" => {
+            "@rspack/core" => "workspace:*",
+            "@rspack/cli" => "^1.0.0"
+          }
+        }))
+      end
+
+      it "falls back to @rspack/cli and emits the v1 advisory" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack v1 detected/))
       end
     end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -733,6 +733,22 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when cache: false belongs to a local base config object" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const baseConfig = { cache: false }
+          module.exports = merge(baseConfig, {
+            module: { rules: [] }
+          })
+        JS
+      end
+
+      it "does not flag the local object as the exported cache setting" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when both rspack.config.js and rspack.config.ts exist" do
       let(:rspack_config_ts_path) { rspack_config_dir.join("rspack.config.ts") }
 
@@ -800,6 +816,20 @@ describe Shakapacker::Doctor do
         doctor.send(:check_rspack_cache_configuration)
 
         expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*config\/rspack\/rspack\.config\.js/))
+      end
+    end
+
+    context "when the configured rspack config directory is an equivalent Pathname" do
+      it "still checks the config/webpack fallback" do
+        allow(config).to receive(:assets_bundler_config_path).and_return(Pathname.new("config/rspack/"))
+        FileUtils.rm_f(rspack_config_path)
+        webpack_config_path = root_path.join("config/webpack/webpack.config.js")
+        FileUtils.mkdir_p(webpack_config_path.dirname)
+        File.write(webpack_config_path, "module.exports = { cache: false }")
+
+        doctor.send(:check_rspack_cache_configuration)
+
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*config\/webpack\/webpack\.config\.js/))
       end
     end
 

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -834,6 +834,41 @@ describe Shakapacker::Doctor do
       end
     end
 
+    context "when cache: false is re-exported as default via ESM alias syntax" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const rspackConfig = {
+            cache: false
+          }
+
+          export { rspackConfig as default }
+        JS
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when cache: false is re-exported as default alongside other named exports" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const rspackConfig = {
+            cache: false
+          }
+          const helper = {}
+
+          export { helper, rspackConfig as default }
+        JS
+      end
+
+      it "warns that cache is disabled" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
     context "when the active rspack config cannot be read" do
       before do
         File.write(rspack_config_path, "module.exports = { cache: false }")

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -66,12 +66,13 @@ describe Shakapacker::Doctor do
   end
 
   describe "warning formatting" do
-    it "stores fix hints as recommended warnings by default" do
+    it "stores fix hints as recommended warnings by default with the :fix marker" do
       doctor.send(:add_fix_hint, "Test fix instruction")
 
       expect(doctor.warnings.last).to eq(
         category: described_class::CATEGORY_RECOMMENDED,
-        message: "  Fix: Test fix instruction"
+        message: "Test fix instruction",
+        fix: true
       )
     end
 
@@ -80,7 +81,8 @@ describe Shakapacker::Doctor do
 
       expect(doctor.warnings.last).to eq(
         category: described_class::CATEGORY_ACTION_REQUIRED,
-        message: "  Fix: Test fix instruction"
+        message: "Test fix instruction",
+        fix: true
       )
     end
 
@@ -1035,6 +1037,54 @@ describe Shakapacker::Doctor do
       it "uses the dependencies version (production wins) and does not warn about v1" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).not_to include(match(/Rspack v1 detected/))
+      end
+    end
+
+    context "when cache: false appears at depth 1 inside a base config used in a merge" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const baseConfig = { cache: false }
+          module.exports = merge(baseConfig, { output: { path: '/tmp' } })
+        JS
+      end
+
+      # Known limitation: the heuristic only catches variables exported directly
+      # (`module.exports = baseConfig`); composition via merge is not flagged.
+      # The "appears to be disabled" wording is the mitigation when the heuristic
+      # does fire on related patterns.
+      it "does not warn when the variable is only referenced inside merge() (false-negative gap)" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when a regex literal sits on its own line away from any comment" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const re = /https?:\\/\\/cdn\\.example\\.com/
+          module.exports = { cache: false }
+        JS
+      end
+
+      it "strips the regex first and still detects cache: false" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).to include(match(/Rspack cache appears to be disabled/))
+      end
+    end
+
+    context "when a multiline ternary contains the quoted key \"cache\" followed by : false on the next line" do
+      before do
+        File.write(rspack_config_path, <<~JS)
+          const label = condition
+            ? "cache"
+            : false
+          module.exports = { cache: { type: 'filesystem' } }
+        JS
+      end
+
+      it "does not fold the quote-key normalization across the newline (no false positive)" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
       end
     end
   end

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -466,6 +466,7 @@ describe Shakapacker::Doctor do
 
     before do
       allow(config).to receive(:assets_bundler).and_return("rspack")
+      allow(config).to receive(:rspack?).and_return(true)
       allow(config).to receive(:assets_bundler_config_path).and_return("config/rspack")
       FileUtils.mkdir_p(rspack_config_dir)
       File.write(package_json_path, JSON.generate({
@@ -479,6 +480,7 @@ describe Shakapacker::Doctor do
     context "when bundler is webpack" do
       before do
         allow(config).to receive(:assets_bundler).and_return("webpack")
+        allow(config).to receive(:rspack?).and_return(false)
         File.write(rspack_config_path, "module.exports = { cache: false }")
       end
 
@@ -739,6 +741,20 @@ describe Shakapacker::Doctor do
       it "inspects the webpack fallback (matching the runner) instead of the unsupported .mjs" do
         doctor.send(:check_rspack_cache_configuration)
         expect(warning_messages).to include(match(/Rspack cache appears to be disabled.*webpack\.config\.js/))
+      end
+    end
+
+    context "when only rspack.config.mjs exists with no fallback" do
+      let(:rspack_config_mjs_path) { rspack_config_dir.join("rspack.config.mjs") }
+
+      before do
+        FileUtils.rm_f(rspack_config_path)
+        File.write(rspack_config_mjs_path, "export default { cache: false }")
+      end
+
+      it "silently skips the unsupported .mjs file and emits no cache warning" do
+        doctor.send(:check_rspack_cache_configuration)
+        expect(warning_messages).not_to include(match(/Rspack cache appears to be disabled/))
       end
     end
 


### PR DESCRIPTION
## Summary

- `shakapacker:doctor` now inspects the Rspack config file for an explicit `cache: false` and warns when found. Disabling cache causes significantly slower builds, especially on rebuilds.
- The check also detects Rspack v1 installs — where persistent caching is experimental and requires manual opt-in — and recommends upgrading to v2 where filesystem caching is stable.
- The compiler logs a one-time `bundle exec rake shakapacker:doctor` tip on the first compile of each process, so users discover the doctor when investigating build issues.

## Design notes

- **Avoiding false positives in the config-file scan:** strips block/line comments and single/double/backtick string literals before matching, and only flags `cache: false` at brace depth 1 (the top level of the exported config object) so nested loader options like `{ loader: 'babel-loader', options: { cache: false } }` don't trigger. The warning wording says "appears to be disabled" since static analysis of a JS config file is best-effort, and the depth-1 heuristic is intentionally conservative for known false-positive patterns documented in the code.
- **Version detection:** prefers the resolved version from `node_modules/@rspack/core/package.json` so `git+…`, `file:…`, `>=1.5 <2`, `npm:` aliases, and compound ranges don't get falsely classified. Falls back to the `package.json` specifier only for clean `^1.x`/`~1.x`/`1.x` strings; unrecognized formats return `nil` rather than guessing.
- **Hint cadence:** the doctor tip appears once per process, at the start of the first compilation. No extra duplicate on failure so `foreman`/dev-server reload loops don't spam the log.
- **Config extensions:** the doctor inspects `rspack.config.{ts,js}` (and the `webpack.config.{ts,js}` fallback) — the same files `Shakapacker::Runner#find_rspack_config_with_fallback` actually loads. `.mjs` / `.cjs` are silently skipped because the runner does not load them either.

## Test plan

- [x] `bundle exec rspec spec/shakapacker/doctor_spec.rb` — 119 examples including 20 in "rspack cache configuration checks"
- [x] `bundle exec rspec spec/shakapacker/compiler_spec.rb` — 27 examples including 3 in "doctor hint messages"
- [x] `bundle exec rubocop lib/shakapacker spec/shakapacker` — no offenses
- [ ] Manual verification in a real Rspack v2 app with `cache: false` in `config/rspack/rspack.config.js` that `bundle exec rake shakapacker:doctor` prints the new warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now warn when Rspack persistent caching is disabled, provide concrete "Fix:" hints, and flag Rspack v1 installs with upgrade advice.  
  * Compiler emits a one-time tip (shown after a failed compilation) suggesting running the diagnostic task.

* **Tests**
  * Added extensive tests covering cache validation, Rspack version detection, config resolution/precedence, numerous false-positive scenarios, and the compiler’s one-time diagnostic hint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new diagnostics that parse user Rspack config files and changes compiler logging on failed builds; low blast radius but the heuristic scanning could mis-warn or miss some edge cases.
> 
> **Overview**
> `shakapacker:doctor` now checks the *active* Rspack config (matching the runner’s resolution order) and warns if it detects top-level `cache: false`, including upgrade guidance when Rspack v1 is installed.
> 
> Doctor warning output was refactored to support structured “Fix” sub-items via `add_fix_hint`, improving formatting/indentation while keeping the parent warning’s severity.
> 
> The compiler now emits a thread-safe, once-per-process tip to run `bundle exec rake shakapacker:doctor` after the first failed compilation, and specs were expanded/updated to cover the new hint behavior and the cache/version detection edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1b9840b9c03dcf7a570fe301369f667b9eec63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->