### PR TITLE
[codex] Rewrite transpiler performance guide qualitatively

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/) for faster webpack-compatible builds!_
+_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/) — upstream benchmark: roughly [8–17x faster than webpack](https://rspack.rs/) on its reference React app, with full webpack compatibility!_
 
 _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 
@@ -275,7 +275,7 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 }
 ```
 
-**For Rspack + SWC (faster bundling):**
+**For Rspack + SWC (largest end-to-end speedup — see [transpiler-performance guide](./docs/transpiler-performance.md#published-benchmarks)):**
 
 ```json
 {
@@ -924,7 +924,7 @@ You can also change your Babel configuration by removing these lines in your `pa
 
 ### SWC configuration
 
-SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
+SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9). SWC's own benchmark reports being [20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/); end-to-end Shakapacker speedups are typically smaller but still substantial. New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
 
 **Note on defaults**: The installation template explicitly sets `javascript_transpiler: "swc"` for new projects. However, for backward compatibility, webpack's runtime default (when no explicit config exists) remains `"babel"`. Rspack always defaults to `"swc"`.
 
@@ -1284,8 +1284,8 @@ for a `.github/dependabot.yml` example that updates both in a single PR.
 For step-by-step guides on common migrations, see the [Common Upgrades Guide](./docs/common-upgrades.md):
 
 - [Migrating Package Managers](./docs/common-upgrades.md#migrating-package-managers) (Yarn ↔ npm, pnpm)
-- [Migrating from Babel to SWC](./docs/common-upgrades.md#migrating-from-babel-to-swc)
-- [Migrating from Webpack to Rspack](./docs/common-upgrades.md#migrating-from-webpack-to-rspack)
+- [Migrating from Babel to SWC](./docs/common-upgrades.md#migrating-from-babel-to-swc) (upstream: ~20x faster transpilation)
+- [Migrating from Webpack to Rspack](./docs/common-upgrades.md#migrating-from-webpack-to-rspack) (upstream: ~8–17x faster bundler)
 
 ### Paths
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/) — upstream benchmark: roughly [8–17x faster than webpack](https://rspack.rs/) on its reference React app, with full webpack compatibility!_
+_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/) — up to 17x faster than webpack per [upstream benchmarks](./docs/transpiler-performance.md#published-benchmarks)!_
 
 _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/)! 10x faster than webpack!_
+_🚀 Shakapacker 10 supports [Rspack](https://rspack.rs/) for faster webpack-compatible builds!_
 
 _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 
@@ -275,7 +275,7 @@ Depending on your setup, you'll need different subsets of the optional peer depe
 }
 ```
 
-**For Rspack + SWC (10x faster bundling):**
+**For Rspack + SWC (faster bundling):**
 
 ```json
 {
@@ -924,7 +924,7 @@ You can also change your Babel configuration by removing these lines in your `pa
 
 ### SWC configuration
 
-SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9; 20x faster than Babel). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
+SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default was introduced in v9). New installations use SWC by default via the installation template. You can read more at [SWC usage docs](./docs/using_swc_loader.md).
 
 **Note on defaults**: The installation template explicitly sets `javascript_transpiler: "swc"` for new projects. However, for backward compatibility, webpack's runtime default (when no explicit config exists) remains `"babel"`. Rspack always defaults to `"swc"`.
 
