### PR TITLE
fix: allow `webpack-dev-server` v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Allowed `webpack-dev-server` v6**. [PR #1102](https://github.com/shakacode/shakapacker/pull/1102) by [G-Rath](https://github.com/G-Rath).
+
 ### Fixed
 
 - **Fixed helper binstubs delegating Node resolution to Ruby `exec` in unset and empty `PATH` environments.** [PR #1200](https://github.com/shakacode/shakapacker/pull/1200) and [PR #1201](https://github.com/shakacode/shakapacker/pull/1201) by [justin808](https://github.com/justin808). Restores shell-compatible Node lookup for `bin/shakapacker-config` and `bin/diff-bundler-config` after the `v10.2.0` Ruby-binstub regression, while keeping friendly missing-Node errors for `ENOENT` and `EACCES`.

--- a/docs/dependency-strategy.md
+++ b/docs/dependency-strategy.md
@@ -150,7 +150,7 @@ Supplemental package for the standard webpack managed build experience.
 
 | Package                              | Range                | When needed       |
 | ------------------------------------ | -------------------- | ----------------- |
-| webpack-dev-server                   | `^5.2.2`             | Dev mode with HMR |
+| webpack-dev-server                   | `^5.2.2 \|\| ^6.0.0` | Dev mode with HMR |
 | mini-css-extract-plugin              | `^2.0.0`             | CSS extraction    |
 | webpack-subresource-integrity        | `^5.1.0`             | SRI hashes        |
 | @pmmmwh/react-refresh-webpack-plugin | `^0.5.0 \|\| ^0.6.0` | React HMR         |
@@ -225,7 +225,7 @@ The core `shakapacker` package keeps intentional optional peer ranges where comp
 {
   "devDependencies": {
     "shakapacker-webpack": "^11.0.0",
-    "webpack-dev-server": "^5.2.2",
+    "webpack-dev-server": "^6.0.0",
     "@swc/core": "^1.3.0",
     "swc-loader": "^0.2.0",
     "css-loader": "^7.0.0",

--- a/docs/peer-dependencies.md
+++ b/docs/peer-dependencies.md
@@ -30,7 +30,7 @@ releases support.
 "terser-webpack-plugin": "^5.3.1"
 "webpack-assets-manifest": "^5.0.6 || ^6.0.0"
 "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-"webpack-dev-server": "^5.2.2"
+"webpack-dev-server": "^5.2.2 || ^6.0.0"
 "webpack-subresource-integrity": "^5.1.0"
 ```
 

--- a/lib/install/package.json
+++ b/lib/install/package.json
@@ -11,7 +11,7 @@
     "webpack": "^5.101.0",
     "webpack-assets-manifest": "^5.0.6 || ^6.0.0",
     "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "webpack-dev-server": "^5.2.2",
+    "webpack-dev-server": "^5.2.2 || ^6.0.0",
     "webpack-merge": "^5.8.0 || ^6.0.0",
     "webpack-subresource-integrity": "^5.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "webpack": "^5.101.0",
     "webpack-assets-manifest": "^5.0.6 || ^6.0.0",
     "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "webpack-dev-server": "^5.2.2",
+    "webpack-dev-server": "^5.2.2 || ^6.0.0",
     "webpack-subresource-integrity": "^5.1.0"
   },
   "peerDependenciesMeta": {

--- a/packages/shakapacker-webpack/package.json
+++ b/packages/shakapacker-webpack/package.json
@@ -33,7 +33,7 @@
     "webpack": "^5.101.0",
     "webpack-cli": "^7.0.0",
     "webpack-assets-manifest": "^6.0.0",
-    "webpack-dev-server": "^5.2.2",
+    "webpack-dev-server": "^5.2.2 || ^6.0.0",
     "mini-css-extract-plugin": "^2.0.0",
     "webpack-subresource-integrity": "^5.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0 || ^0.6.0",


### PR DESCRIPTION
### Summary

This [version will be released in the next week or so](https://github.com/webpack/webpack-dev-server/issues/5662#issuecomment-4329992273), and importantly enables addressing GHSA-w5hq-g745-h8pq

The migration docs are [here](https://github.com/webpack/webpack-dev-server/blob/93c191a285101c94a72e5be180c997595cb330f3/migration-v6.md) - I don't think any of the breaking changes require any changes to Shakapacker

### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [x] Add/update test to cover these changes
- [x] Update documentation
- [ ] Update CHANGELOG file

### Other Information

<!--
  Mention any other important information that might relate to this PR but that don't belong in the summary,
  like detailed benchmarks or possible follow-up changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated peer dependency and dependency strategy guidance to include support for `webpack-dev-server` v6 (in addition to v5).
* **Chores**
  * Broadened `webpack-dev-server` version ranges across package and install configuration to support either v5 or v6.
* **Changelog**
  * Added an “Unreleased” note highlighting support for `webpack-dev-server` v6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->