### PR TITLE
[codex] Detect single-dot local shakapacker paths

### DIFF
--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,11 +67,10 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
-        # Matches package.json values that point at a local path: "../...", bare "..",
-        # or "file:..." at the start of the string. Bare "..foo" (two dots, no slash,
-        # non-empty suffix) is intentionally not matched — package managers don't emit
-        # that form.
-        LOCAL_PATH_REGEX = %r{\A(\.\.(/|\z)|file:)}.freeze
+        # Matches package.json values that point at a local path: "./...", "../...",
+        # bare "..", or "file:..." at the start of the string. Bare ".foo" or
+        # "..foo" forms are intentionally not matched.
+        LOCAL_PATH_REGEX = %r{\A(\./|\.\.(/|\z)|file:)}.freeze
 
         attr_reader :package_json
 

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,9 +67,7 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
-        # Matches package.json values that point at a local path: "./...", "../...",
-        # bare "..", or "file:..." at the start of the string. Bare ".foo" or
-        # "..foo" forms are intentionally not matched.
+        # Matches local paths package managers emit; excludes unsupported bare ".foo"/"..foo" forms.
         LOCAL_PATH_REGEX = %r{\A(\./|\.\.(/|\z)|file:)}.freeze
 
         attr_reader :package_json

--- a/lib/shakapacker/version_checker.rb
+++ b/lib/shakapacker/version_checker.rb
@@ -67,7 +67,9 @@ module Shakapacker
 
       # TODO: this might as well use package_json
       class NodePackageVersion
-        # Matches local paths package managers emit; excludes unsupported bare ".foo"/"..foo" forms.
+        # Matches local paths package managers emit: "./...", "../..", bare "..", or "file:...".
+        # Bare "..foo" (two dots, no slash, non-empty suffix) and bare "." are intentionally not
+        # matched — package managers don't emit those forms for shakapacker installs.
         LOCAL_PATH_REGEX = %r{\A(\./|\.\.(/|\z)|file:)}.freeze
 
         attr_reader :package_json

--- a/spec/fixtures/single_dot_path_package.json
+++ b/spec/fixtures/single_dot_path_package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "shakapacker": "./vendor/shakapacker"
+  },
+  "devDependencies": {
+    "right-pad": "^1.0.1"
+  }
+}

--- a/spec/fixtures/single_dot_path_yarn.v1.lock
+++ b/spec/fixtures/single_dot_path_yarn.v1.lock
@@ -1,2 +1,5 @@
+# Intentionally stale: key differs from package.json's ./vendor/shakapacker to simulate
+# a lockfile that was not updated after the local path was changed. The yarn parser's
+# greedy matcher still finds and returns "9.7.0", proving the short-circuit is necessary.
 shakapacker@./stale-lockfile-entry:
   version "9.7.0"

--- a/spec/fixtures/single_dot_path_yarn.v1.lock
+++ b/spec/fixtures/single_dot_path_yarn.v1.lock
@@ -1,0 +1,2 @@
+shakapacker@9.7.0:
+  version "9.7.0"

--- a/spec/fixtures/single_dot_path_yarn.v1.lock
+++ b/spec/fixtures/single_dot_path_yarn.v1.lock
@@ -1,2 +1,2 @@
-shakapacker@9.7.0:
+shakapacker@./stale-lockfile-entry:
   version "9.7.0"

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -100,6 +100,30 @@ describe "VersionChecker" do
 end
 
 describe "VersionChecker::NodePackageVersion" do