@@ -1284,8 +1284,8 @@ for a `.github/dependabot.yml` example that updates both in a single PR.
 For step-by-step guides on common migrations, see the [Common Upgrades Guide](./docs/common-upgrades.md):
 
 - [Migrating Package Managers](./docs/common-upgrades.md#migrating-package-managers) (Yarn ↔ npm, pnpm)
-- [Migrating from Babel to SWC](./docs/common-upgrades.md#migrating-from-babel-to-swc) (20-70x faster builds)
-- [Migrating from Webpack to Rspack](./docs/common-upgrades.md#migrating-from-webpack-to-rspack) (5-10x faster builds)
+- [Migrating from Babel to SWC](./docs/common-upgrades.md#migrating-from-babel-to-swc)
+- [Migrating from Webpack to Rspack](./docs/common-upgrades.md#migrating-from-webpack-to-rspack)
 
 ### Paths
 

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -277,7 +277,7 @@ pnpm run build
 
 ## Migrating from Babel to SWC
 
-SWC is a high-performance Rust-based JavaScript/TypeScript compiler that can be significantly faster than Babel. For complete details, see [JavaScript Transpiler Configuration](./transpiler-migration.md).
+SWC is a high-performance Rust-based JavaScript/TypeScript compiler. SWC reports being [20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/) in its own transpiler benchmark; the practical speedup on a full Shakapacker build is usually smaller but still substantial. For complete details, see [JavaScript Transpiler Configuration](./transpiler-migration.md).
 
 ### Quick Migration Steps
 
@@ -361,10 +361,18 @@ bundle exec rspec
 
 ### Performance Expectations
 
-SWC often improves transpilation time, especially when an app has many files or
-an expensive Babel plugin chain. Exact gains depend on project size,
-configuration, source maps, cache state, hardware, and whether you measure only
-transpilation or the full Shakapacker build.
+SWC's own benchmark reports being [20x faster than Babel single-threaded and
+70x faster on four cores](https://swc.rs/) for pure transpilation. A real
+Shakapacker build also runs CSS processing, minification, source map
+generation, and your plugin chain, so the end-to-end speedup is typically
+smaller than the transpiler number in isolation — but the transpiler is
+usually the dominant cost on Babel-heavy projects, so the move is almost
+always a large win.
+
+Exact gains depend on project size, configuration, source maps, cache state,
+hardware, and whether you measure only transpilation or the full Shakapacker
+build. See [Measuring Your App](./transpiler-performance.md#measuring-your-app)
+for how to confirm the gain on your codebase.
 
 ### Common Issues
 
@@ -410,7 +418,7 @@ bundle exec rake shakapacker:compile
 
 ## Migrating from Webpack to Rspack
 
-[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility. For complete details, see [Rspack Migration Guide](./rspack_migration_guide.md).
+[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility. Rspack's published benchmark on a 5,000-component React app reports roughly 8x faster production builds, 10–15x faster development startup, and 17x faster HMR vs webpack ([rspack.rs](https://rspack.rs/), [benchmark sources](https://github.com/rstackjs/build-tools-performance)). For complete details, see [Rspack Migration Guide](./rspack_migration_guide.md).
 
 ### Quick Migration Steps
 
@@ -612,9 +620,20 @@ bin/shakapacker-dev-server
 
 ### Performance Benefits
 
-Rspack can improve cold builds, hot reloads, and production builds, but exact
-gains vary by project size, configuration, cache state, and hardware. Measure
-your real build and development workflows before relying on a specific speedup.
+Rspack's own published benchmark on a 5,000-component React app reports:
+
+| Workload               | Webpack 5 | Rspack | Approx. speedup |
+| ---------------------- | --------- | ------ | --------------- |
+| Cold development start | ~8.2s     | ~0.7s  | ~10x            |
+| Cold production build  | ~9.5s     | ~1.6s  | ~6x             |
+| HMR update             | ~2.8s     | ~160ms | ~17x            |
+
+Source: [rspack.rs](https://rspack.rs/) and [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance) (`react-5k` case).
+
+Real Shakapacker apps will land somewhere in this range depending on project
+size, configuration, source maps, cache state, and hardware. Measure your real
+build and development workflows to confirm the gain on your app — see
+[Measuring Your App](./transpiler-performance.md#measuring-your-app).
 
 ### Common Issues
 
@@ -660,9 +679,10 @@ For maximum performance improvements, you can combine multiple migrations:
 
 ### Recommended: Webpack + Babel → Rspack + SWC
 
-This combination provides the best opportunity for broad build performance improvements:
+This combination provides the largest end-to-end build performance improvement available in Shakapacker: SWC handles transpilation in Rust (upstream reports up to [20x/70x vs Babel](https://swc.rs/)) and Rspack handles the rest of the bundler pipeline in Rust (upstream reports roughly [8–17x vs webpack on its own benchmark](https://rspack.rs/)). Apply them in order so you can attribute any regression to the right layer:
 
 1. **First, migrate to SWC** (while still on webpack)
+
    - Follow [Migrating from Babel to SWC](#migrating-from-babel-to-swc)
    - Test thoroughly
    - This is a smaller change to validate first

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -269,7 +269,7 @@ pnpm run build
 
 #### pnpm benefits
 
-- **Faster installs**: Up to 2x faster than npm/Yarn
+- **Faster installs**: Often faster than npm/Yarn
 - **Disk space efficient**: Uses hard links to save disk space
 - **Strict**: Better at catching dependency issues
 
@@ -277,7 +277,7 @@ pnpm run build
 
 ## Migrating from Babel to SWC
 
-SWC is a Rust-based JavaScript/TypeScript compiler that's significantly faster than Babel (20-70x on multi-core with optimal setup, 5-7.5x in typical single-threaded scenarios). For complete details, see [JavaScript Transpiler Configuration](./transpiler-migration.md).
+SWC is a high-performance Rust-based JavaScript/TypeScript compiler that can be significantly faster than Babel. For complete details, see [JavaScript Transpiler Configuration](./transpiler-migration.md).
 
 ### Quick Migration Steps
 
@@ -361,15 +361,10 @@ bundle exec rspec
 
 ### Performance Expectations
 
-Typical build time improvements when migrating from Babel to SWC (single-threaded transpilation):
-
-| Project Size           | Babel | SWC | Improvement |
-| ---------------------- | ----- | --- | ----------- |
-| Small (<100 files)     | 5s    | 1s  | 5x faster   |
-| Medium (100-500 files) | 20s   | 3s  | 6.7x faster |
-| Large (500+ files)     | 60s   | 8s  | 7.5x faster |
-
-**Note:** With multi-core optimization and ideal conditions, SWC can achieve 20-70x improvements over Babel.
+SWC often improves transpilation time, especially when an app has many files or
+an expensive Babel plugin chain. Exact gains depend on project size,
+configuration, source maps, cache state, hardware, and whether you measure only
+transpilation or the full Shakapacker build.
 
 ### Common Issues
 
@@ -415,7 +410,7 @@ bundle exec rake shakapacker:compile
 
 ## Migrating from Webpack to Rspack
 
-[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust, offering 5-10x faster build times than webpack with excellent webpack compatibility. For complete details, see [Rspack Migration Guide](./rspack_migration_guide.md).
+[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility. For complete details, see [Rspack Migration Guide](./rspack_migration_guide.md).
 
 ### Quick Migration Steps
 
@@ -617,15 +612,9 @@ bin/shakapacker-dev-server
 
 ### Performance Benefits
 
-Typical build time improvements when migrating from webpack to Rspack:
-
-| Build Type       | Webpack | Rspack | Improvement |
-| ---------------- | ------- | ------ | ----------- |
-| Cold build       | 60s     | 8s     | 7.5x faster |
-| Hot reload       | 3s      | 0.5s   | 6x faster   |
-| Production build | 120s    | 15s    | 8x faster   |
-
-**Note:** Actual improvements vary based on project size, configuration, and hardware. Rspack's Rust-based architecture provides consistent 5-10x performance gains across most scenarios.
+Rspack can improve cold builds, hot reloads, and production builds, but exact
+gains vary by project size, configuration, cache state, and hardware. Measure
+your real build and development workflows before relying on a specific speedup.
 
 ### Common Issues
 
@@ -671,7 +660,7 @@ For maximum performance improvements, you can combine multiple migrations:
 
 ### Recommended: Webpack + Babel → Rspack + SWC
 
-This combination provides the best performance improvement (up to 50-70x faster builds):
+This combination provides the best opportunity for broad build performance improvements:
 
 1. **First, migrate to SWC** (while still on webpack)
    - Follow [Migrating from Babel to SWC](#migrating-from-babel-to-swc)

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -269,7 +269,7 @@ pnpm run build
 
 #### pnpm benefits
 
-- **Faster installs**: Often faster than npm/Yarn
+- **Faster installs**: Uses pnpm's content-addressable store and hard links to speed up repeat installs
 - **Disk space efficient**: Uses hard links to save disk space
 - **Strict**: Better at catching dependency issues
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ assets_bundler_config_path: "."
 Specifies which transpiler to use for JavaScript/TypeScript.
 
 ```yaml
-# Use SWC (recommended - 20x faster than Babel, set by default in new installations)
+# Use SWC (recommended faster default for new installations)
 javascript_transpiler: "swc"
 
 # Use Babel (for maximum compatibility, webpack runtime default if not configured)
@@ -115,7 +115,7 @@ javascript_transpiler: "esbuild"
 - **Webpack runtime default**: If not explicitly configured, defaults to `"babel"` for backward compatibility
 - **Rspack runtime default**: If not explicitly configured, defaults to `"swc"` as rspack is a newer bundler
 
-See [Transpiler Performance Guide](transpiler-performance.md) for benchmarks and migration guides.
+See [Transpiler Performance Guide](transpiler-performance.md) for performance tradeoffs and migration guidance.
 
 ## Source Configuration
 
@@ -674,7 +674,7 @@ console.log(process.env.FEATURE_FLAGS)
 ## Best Practices
 
 1. **Use default paths** unless you have a specific reason to change them
-2. **Enable SWC transpiler** for faster builds (20x faster than Babel)
+2. **Enable SWC transpiler** for faster builds
 3. **Use rspack** for even faster builds if compatible with your setup
 4. **Cache manifest** in production for better performance
 5. **Enable integrity hashes** in production for security

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ assets_bundler_config_path: "."
 Specifies which transpiler to use for JavaScript/TypeScript.
 
 ```yaml
-# Use SWC (recommended faster default for new installations)
+# Use SWC (recommended - upstream benchmark: ~20x faster than Babel; set by default in new installations)
 javascript_transpiler: "swc"
 
 # Use Babel (for maximum compatibility, webpack runtime default if not configured)
@@ -115,7 +115,7 @@ javascript_transpiler: "esbuild"
 - **Webpack runtime default**: If not explicitly configured, defaults to `"babel"` for backward compatibility
 - **Rspack runtime default**: If not explicitly configured, defaults to `"swc"` as rspack is a newer bundler
 
-See [Transpiler Performance Guide](transpiler-performance.md) for performance tradeoffs and migration guidance.
+See [Transpiler Performance Guide](transpiler-performance.md) for cited benchmarks, performance tradeoffs, and migration guidance.
 
 ## Source Configuration
 
@@ -674,8 +674,8 @@ console.log(process.env.FEATURE_FLAGS)
 ## Best Practices
 
 1. **Use default paths** unless you have a specific reason to change them
-2. **Enable SWC transpiler** for faster builds
-3. **Use rspack** for even faster builds if compatible with your setup
+2. **Enable SWC transpiler** for faster builds (upstream reports ~20x vs Babel)
+3. **Use rspack** for an even larger bundler-level speedup (upstream reports ~8–17x vs webpack on its own benchmark) if compatible with your setup
 4. **Cache manifest** in production for better performance
 5. **Enable integrity hashes** in production for security
 6. **Keep development and production configs aligned** except for optimization settings

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -63,7 +63,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 }
 ```
 
-### Webpack + SWC (20x Faster)
+### Webpack + SWC
 
 ```json
 {
@@ -79,7 +79,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 
 > **Note:** `webpack-cli` v7 is also supported but requires Node.js >= 20.9.0. If your project meets that requirement, you can use `"webpack-cli": "^7.0.0"` instead.
 
-### Rspack + SWC (10x Faster Bundling)
+### Rspack + SWC
 
 ```json
 {

--- a/docs/optional-peer-dependencies.md
+++ b/docs/optional-peer-dependencies.md
@@ -63,7 +63,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 }
 ```
 
-### Webpack + SWC
+### Webpack + SWC (faster transpilation — see [benchmarks](./transpiler-performance.md#published-benchmarks))
 
 ```json
 {
@@ -79,7 +79,7 @@ Type-only imports are erased during compilation and don't trigger module resolut
 
 > **Note:** `webpack-cli` v7 is also supported but requires Node.js >= 20.9.0. If your project meets that requirement, you can use `"webpack-cli": "^7.0.0"` instead.
 
-### Rspack + SWC
+### Rspack + SWC (largest end-to-end speedup — see [benchmarks](./transpiler-performance.md#published-benchmarks))
 
 ```json
 {

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -160,10 +160,12 @@ The same dev server configuration in `shakapacker.yml` applies to both webpack a
 
 Rspack typically provides:
 
-- **Often faster cold builds**
-- **Often faster incremental builds**
-- **Often faster HMR** (Hot Module Replacement)
-- **Often lower memory usage**
+- **Substantially faster cold builds** — Rspack's own benchmark reports roughly 8x faster production builds on a 5,000-component React app ([rspack.rs](https://rspack.rs/), [benchmark sources](https://github.com/rstackjs/build-tools-performance))
+- **Substantially faster development startup** — roughly 10–15x in the same benchmark
+- **Substantially faster HMR** — roughly 17x in the same benchmark
+- **Lower memory usage** in most reported cases
+
+Actual gains depend on project size, configuration, source maps, cache state, and hardware. See [Transpiler Performance Guide](./transpiler-performance.md) for measurement guidance.
 
 ## Migration Checklist
 

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -160,8 +160,8 @@ The same dev server configuration in `shakapacker.yml` applies to both webpack a
 
 Rspack typically provides:
 
-- **2-10x faster** cold builds
-- **5-20x faster** incremental builds
+- **Faster cold builds**
+- **Faster incremental builds**
 - **Faster HMR** (Hot Module Replacement)
 - **Lower memory usage**
 

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -163,7 +163,7 @@ Rspack typically provides:
 - **Often faster cold builds**
 - **Often faster incremental builds**
 - **Often faster HMR** (Hot Module Replacement)
-- **Lower memory usage**
+- **Often lower memory usage**
 
 ## Migration Checklist
 

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -160,9 +160,9 @@ The same dev server configuration in `shakapacker.yml` applies to both webpack a
 
 Rspack typically provides:
 
-- **Faster cold builds**
-- **Faster incremental builds**
-- **Faster HMR** (Hot Module Replacement)
+- **Often faster cold builds**
+- **Often faster incremental builds**
+- **Often faster HMR** (Hot Module Replacement)
 - **Lower memory usage**
 
 ## Migration Checklist

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -23,7 +23,7 @@
 
 This guide documents the differences between webpack and Rspack configurations in Shakapacker, and provides migration guidance for users switching to Rspack.
 
-[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust, offering 5-10x faster build times than webpack with excellent webpack compatibility.
+[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility.
 
 ## Before You Migrate
 
@@ -74,7 +74,7 @@ Rspack provides built-in loaders for better performance:
 **JavaScript/TypeScript:**
 
 - Use `builtin:swc-loader` instead of `babel-loader` or `ts-loader`
-- 20x faster than Babel on single thread, 70x on multiple cores
+- Usually much faster than Babel in transpilation-heavy builds
 - Configuration example:
 
 ```javascript
@@ -801,13 +801,10 @@ npx patch-package @package/name
 
 **Expected Performance Improvements:**
 
-| Build Type       | Webpack | Rspack | Improvement |
-| ---------------- | ------- | ------ | ----------- |
-| Cold build       | 60s     | 8s     | 7.5x faster |
-| Hot reload       | 3s      | 0.5s   | 6x faster   |
-| Production build | 120s    | 15s    | 8x faster   |
-
-**Note:** Actual improvements vary based on project size, configuration, and hardware. Rspack's Rust-based architecture provides consistent 5-10x performance gains across most scenarios.
+Rspack can improve cold builds, hot reloads, and production builds. Actual
+results vary based on project size, configuration, cache state, source maps, and
+hardware, so measure your real Shakapacker commands before relying on a specific
+speedup.
 
 ## Debugging Configuration
 

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -23,7 +23,7 @@
 
 This guide documents the differences between webpack and Rspack configurations in Shakapacker, and provides migration guidance for users switching to Rspack.
 
-[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility.
+[Rspack](https://rspack.rs/) is a high-performance bundler written in Rust with excellent webpack compatibility. Rspack's own published benchmark on a 5,000-component React app reports roughly 8x faster production builds, 10–15x faster development startup, and 17x faster HMR vs webpack ([rspack.rs](https://rspack.rs/), [benchmark sources](https://github.com/rstackjs/build-tools-performance)). Real-world Shakapacker apps will land somewhere in this range depending on size, configuration, and cache state.
 
 ## Before You Migrate
 
@@ -74,7 +74,7 @@ Rspack provides built-in loaders for better performance:
 **JavaScript/TypeScript:**
 
 - Use `builtin:swc-loader` instead of `babel-loader` or `ts-loader`
-- Usually much faster than Babel in transpilation-heavy builds
+- SWC reports being [20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/) in its own benchmark; the practical speedup on a Shakapacker build is usually smaller but still substantial
 - Configuration example:
 
 ```javascript
@@ -422,6 +422,7 @@ baseConfig.module.rules.forEach((rule) => {
 When upgrading to Shakapacker v10 with Rspack (or any v9+ app):
 
 1. **CSS Modules default exports → named exports**: This is a breaking change. Either:
+
    - Update your code to use named imports (recommended for new projects)
    - Override the configuration to keep default exports (easier for existing large codebases)
 
@@ -801,10 +802,20 @@ npx patch-package @package/name
 
 **Expected Performance Improvements:**
 
-Rspack can improve cold builds, hot reloads, and production builds. Actual
-results vary based on project size, configuration, cache state, source maps, and
-hardware, so measure your real Shakapacker commands before relying on a specific
-speedup.
+Rspack's own published benchmark on a 5,000-component React app reports:
+
+| Workload               | Webpack 5 | Rspack | Approx. speedup |
+| ---------------------- | --------- | ------ | --------------- |
+| Cold development start | ~8.2s     | ~0.7s  | ~10x            |
+| Cold production build  | ~9.5s     | ~1.6s  | ~6x             |
+| HMR update             | ~2.8s     | ~160ms | ~17x            |
+
+Source: [rspack.rs](https://rspack.rs/) and [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance) (`react-5k` case).
+
+These are upstream micro-benchmarks. Real Shakapacker apps will land somewhere
+in this range depending on project size, configuration, source maps, cache
+state, and hardware, so measure your real Shakapacker commands to confirm the
+gain on your app — see [Measuring Your App](./transpiler-performance.md#measuring-your-app).
 
 ## Debugging Configuration
 

--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -6,7 +6,7 @@
 
 Shakapacker v10 transpiler defaults depend on the bundler and installation:
 
-- **New installations (v9+, including v10)**: `swc` - Installation template explicitly sets SWC for faster default transpilation
+- **New installations (v9+, including v10)**: `swc` - Installation template explicitly sets SWC, which upstream reports as [20x faster than Babel single-threaded and 70x on four cores](https://swc.rs/)
 - **Webpack runtime default**: `babel` - Used when no explicit config is provided (maintains backward compatibility)
 - **Rspack runtime default**: `swc` - Rspack defaults to SWC as it's a newer bundler with modern defaults
 
@@ -15,8 +15,8 @@ Shakapacker v10 transpiler defaults depend on the bundler and installation:
 ## Available Transpilers
 
 - `babel` - Traditional JavaScript transpiler with wide ecosystem support
-- `swc` - High-performance Rust-based transpiler
-- `esbuild` - Go-based transpiler, extremely fast
+- `swc` - High-performance Rust-based transpiler; upstream reports [20x faster than Babel single-threaded and 70x on four cores](https://swc.rs/)
+- `esbuild` - Go-based transpiler; extremely fast for supported transforms ([benchmark](https://esbuild.github.io/))
 - `none` - No transpilation (use native JavaScript)
 
 ## Configuration
@@ -90,11 +90,16 @@ yarn add --dev @rspack/plugin-react-refresh
 
 ### Performance Expectations
 
-SWC often reduces transpilation time significantly, especially in projects with
-many files or expensive Babel plugin chains. Treat published benchmark numbers
-as directional only; measure your own app with its real Shakapacker command,
-source map settings, cache state, and CI hardware before relying on a specific
-speedup.
+SWC's own benchmark reports being [20x faster than Babel single-threaded and
+70x faster on four cores](https://swc.rs/) for pure transpilation. Transpilation
+is usually the dominant cost in Babel-heavy Shakapacker builds, so this
+translates into a large end-to-end win for most apps, even though the full
+Shakapacker pipeline (CSS, minification, source maps, plugins) means the
+end-to-end speedup is usually smaller than the pure-transpiler number.
+
+Confirm the gain on your codebase by following
+[Measuring Your App](./transpiler-performance.md#measuring-your-app) before and
+after the migration.
 
 ### Compatibility Notes
 

--- a/docs/transpiler-migration.md
+++ b/docs/transpiler-migration.md
@@ -6,7 +6,7 @@
 
 Shakapacker v10 transpiler defaults depend on the bundler and installation:
 
-- **New installations (v9+, including v10)**: `swc` - Installation template explicitly sets SWC (20x faster than Babel)
+- **New installations (v9+, including v10)**: `swc` - Installation template explicitly sets SWC for faster default transpilation
 - **Webpack runtime default**: `babel` - Used when no explicit config is provided (maintains backward compatibility)
 - **Rspack runtime default**: `swc` - Rspack defaults to SWC as it's a newer bundler with modern defaults
 
@@ -15,7 +15,7 @@ Shakapacker v10 transpiler defaults depend on the bundler and installation:
 ## Available Transpilers
 
 - `babel` - Traditional JavaScript transpiler with wide ecosystem support
-- `swc` - Rust-based transpiler, 20-70x faster than Babel
+- `swc` - High-performance Rust-based transpiler
 - `esbuild` - Go-based transpiler, extremely fast
 - `none` - No transpilation (use native JavaScript)
 
@@ -88,15 +88,13 @@ yarn add --dev @pmmmwh/react-refresh-webpack-plugin
 yarn add --dev @rspack/plugin-react-refresh
 ```
 
-### Performance Comparison
+### Performance Expectations
 
-Typical build time improvements when migrating from Babel to SWC:
-
-| Project Size           | Babel | SWC | Improvement |
-| ---------------------- | ----- | --- | ----------- |
-| Small (<100 files)     | 5s    | 1s  | 5x faster   |
-| Medium (100-500 files) | 20s   | 3s  | 6.7x faster |
-| Large (500+ files)     | 60s   | 8s  | 7.5x faster |
+SWC often reduces transpilation time significantly, especially in projects with
+many files or expensive Babel plugin chains. Treat published benchmark numbers
+as directional only; measure your own app with its real Shakapacker command,
+source map settings, cache state, and CI hardware before relying on a specific
+speedup.
 
 ### Compatibility Notes
 

--- a/docs/transpiler-performance.md
+++ b/docs/transpiler-performance.md
@@ -1,156 +1,130 @@
-# JavaScript Transpiler Performance Benchmarks
+# JavaScript Transpiler Performance Guide
 
-This document provides performance benchmarks comparing different JavaScript transpilers supported by Shakapacker.
+Shakapacker supports Babel, SWC, and esbuild for webpack-based JavaScript
+transpilation. Rspack uses its built-in SWC-based loader by default.
 
-## Executive Summary
+This guide intentionally avoids exact benchmark numbers. Build performance
+depends heavily on project size, loader configuration, source maps, minification,
+cache state, hardware, and whether the measurement covers transpilation alone or
+the full bundler pipeline.
 
-| Transpiler  | Relative Speed | Configuration    | Best For                                       |
-| ----------- | -------------- | ---------------- | ---------------------------------------------- |
-| **SWC**     | **20x faster** | Zero config      | Production builds, large codebases             |
-| **esbuild** | **15x faster** | Minimal config   | Modern browsers, simple transformations        |
-| **Babel**   | **Baseline**   | Extensive config | Legacy browser support, custom transformations |
+## Summary
 
-## Detailed Benchmarks
+| Transpiler  | Performance Profile            | Configuration Profile | Best Fit                                     |
+| ----------- | ------------------------------ | --------------------- | -------------------------------------------- |
+| **SWC**     | Usually much faster than Babel | Moderate              | Default choice for most new Shakapacker apps |
+| **esbuild** | Usually very fast              | Minimal               | Modern syntax with simple transform needs    |
+| **Babel**   | Usually slowest                | Most flexible         | Existing Babel plugins or custom transforms  |
 
-### Test Environment
+SWC is the recommended default for new Shakapacker apps because it usually gives
+large speedups over Babel while covering the common JavaScript, TypeScript, and
+React cases. esbuild can also be very fast, but its transform model is less
+compatible with Babel-style plugin workflows.
 
-- **Hardware**: MacBook Pro M1, 16GB RAM
-- **Node Version**: 20.x
-- **Project Size Categories**:
-  - Small: < 100 files
-  - Medium: 100-1000 files
-  - Large: 1000+ files
+## What Usually Affects Build Time
 
-### Build Time Comparison
+The transpiler is only one part of a Shakapacker build. Measure the whole build
+before attributing performance to one tool.
 
-#### Small Project (<100 files, ~50KB total)
+Common factors:
 
-```text
-SWC:      0.3s  (20x faster)
-esbuild:  0.4s  (15x faster)
-Babel:    6.0s  (baseline)
-```
+- Source map mode
+- TypeScript type-checking outside the transpiler
+- Minification and CSS processing
+- Babel plugin count and plugin behavior
+- Webpack vs Rspack
+- Filesystem cache state
+- Number and size of entry points
+- Number of files outside `node_modules` processed by rules
+- CI hardware and CPU concurrency
 
-#### Medium Project (500 files, ~2MB total)
+When comparing options, run the same command several times after clearing or
+warming caches intentionally. Record the command, environment, lockfile, and
+Shakapacker config alongside the results.
 
-```text
-SWC:      1.2s  (25x faster)
-esbuild:  1.8s  (17x faster)
-Babel:    30s   (baseline)
-```
+## Choosing a Transpiler
 
-#### Large Project (2000 files, ~10MB total)
+### Choose SWC When
 
-```text
-SWC:      4.5s  (22x faster)
-esbuild:  6.2s  (16x faster)
-Babel:    100s  (baseline)
-```
+- You are starting a new app.
+- You want a faster default than Babel without moving to Rspack yet.
+- You use common JavaScript, TypeScript, JSX, or TSX transforms.
+- You can configure the few project-specific SWC options you need in
+  `config/swc.config.js`.
 
-### Memory Usage
+See [Using SWC Loader](./using_swc_loader.md).
 
-| Transpiler  | Peak Memory (Small) | Peak Memory (Medium) | Peak Memory (Large) |
-| ----------- | ------------------- | -------------------- | ------------------- |
-| **SWC**     | 150MB               | 250MB                | 450MB               |
-| **esbuild** | 180MB               | 300MB                | 500MB               |
-| **Babel**   | 350MB               | 600MB                | 1200MB              |
+### Choose esbuild When
 
-## Incremental Build Performance
+- You target modern browsers or have a simple transpilation target.
+- You do not rely on Babel plugins, Babel macros, or transform behavior that
+  esbuild does not implement.
+- You want a small configuration surface.
 
-For development with watch mode enabled:
+See [Using esbuild-loader](./using_esbuild_loader.md).
 
-| Transpiler  | Initial Build | Incremental Build | HMR Update |
-| ----------- | ------------- | ----------------- | ---------- |
-| **SWC**     | 1.2s          | 0.1s              | <50ms      |
-| **esbuild** | 1.8s          | 0.15s             | <70ms      |
-| **Babel**   | 30s           | 2-5s              | 200-500ms  |
+### Choose Babel When
 
-## Feature Comparison
+- You already rely on Babel plugins or Babel macros.
+- You need custom transforms that do not have SWC or esbuild equivalents.
+- You have mature Babel configuration that is more important than raw build
+  speed.
+- You need compatibility with old browser targets that your SWC/esbuild setup
+  does not cover.
+
+See [Customizing Babel Config](./customizing_babel_config.md).
+
+## Compatibility Tradeoffs
 
 ### SWC
 
-- ✅ TypeScript support built-in
-- ✅ JSX/TSX transformation
-- ✅ Minification built-in
-- ✅ Tree-shaking support
-- ✅ Source maps
-- ⚠️ Limited plugin ecosystem
-- ⚠️ Newer, less battle-tested
+Strengths:
+
+- Fast Rust implementation
+- JavaScript, TypeScript, JSX, and TSX support
+- Good fit for React applications
+- Works well with Shakapacker's default config
+
+Watch for:
+
+- Smaller plugin ecosystem than Babel
+- Project-specific transform options may need `config/swc.config.js`
+- Stimulus apps should preserve class names; see
+  [Using SWC with Stimulus](./using_swc_loader.md#using-swc-with-stimulus)
+- `.swcrc` can override Shakapacker defaults in surprising ways; prefer
+  `config/swc.config.js`
 
 ### esbuild
 
-- ✅ TypeScript support built-in
-- ✅ JSX transformation
-- ✅ Extremely fast bundling
-- ✅ Tree-shaking support
-- ⚠️ Limited transformation options
-- ❌ No plugin system for custom transforms
+Strengths:
+
+- Very fast Go implementation
+- Simple configuration
+- Good fit for modern JavaScript and TypeScript transpilation
+
+Watch for:
+
+- Not a Babel-compatible plugin system
+- Some TypeScript and transform options are intentionally unsupported
+- Decorators and framework-specific transforms may need extra care
 
 ### Babel
 
-- ✅ Most comprehensive browser support
-- ✅ Extensive plugin ecosystem
-- ✅ Custom transformation support
-- ✅ Battle-tested in production
-- ❌ Slowest performance
-- ❌ Complex configuration
+Strengths:
 
-## Recommendations by Use Case
+- Largest plugin ecosystem
+- Mature support for custom transformations
+- Good fit for apps that already have working Babel config
 
-### Choose SWC when:
+Watch for:
 
-- Performance is critical
-- Using modern JavaScript/TypeScript
-- Building large applications
-- Need fast development feedback loops
-- Default choice for new projects
-
-### Choose esbuild when:
-
-- Need the absolute fastest builds
-- Targeting modern browsers only
-- Simple transformation requirements
-- Minimal configuration preferred
-
-### Choose Babel when:
-
-- Need extensive browser compatibility (IE11, etc.)
-- Using experimental JavaScript features
-- Require specific Babel plugins
-- Have existing Babel configuration
-
-## Migration Impact
-
-### From Babel to SWC
-
-- **Build time reduction**: 90-95%
-- **Memory usage reduction**: 50-70%
-- **Configuration simplification**: 80% less config
-- **Developer experience**: Significantly improved
-
-### Real-world Examples
-
-#### E-commerce Platform (1500 components)
-
-- **Before (Babel)**: 120s production build
-- **After (SWC)**: 5.5s production build
-- **Improvement**: 95.4% faster
-
-#### SaaS Dashboard (800 files)
-
-- **Before (Babel)**: 45s development build
-- **After (SWC)**: 2.1s development build
-- **Improvement**: 95.3% faster
-
-#### Blog Platform (200 files)
-
-- **Before (Babel)**: 15s build time
-- **After (SWC)**: 0.8s build time
-- **Improvement**: 94.7% faster
+- Slower builds on large codebases
+- More configuration to maintain
+- Plugin behavior can be hard to compare directly with SWC or esbuild
 
 ## How to Switch Transpilers
 
-### To SWC (Recommended)
+### SWC
 
 ```yaml
 # config/shakapacker.yml
@@ -161,7 +135,7 @@ javascript_transpiler: "swc"
 npm install @swc/core swc-loader
 ```
 
-### To esbuild
+### esbuild
 
 ```yaml
 # config/shakapacker.yml
@@ -172,7 +146,7 @@ javascript_transpiler: "esbuild"
 npm install esbuild esbuild-loader
 ```
 
-### To Babel
+### Babel
 
 ```yaml
 # config/shakapacker.yml
@@ -183,18 +157,50 @@ javascript_transpiler: "babel"
 npm install babel-loader @babel/core @babel/preset-env
 ```
 
-## Testing Methodology
+Replace `npm` with your app's package manager when using Yarn, pnpm, or Bun.
 
-Benchmarks were conducted using:
+## Measuring Your App
 
-1. Clean builds (no cache)
-2. Average of 10 runs
-3. Same source code for all transpilers
-4. Production optimizations enabled
-5. Source maps disabled for fair comparison
+Use your app's real build command rather than a synthetic number from another
+project:
 
-## Conclusion
+```bash
+time bin/shakapacker
+```
 
-For most projects, **SWC provides the best balance** of performance, features, and ease of use. It offers a 20x performance improvement over Babel with minimal configuration required.
+For development feedback, measure the dev server or watch workflow you actually
+use:
 
-Consider your specific requirements around browser support, plugin needs, and existing infrastructure when choosing a transpiler. The performance gains from switching to SWC or esbuild can significantly improve developer productivity and CI/CD pipeline efficiency.
+```bash
+time bin/shakapacker-dev-server
+```
+
+For CI, measure the full command sequence, including dependency install and
+asset compilation if those are part of the job.
+
+Record:
+
+- Ruby, Node.js, package manager, and Shakapacker versions
+- Bundler (`webpack` or `rspack`)
+- Transpiler (`babel`, `swc`, or `esbuild`)
+- `NODE_ENV` and `RAILS_ENV`
+- Whether caches were warm or cold
+- Source map and minification settings
+- Hardware or CI runner type
+
+## Migration Guidance
+
+For most apps, migrate incrementally:
+
+1. Commit the current working build.
+2. Switch from Babel to SWC or esbuild.
+3. Run the test suite and a production build.
+4. Compare build output and browser behavior.
+5. Keep Babel only for the paths that need Babel-specific transforms.
+
+If you want the biggest bundler-level performance change, evaluate
+[Rspack](./rspack_migration_guide.md) separately from the transpiler change so
+you can attribute any regressions to the right layer.
+
+See [Transpiler Migration](./transpiler-migration.md) for step-by-step migration
+commands.

--- a/docs/transpiler-performance.md
+++ b/docs/transpiler-performance.md
@@ -2,21 +2,40 @@
 
 Shakapacker supports Babel, SWC, and esbuild for webpack-based JavaScript transpilation. Rspack uses its built-in SWC-based loader by default.
 
-This guide intentionally avoids exact benchmark numbers. Build performance depends heavily on project size, loader configuration, source maps, minification, cache state, hardware, and whether the measurement covers transpilation alone or the full bundler pipeline.
+For most apps, moving off Babel is the single highest-impact change you can make to build performance. Moving from webpack to Rspack on top of that is usually the next biggest win. The numbers below come from the upstream projects' own published benchmarks, so treat them as a realistic upper bound rather than a guarantee for your app.
+
+## Published Benchmarks
+
+Use these as a starting point, then [measure your own app](#measuring-your-app):
+
+- **SWC vs Babel**: SWC reports being **[20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/)** on its own transpiler benchmark.
+- **Rspack vs webpack**: The official Rspack landing page reports roughly **[10x faster development startup, ~8x faster production builds, and ~17x faster HMR](https://rspack.rs/)** on its reference React app, with [full benchmark sources in `rstackjs/build-tools-performance`](https://github.com/rstackjs/build-tools-performance). Numbers vary by case size; cold builds of the `react-5k` case run in roughly 1.6s on Rspack vs ~9.5s on webpack.
+- **esbuild vs other bundlers**: esbuild's homepage benchmark bundles 10 copies of three.js in **[~0.4s with esbuild vs ~41s with webpack 5](https://esbuild.github.io/)** (minified, with source maps).
+
+These are upstream micro-benchmarks. Your Shakapacker build also runs CSS processing, minification, source map generation, plugin chains, and Rails-side hooks, so end-to-end speedups are typically smaller than the transpiler or bundler number in isolation. They are still very substantial for most apps.
 
 ## Summary
 
-| Transpiler  | Performance Profile            | Configuration Profile | Best Fit                                     |
-| ----------- | ------------------------------ | --------------------- | -------------------------------------------- |
-| **SWC**     | Usually much faster than Babel | Moderate              | Default choice for most new Shakapacker apps |
-| **esbuild** | Usually very fast              | Minimal               | Modern syntax with simple transform needs    |
-| **Babel**   | Usually slowest                | Most flexible         | Existing Babel plugins or custom transforms  |
+| Transpiler  | Performance Profile (vs Babel)                            | Configuration Profile | Best Fit                                     |
+| ----------- | --------------------------------------------------------- | --------------------- | -------------------------------------------- |
+| **SWC**     | Much faster; upstream reports up to 20x / 70x multi-core¹ | Moderate              | Default choice for most new Shakapacker apps |
+| **esbuild** | Very fast for supported transforms²                       | Minimal               | Modern syntax with simple transform needs    |
+| **Babel**   | Baseline                                                  | Most flexible         | Existing Babel plugins or custom transforms  |
 
-SWC is the recommended default for new Shakapacker apps because it usually gives large speedups over Babel while covering the common JavaScript, TypeScript, and React cases. esbuild can also be very fast, but its transform model is less compatible with Babel-style plugin workflows.
+| Bundler     | Performance Profile (vs webpack)                              | Configuration Profile           | Best Fit                                               |
+| ----------- | ------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| **Rspack**  | Substantially faster; upstream reports roughly 8–17x typical³ | Mostly webpack-compatible       | Apps that want the biggest single performance jump     |
+| **webpack** | Baseline                                                      | Largest plugin/loader ecosystem | Apps with webpack-only loaders or plugins they rely on |
+
+¹ [swc.rs](https://swc.rs/) — "SWC is 20x faster than Babel on a single thread and 70x faster on four cores."
+² [esbuild.github.io](https://esbuild.github.io/) — bundle of 10× three.js: esbuild ~0.4s vs webpack 5 ~41s.
+³ [rspack.rs](https://rspack.rs/) and [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance) — published numbers on the `react-5k` case.
+
+**Recommended path for most apps:** SWC first (small change, large win on transpilation), then Rspack (larger change, large win on the full bundler pipeline). The combination is what produces the biggest end-to-end improvement.
 
 ## What Usually Affects Build Time
 
-The transpiler is only one part of a Shakapacker build. Measure the whole build before attributing performance to one tool.
+The transpiler is one part of a Shakapacker build. Measure the whole build before attributing performance to any single tool.
 
 Common factors:
 
@@ -66,7 +85,7 @@ See [Customizing Babel Config](./customizing_babel_config.md).
 
 Strengths:
 
-- Fast Rust implementation
+- Fast Rust implementation (upstream reports 20x/70x vs Babel¹)
 - JavaScript, TypeScript, JSX, and TSX support
 - Good fit for React applications
 - Works well with Shakapacker's default config
@@ -82,7 +101,7 @@ Watch for:
 
 Strengths:
 
-- Very fast Go implementation
+- Very fast Go implementation (upstream three.js benchmark shows ~100x vs webpack 5²)
 - Simple configuration
 - Good fit for modern JavaScript and TypeScript transpilation
 
@@ -145,7 +164,7 @@ npm install babel-loader @babel/core @babel/preset-env
 
 ## Measuring Your App
 
-Use your app's real build command rather than a synthetic number from another project:
+Published benchmarks measure transpilation or bundling in isolation on synthetic projects. Your Shakapacker build is the full pipeline, so always measure end-to-end with your real command before deciding what to keep or revert:
 
 ```bash
 time bin/shakapacker
@@ -179,6 +198,12 @@ For most apps, migrate incrementally:
 4. Compare build output and browser behavior.
 5. Keep Babel only for the paths that need Babel-specific transforms.
 
-If you want the biggest bundler-level performance change, evaluate [Rspack](./rspack_migration_guide.md) separately from the transpiler change so you can attribute any regressions to the right layer.
+If you want the biggest bundler-level performance change, evaluate [Rspack](./rspack_migration_guide.md) as a separate step so you can attribute any regressions to the right layer. For most apps the combined **Rspack + SWC** path is the highest-leverage change available — see [Combined Migration Path](./common-upgrades.md#combined-migration-path).
 
 See [Transpiler Migration](./transpiler-migration.md) for step-by-step migration commands.
+
+## Sources
+
+- SWC benchmark: [swc.rs](https://swc.rs/)
+- Rspack benchmark: [rspack.rs](https://rspack.rs/) and [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance)
+- esbuild benchmark: [esbuild.github.io](https://esbuild.github.io/)

--- a/docs/transpiler-performance.md
+++ b/docs/transpiler-performance.md
@@ -124,6 +124,9 @@ Watch for:
 
 ## How to Switch Transpilers
 
+The examples below use `npm`. Replace `npm` with your app's package manager
+when using Yarn, pnpm, or Bun.
+
 ### SWC
 
 ```yaml
@@ -156,8 +159,6 @@ javascript_transpiler: "babel"
 ```bash
 npm install babel-loader @babel/core @babel/preset-env
 ```
-
-Replace `npm` with your app's package manager when using Yarn, pnpm, or Bun.
 
 ## Measuring Your App
 

--- a/docs/transpiler-performance.md
+++ b/docs/transpiler-performance.md
@@ -1,12 +1,8 @@
 # JavaScript Transpiler Performance Guide
 
-Shakapacker supports Babel, SWC, and esbuild for webpack-based JavaScript
-transpilation. Rspack uses its built-in SWC-based loader by default.
+Shakapacker supports Babel, SWC, and esbuild for webpack-based JavaScript transpilation. Rspack uses its built-in SWC-based loader by default.
 
-This guide intentionally avoids exact benchmark numbers. Build performance
-depends heavily on project size, loader configuration, source maps, minification,
-cache state, hardware, and whether the measurement covers transpilation alone or
-the full bundler pipeline.
+This guide intentionally avoids exact benchmark numbers. Build performance depends heavily on project size, loader configuration, source maps, minification, cache state, hardware, and whether the measurement covers transpilation alone or the full bundler pipeline.
 
 ## Summary
 
@@ -16,15 +12,11 @@ the full bundler pipeline.
 | **esbuild** | Usually very fast              | Minimal               | Modern syntax with simple transform needs    |
 | **Babel**   | Usually slowest                | Most flexible         | Existing Babel plugins or custom transforms  |
 
-SWC is the recommended default for new Shakapacker apps because it usually gives
-large speedups over Babel while covering the common JavaScript, TypeScript, and
-React cases. esbuild can also be very fast, but its transform model is less
-compatible with Babel-style plugin workflows.
+SWC is the recommended default for new Shakapacker apps because it usually gives large speedups over Babel while covering the common JavaScript, TypeScript, and React cases. esbuild can also be very fast, but its transform model is less compatible with Babel-style plugin workflows.
 
 ## What Usually Affects Build Time
 
-The transpiler is only one part of a Shakapacker build. Measure the whole build
-before attributing performance to one tool.
+The transpiler is only one part of a Shakapacker build. Measure the whole build before attributing performance to one tool.
 
 Common factors:
 
@@ -38,9 +30,7 @@ Common factors:
 - Number of files outside `node_modules` processed by rules
 - CI hardware and CPU concurrency
 
-When comparing options, run the same command several times after clearing or
-warming caches intentionally. Record the command, environment, lockfile, and
-Shakapacker config alongside the results.
+When comparing options, run the same command several times after clearing or warming caches intentionally. Record the command, environment, lockfile, and Shakapacker config alongside the results.
 
 ## Choosing a Transpiler
 
@@ -49,16 +39,14 @@ Shakapacker config alongside the results.
 - You are starting a new app.
 - You want a faster default than Babel without moving to Rspack yet.
 - You use common JavaScript, TypeScript, JSX, or TSX transforms.
-- You can configure the few project-specific SWC options you need in
-  `config/swc.config.js`.
+- You can configure the few project-specific SWC options you need in `config/swc.config.js`.
 
 See [Using SWC Loader](./using_swc_loader.md).
 
 ### Choose esbuild When
 
 - You target modern browsers or have a simple transpilation target.
-- You do not rely on Babel plugins, Babel macros, or transform behavior that
-  esbuild does not implement.
+- You do not rely on Babel plugins, Babel macros, or transform behavior that esbuild does not implement.
 - You want a small configuration surface.
 
 See [Using esbuild-loader](./using_esbuild_loader.md).
@@ -67,10 +55,8 @@ See [Using esbuild-loader](./using_esbuild_loader.md).
 
 - You already rely on Babel plugins or Babel macros.
 - You need custom transforms that do not have SWC or esbuild equivalents.
-- You have mature Babel configuration that is more important than raw build
-  speed.
-- You need compatibility with old browser targets that your SWC/esbuild setup
-  does not cover.
+- You have mature Babel configuration that is more important than raw build speed.
+- You need compatibility with old browser targets that your SWC/esbuild setup does not cover.
 
 See [Customizing Babel Config](./customizing_babel_config.md).
 
@@ -89,10 +75,8 @@ Watch for:
 
 - Smaller plugin ecosystem than Babel
 - Project-specific transform options may need `config/swc.config.js`
-- Stimulus apps should preserve class names; see
-  [Using SWC with Stimulus](./using_swc_loader.md#using-swc-with-stimulus)
-- `.swcrc` can override Shakapacker defaults in surprising ways; prefer
-  `config/swc.config.js`
+- Stimulus apps should preserve class names; see [Using SWC with Stimulus](./using_swc_loader.md#using-swc-with-stimulus)
+- `.swcrc` can override Shakapacker defaults in surprising ways; prefer `config/swc.config.js`
 
 ### esbuild
 
@@ -124,8 +108,7 @@ Watch for:
 
 ## How to Switch Transpilers
 
-The examples below use `npm`. Replace `npm` with your app's package manager
-when using Yarn, pnpm, or Bun.
+The examples below use `npm`. Replace `npm` with your app's package manager when using Yarn, pnpm, or Bun.
 
 ### SWC
 
@@ -162,22 +145,19 @@ npm install babel-loader @babel/core @babel/preset-env
 
 ## Measuring Your App
 
-Use your app's real build command rather than a synthetic number from another
-project:
+Use your app's real build command rather than a synthetic number from another project:
 
 ```bash
 time bin/shakapacker
 ```
 
-For development feedback, measure the dev server or watch workflow you actually
-use:
+For development feedback, measure the dev server or watch workflow you actually use:
 
 ```bash
 time bin/shakapacker-dev-server
 ```
 
-For CI, measure the full command sequence, including dependency install and
-asset compilation if those are part of the job.
+For CI, measure the full command sequence, including dependency install and asset compilation if those are part of the job.
 
 Record:
 
@@ -199,9 +179,6 @@ For most apps, migrate incrementally:
 4. Compare build output and browser behavior.
 5. Keep Babel only for the paths that need Babel-specific transforms.
 
-If you want the biggest bundler-level performance change, evaluate
-[Rspack](./rspack_migration_guide.md) separately from the transpiler change so
-you can attribute any regressions to the right layer.
+If you want the biggest bundler-level performance change, evaluate [Rspack](./rspack_migration_guide.md) separately from the transpiler change so you can attribute any regressions to the right layer.
 
-See [Transpiler Migration](./transpiler-migration.md) for step-by-step migration
-commands.
+See [Transpiler Migration](./transpiler-migration.md) for step-by-step migration commands.

--- a/docs/using_swc_loader.md
+++ b/docs/using_swc_loader.md
@@ -4,7 +4,7 @@ SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default wa
 
 ## About SWC
 
-[SWC (Speedy Web compiler)](https://swc.rs/) is a Rust-based compilation and bundler tool that can be used for Javascript and Typescript files. It is designed for fast compilation and can be a strong replacement for Babel in many projects.
+[SWC (Speedy Web compiler)](https://swc.rs/) is a Rust-based compilation and bundler tool that can be used for Javascript and Typescript files. SWC's own benchmark reports being [20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/); end-to-end Shakapacker build wins are typically smaller than that pure-transpiler number but still substantial.
 
 It supports all ECMAScript features and it's designed to be a drop-in replacement for Babel and its plugins. Out of the box, it supports TS, JSX syntax, React fast refresh, and much more.
 
@@ -45,7 +45,7 @@ default: &default
   cache_manifest: false
 
   # Select JavaScript transpiler to use
-  # Available options: 'swc' (default), 'babel', or 'esbuild'
+  # Available options: 'swc' (default, ~20x faster than Babel per swc.rs), 'babel', or 'esbuild'
   # Note: When using rspack, swc is used automatically regardless of this setting
   javascript_transpiler: "swc"
 ```

--- a/docs/using_swc_loader.md
+++ b/docs/using_swc_loader.md
@@ -4,7 +4,7 @@ SWC is the recommended JavaScript transpiler in Shakapacker v10 (this default wa
 
 ## About SWC
 
-[SWC (Speedy Web compiler)](https://swc.rs/) is a Rust-based compilation and bundler tool that can be used for Javascript and Typescript files. It claims to be 20x faster than Babel!
+[SWC (Speedy Web compiler)](https://swc.rs/) is a Rust-based compilation and bundler tool that can be used for Javascript and Typescript files. It is designed for fast compilation and can be a strong replacement for Babel in many projects.
 
 It supports all ECMAScript features and it's designed to be a drop-in replacement for Babel and its plugins. Out of the box, it supports TS, JSX syntax, React fast refresh, and much more.
 
@@ -45,7 +45,7 @@ default: &default
   cache_manifest: false
 
   # Select JavaScript transpiler to use
-  # Available options: 'swc' (default, 20x faster), 'babel', or 'esbuild'
+  # Available options: 'swc' (default), 'babel', or 'esbuild'
   # Note: When using rspack, swc is used automatically regardless of this setting
   javascript_transpiler: "swc"
 ```

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -141,6 +141,7 @@ import * as styles from './Component.module.css';
 **Migration Options:**
 
 1. **Update your code** (Recommended):
+
    - JavaScript: Change to named imports (`import { className }`)
    - TypeScript: Change to namespace imports (`import * as styles`)
    - Kebab-case class names are automatically converted to camelCase
@@ -198,6 +199,7 @@ import * as styles from './Component.module.css';
    ```
 
    **Key points:**
+
    - Test both `.module.scss` and `.module.css` file extensions
    - Validate all loader properties exist before accessing them
    - Use `.includes('css-loader')` since the loader path may vary
@@ -255,7 +257,7 @@ javascript_transpiler: "babel"
 
 **What changed:** SWC replaces Babel as the default JavaScript transpiler. Babel is no longer included in peer dependencies.
 
-**Why:** SWC can be significantly faster than Babel while maintaining compatibility with most JavaScript and TypeScript code.
+**Why:** SWC reports being [20x faster than Babel on a single thread and 70x faster on four cores](https://swc.rs/) in its own benchmark, while maintaining compatibility with most JavaScript and TypeScript code.
 
 **Impact on existing projects:**
 

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -255,7 +255,7 @@ javascript_transpiler: "babel"
 
 **What changed:** SWC replaces Babel as the default JavaScript transpiler. Babel is no longer included in peer dependencies.
 
-**Why:** SWC is 20x faster than Babel while maintaining compatibility with most JavaScript and TypeScript code.
+**Why:** SWC can be significantly faster than Babel while maintaining compatibility with most JavaScript and TypeScript code.
 
 **Impact on existing projects:**
 


### PR DESCRIPTION
## Summary

The original PR removed unreproducible benchmark claims but went too far — it left the docs sounding noncommittal about SWC and Rspack, even though both upstream projects publish specific, citable benchmark numbers. This revision restores the value proposition with citations.

What's in:

- `docs/transpiler-performance.md` gets a new **Published Benchmarks** section with cited claims for SWC (swc.rs), Rspack (rspack.rs and rstackjs/build-tools-performance), and esbuild (esbuild.github.io)
- A second comparison table for Rspack vs webpack
- Restored speedup claims with inline citations in `README.md`, `docs/common-upgrades.md`, `docs/configuration.md`, `docs/optional-peer-dependencies.md`, `docs/rspack.md`, `docs/rspack_migration_guide.md`, `docs/transpiler-migration.md`, `docs/using_swc_loader.md`, and `docs/v9_upgrade.md`
- Specific Rspack benchmark table (react-5k case) restored in `docs/common-upgrades.md` and `docs/rspack_migration_guide.md`, attributed to the upstream sources

What stays from the previous rewrite (the part #1024 was actually about):

- "Measure your own app" section with a concrete checklist
- The point that end-to-end Shakapacker speedups are typically smaller than upstream micro-benchmark numbers (CSS, minification, source maps, plugins all eat into the transpiler/bundler win)
- Removal of the fabricated "MacBook Pro M1" methodology section and the made-up "E-commerce Platform 95.4% faster" case studies that had no source
- Removal of the precise project-specific tables (e.g. `Small project: SWC 0.3s / Babel 6.0s`) that nobody could reproduce

## Citations used

| Claim | Source |
| --- | --- |
| SWC: 20x faster than Babel single-threaded, 70x on four cores | [swc.rs](https://swc.rs/) |
| Rspack: ~8x build / ~10–15x dev start / ~17x HMR vs webpack on react-5k | [rspack.rs](https://rspack.rs/), [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance) |
| esbuild: ~0.4s vs webpack 5 ~41s on 10× three.js | [esbuild.github.io](https://esbuild.github.io/) |

Fixes #1024.

## Validation

- `npx prettier --write` on all changed docs
- `git diff --check` (no whitespace issues)
- Verified all in-doc anchors (`#published-benchmarks`, `#measuring-your-app`, `#combined-migration-path`) resolve to actual headings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update performance claims and add benchmark citations; low risk aside from potential confusion if the cited upstream numbers change over time.
> 
> **Overview**
> Updates performance messaging across the docs to be **citation-backed and less absolute**, replacing ad-hoc speed claims with references to upstream benchmarks and repeated reminders that end-to-end Shakapacker gains vary.
> 
> Reworks `docs/transpiler-performance.md` into a guide with a new *Published Benchmarks* section (SWC vs Babel, Rspack vs webpack, esbuild vs webpack) plus a concrete *Measuring Your App* checklist, and aligns related pages (`README.md`, upgrade/migration guides, configuration docs) to point to these benchmarks and describe expected performance more carefully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3cb6fd2b1d83c6a62ce28a6a7cda288c33f570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->