+  it "treats single-dot package.json dependencies as local paths before lockfiles" do
+    Dir.mktmpdir do |dir|
+      package_json = File.join(dir, "package.json")
+      File.write(package_json, <<~JSON)
+        {
+          "dependencies": {
+            "shakapacker": "./vendor/shakapacker"
+          }
+        }
+      JSON
+
+      node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
+        package_json,
+        File.expand_path("../fixtures/semver_exact_yarn.v1.lock", __dir__),
+        "file/does/not/exist",
+        "file/does/not/exist"
+      )
+
+      expect(node_package_version.raw).to eq "./vendor/shakapacker"
+      expect(node_package_version.major_minor_patch).to be nil
+      expect(node_package_version.skip_processing?).to be true
+    end
+  end
+
   context "with no lock file" do
     def node_package_version(fixture_version:)
       Shakapacker::VersionChecker::NodePackageVersion.new(

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -100,30 +100,6 @@ describe "VersionChecker" do
 end
 
 describe "VersionChecker::NodePackageVersion" do
-  it "treats single-dot package.json dependencies as local paths before lockfiles" do
-    Dir.mktmpdir do |dir|
-      package_json = File.join(dir, "package.json")
-      File.write(package_json, <<~JSON)
-        {
-          "dependencies": {
-            "shakapacker": "./vendor/shakapacker"
-          }
-        }
-      JSON
-
-      node_package_version = Shakapacker::VersionChecker::NodePackageVersion.new(
-        package_json,
-        File.expand_path("../fixtures/semver_exact_yarn.v1.lock", __dir__),
-        "file/does/not/exist",
-        "file/does/not/exist"
-      )
-
-      expect(node_package_version.raw).to eq "./vendor/shakapacker"
-      expect(node_package_version.major_minor_patch).to be nil
-      expect(node_package_version.skip_processing?).to be true
-    end
-  end
-
   context "with no lock file" do
     def node_package_version(fixture_version:)
       Shakapacker::VersionChecker::NodePackageVersion.new(
@@ -231,6 +207,28 @@ describe "VersionChecker::NodePackageVersion" do
 
       it "#semver_wildcard? returns false" do
         expect(node_package_version_from_relative_path.semver_wildcard?).to be false
+      end
+    end
+
+    context "when using a single-dot relative path" do
+      let(:node_package_version_from_single_dot_path) { node_package_version(fixture_version: "single_dot_path") }
+
+      it "#raw returns the single-dot relative path without consulting lockfiles" do
+        expect(File).not_to receive(:exist?)
+
+        expect(node_package_version_from_single_dot_path.raw).to eq "./vendor/shakapacker"
+      end
+
+      it "#major_minor_patch returns nil" do
+        expect(node_package_version_from_single_dot_path.major_minor_patch).to be nil
+      end
+
+      it "#skip_processing? returns true" do
+        expect(node_package_version_from_single_dot_path.skip_processing?).to be true
+      end
+
+      it "#semver_wildcard? returns false" do
+        expect(node_package_version_from_single_dot_path.semver_wildcard?).to be false
       end
     end
 
@@ -402,6 +400,26 @@ describe "VersionChecker::NodePackageVersion" do
 
       it "#semver_wildcard? returns false" do
         expect(node_package_version_from_relative_path.semver_wildcard?).to be false
+      end
+    end
+
+    context "when using a single-dot relative path" do
+      let(:node_package_version_from_single_dot_path) { node_package_version(fixture_version: "single_dot_path") }
+
+      it "#raw returns the single-dot relative path" do
+        expect(node_package_version_from_single_dot_path.raw).to eq "./vendor/shakapacker"
+      end
+
+      it "#major_minor_patch returns nil" do
+        expect(node_package_version_from_single_dot_path.major_minor_patch).to be nil
+      end
+
+      it "#skip_processing? returns true" do
+        expect(node_package_version_from_single_dot_path.skip_processing?).to be true
+      end
+
+      it "#semver_wildcard? returns false" do
+        expect(node_package_version_from_single_dot_path.semver_wildcard?).to be false
       end
     end
 

--- a/spec/shakapacker/version_checker_spec.rb
+++ b/spec/shakapacker/version_checker_spec.rb
@@ -407,6 +407,8 @@ describe "VersionChecker::NodePackageVersion" do
       let(:node_package_version_from_single_dot_path) { node_package_version(fixture_version: "single_dot_path") }
 
       it "#raw returns the single-dot relative path" do
+        expect(File).not_to receive(:exist?)
+
         expect(node_package_version_from_single_dot_path.raw).to eq "./vendor/shakapacker"
       end
 


### PR DESCRIPTION
## Summary

- extend `NodePackageVersion::LOCAL_PATH_REGEX` to treat `./...` package declarations as local paths
- add regression coverage proving `./vendor/shakapacker` short-circuits before a stale lockfile semver

Fixes #1103.

## Validation

- `bundle exec rspec spec/shakapacker/version_checker_spec.rb`
- `bundle exec rubocop lib/shakapacker/version_checker.rb spec/shakapacker/version_checker_spec.rb`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to local-path detection for package.json dependencies plus added test coverage; it only affects version-consistency checks for node installs using `./...` paths.
> 
> **Overview**
> Extends `VersionChecker::NodePackageVersion::LOCAL_PATH_REGEX` to classify `./...` dependency declarations as local-path installs (alongside `../...` and `file:`), so version checking short-circuits on these values instead of consulting lockfiles.
> 
> Adds fixtures and specs covering `./vendor/shakapacker`, including a regression case showing `raw` should return the package.json path without reading a potentially stale `yarn.lock` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad365c87a511fb5ce3bd0b5f685c80becae47ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced local path dependency recognition to support additional package manager specification formats, including single-dot relative paths.

* **Tests**
  * Added test coverage for local path dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->