### PR TITLE
[codex] Harden release task failure handling

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,19 +1,22 @@
 require_relative File.join("..", "lib", "shakapacker", "utils", "version_syntax_converter")
 require_relative File.join("..", "lib", "shakapacker", "utils", "misc")
+require "English"
 require "rubygems/version"
 require "shellwords"
 require "open3"
 require "tempfile"
 require "tmpdir"
 
-class RaisingMessageHandler
+GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
+
+class AbortingMessageHandler
   def add_error(error)
-    raise error
+    abort "❌ #{error}"
   end
 end
 
 def ensure_clean_worktree!
-  Shakapacker::Utils::Misc.uncommitted_changes?(RaisingMessageHandler.new)
+  Shakapacker::Utils::Misc.uncommitted_changes?(AbortingMessageHandler.new)
 end
 
 def github_repo_slug(gem_root)
@@ -21,10 +24,18 @@ def github_repo_slug(gem_root)
   origin_url = origin_url.strip
   abort "❌ Unable to determine git origin URL for GitHub release checks.\n\n#{origin_url}" unless status.success?
 
-  match = origin_url.match(%r{github\.com[:/](?<repo>[^/]+/[^/]+?)(?:\.git)?\z})
+  match = origin_url.match(%r{\Agit@github\.com:(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+    origin_url.match(%r{\Assh://git@github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+    origin_url.match(%r{\Ahttps://(?:[^/@]+@)?github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+    origin_url.match(%r{\A(?:git://)?github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z})
   abort "❌ Unable to determine GitHub repository from origin URL #{origin_url.inspect}" unless match
 
-  match[:repo]
+  repo_slug = match[:repo]
+  unless repo_slug.match?(GITHUB_REPO_SLUG_PATTERN)
+    abort "❌ GitHub repository slug #{repo_slug.inspect} from origin URL #{origin_url.inspect} is invalid."
+  end
+
+  repo_slug
 end
 
 def verify_npm_auth(registry_url = "https://registry.npmjs.org/")
@@ -432,7 +443,13 @@ def with_release_checkout(gem_root:, dry_run:)
     begin
       yield(worktree_dir)
     ensure
-      Shakapacker::Utils::Misc.sh_in_dir(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
+      original_error = $ERROR_INFO
+      begin
+        Shakapacker::Utils::Misc.sh_in_dir(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
+      rescue StandardError => cleanup_error
+        warn "⚠️ Failed to remove dry-run release worktree #{worktree_dir}: #{cleanup_error.message}"
+        raise cleanup_error unless original_error
+      end
     end
   end
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -451,6 +451,7 @@ def with_release_checkout(gem_root:, dry_run:)
       begin
         Shakapacker::Utils::Misc.sh_in_dir(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
       rescue Exception => cleanup_error # rubocop:disable Lint/RescueException
+        # Preserve any release failure already propagating, even if cleanup exits outside StandardError.
         warn "⚠️ Failed to remove dry-run release worktree #{worktree_dir}: #{cleanup_error.message}"
         raise cleanup_error unless original_error
       end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -450,8 +450,7 @@ def with_release_checkout(gem_root:, dry_run:)
       original_error = $ERROR_INFO
       begin
         Shakapacker::Utils::Misc.sh_in_dir(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
-      rescue StandardError => cleanup_error
-        # Intentionally let interrupts and exits propagate instead of treating them as cleanup failures.
+      rescue Exception => cleanup_error # rubocop:disable Lint/RescueException
         warn "⚠️ Failed to remove dry-run release worktree #{worktree_dir}: #{cleanup_error.message}"
         raise cleanup_error unless original_error
       end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -7,11 +7,13 @@ require "open3"
 require "tempfile"
 require "tmpdir"
 
-GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
+GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined?(GITHUB_REPO_SLUG_PATTERN)
 
-class AbortingMessageHandler
-  def add_error(error)
-    abort "❌ #{error}"
+unless defined?(AbortingMessageHandler)
+  class AbortingMessageHandler
+    def add_error(error)
+      abort "❌ #{error}"
+    end
   end
 end
 
@@ -27,7 +29,9 @@ def github_repo_slug(gem_root)
   match = origin_url.match(%r{\Agit@github\.com:(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
     origin_url.match(%r{\Assh://git@github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
     origin_url.match(%r{\Ahttps://(?:[^/@]+@)?github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
-    origin_url.match(%r{\A(?:git://)?github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z})
+    origin_url.match(%r{\Agit://github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+    # Keep bare github.com/owner/repo support for remotes copied without a scheme.
+    origin_url.match(%r{\Agithub\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z})
   abort "❌ Unable to determine GitHub repository from origin URL #{origin_url.inspect}" unless match
 
   repo_slug = match[:repo]
@@ -447,6 +451,7 @@ def with_release_checkout(gem_root:, dry_run:)
       begin
         Shakapacker::Utils::Misc.sh_in_dir(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
       rescue StandardError => cleanup_error
+        # Intentionally let interrupts and exits propagate instead of treating them as cleanup failures.
         warn "⚠️ Failed to remove dry-run release worktree #{worktree_dir}: #{cleanup_error.message}"
         raise cleanup_error unless original_error
       end

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+require "rake"
+
+load File.expand_path("../../rakelib/release.rake", __dir__)
+
+RSpec.describe "release rake helpers" do
+  describe "#ensure_clean_worktree!" do
+    it "aborts with a user-facing message instead of raising a backtrace-producing error" do
+      allow(Shakapacker::Utils::Misc).to receive(:uncommitted_changes?) do |message_handler|
+        message_handler.add_error("You have uncommitted code")
+      end
+
+      expect do
+        expect { ensure_clean_worktree! }.to raise_error(SystemExit)
+      end.to output("❌ You have uncommitted code\n").to_stderr
+    end
+  end
+
+  describe "#github_repo_slug" do
+    def stub_origin_url(url, success: true)
+      status = double("status", success?: success)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/repo", "remote", "get-url", "origin")
+        .and_return(["#{url}\n", status])
+    end
+
+    it "extracts GitHub repo slugs from supported remote URL formats" do
+      {
+        "git@github.com:shakacode/shakapacker.git" => "shakacode/shakapacker",
+        "ssh://git@github.com/shakacode/shakapacker.git" => "shakacode/shakapacker",
+        "https://github.com/shakacode/shakapacker.git" => "shakacode/shakapacker",
+        "https://token@github.com/shakacode/shakapacker.git" => "shakacode/shakapacker",
+        "git://github.com/shakacode/shakapacker.git" => "shakacode/shakapacker",
+        "github.com/shakacode/shakapacker" => "shakacode/shakapacker"
+      }.each do |origin_url, expected_slug|
+        stub_origin_url(origin_url)
+
+        expect(github_repo_slug("/repo")).to eq(expected_slug)
+      end
+    end
+
+    it "rejects non-GitHub remotes" do
+      stub_origin_url("https://example.com/shakacode/shakapacker.git")
+
+      expect do
+        expect { github_repo_slug("/repo") }.to raise_error(SystemExit)
+      end.to output(/Unable to determine GitHub repository/).to_stderr
+    end
+
+    it "rejects unsafe GitHub slug characters" do
+      stub_origin_url("git@github.com:shakacode/shakapacker;touch.git")
+
+      expect do
+        expect { github_repo_slug("/repo") }.to raise_error(SystemExit)
+      end.to output(/repository slug "shakacode\/shakapacker;touch" .* is invalid/).to_stderr
+    end
+  end
+
+  describe "#with_release_checkout" do
+    before do
+      allow(Dir).to receive(:mktmpdir)
+        .with("shakapacker-release-dry-run")
+        .and_yield("/tmp/shakapacker-release")
+    end
+
+    it "preserves the release failure when dry-run worktree cleanup also fails" do
+      allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
+        raise "cleanup failed" if command.include?("git worktree remove")
+      end
+
+      expect do
+        expect do
+          with_release_checkout(gem_root: "/repo", dry_run: true) do
+            raise "release failed"
+          end
+        end.to raise_error(RuntimeError, "release failed")
+      end.to output(/Failed to remove dry-run release worktree/).to_stderr
+    end
+
+    it "raises cleanup failures when the dry run itself succeeded" do
+      allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
+        raise "cleanup failed" if command.include?("git worktree remove")
+      end
+
+      expect do
+        expect do
+          with_release_checkout(gem_root: "/repo", dry_run: true) { "ok" }
+        end.to raise_error(RuntimeError, "cleanup failed")
+      end.to output(/Failed to remove dry-run release worktree/).to_stderr
+    end
+  end
+end

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -4,6 +4,19 @@ require "rake"
 load File.expand_path("../../rakelib/release.rake", __dir__)
 
 RSpec.describe "release rake helpers" do
+  describe "loading the rake file" do
+    it "does not warn about reload-safe top-level definitions" do
+      previous_verbose = $VERBOSE
+      $VERBOSE = true
+
+      expect do
+        load File.expand_path("../../rakelib/release.rake", __dir__)
+      end.not_to output(/GITHUB_REPO_SLUG_PATTERN|AbortingMessageHandler/).to_stderr
+    ensure
+      $VERBOSE = previous_verbose
+    end
+  end
+
   describe "#ensure_clean_worktree!" do
     it "aborts with a user-facing message instead of raising a backtrace-producing error" do
       allow(Shakapacker::Utils::Misc).to receive(:uncommitted_changes?) do |message_handler|

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -80,6 +80,8 @@ RSpec.describe "release rake helpers" do
     it "preserves the release failure when dry-run worktree cleanup also fails" do
       allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
         raise "cleanup failed" if command.include?("git worktree remove")
+
+        true
       end
 
       expect do
@@ -95,6 +97,8 @@ RSpec.describe "release rake helpers" do
       cleanup_error_class = Class.new(Exception)
       allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
         raise cleanup_error_class, "cleanup failed" if command.include?("git worktree remove")
+
+        true
       end
 
       expect do
@@ -109,6 +113,8 @@ RSpec.describe "release rake helpers" do
     it "raises cleanup failures when the dry run itself succeeded" do
       allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
         raise "cleanup failed" if command.include?("git worktree remove")
+
+        true
       end
 
       expect do

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 require "rake"
 
-load File.expand_path("../../rakelib/release.rake", __dir__)
+release_rake_path = File.expand_path("../../rakelib/release.rake", __dir__)
+load release_rake_path unless defined?(ensure_clean_worktree!)
 
 RSpec.describe "release rake helpers" do
   describe "loading the rake file" do
@@ -79,6 +80,21 @@ RSpec.describe "release rake helpers" do
     it "preserves the release failure when dry-run worktree cleanup also fails" do
       allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
         raise "cleanup failed" if command.include?("git worktree remove")
+      end
+
+      expect do
+        expect do
+          with_release_checkout(gem_root: "/repo", dry_run: true) do
+            raise "release failed"
+          end
+        end.to raise_error(RuntimeError, "release failed")
+      end.to output(/Failed to remove dry-run release worktree/).to_stderr
+    end
+
+    it "preserves the release failure when cleanup raises outside StandardError" do
+      cleanup_error_class = Class.new(Exception)
+      allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |_dir, command|
+        raise cleanup_error_class, "cleanup failed" if command.include?("git worktree remove")
       end
 
       expect do


### PR DESCRIPTION
## Summary
- Abort dirty-worktree release checks with a user-facing message instead of raising through the message handler.
- Restrict GitHub release repo slug detection to supported GitHub remote URL formats and validate the extracted `owner/repo` slug.
- Preserve the original dry-run release failure if temporary worktree cleanup also fails, while still surfacing cleanup errors when they are the only failure.

Partially addresses #947.

## Validation
- `bundle exec rspec spec/rakelib/release_spec.rb`
- `bundle exec rubocop rakelib/release.rake spec/rakelib/release_spec.rb`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation behavior (git remote parsing and dry-run worktree cleanup), which could block or alter maintainer release flows if edge cases are missed.
> 
> **Overview**
> Hardens `rakelib/release.rake` failure handling by aborting dirty-worktree checks with a user-facing message (instead of raising) and by making top-level constants/classes reload-safe.
> 
> Tightens GitHub repo detection to only accept specific GitHub remote URL formats and validates the extracted `owner/repo` slug to reject unsafe characters.
> 
> Improves dry-run `git worktree` cleanup so cleanup errors are warned about but **don’t mask the original release failure**, while still raising cleanup errors when they’re the only failure; adds focused RSpec coverage for these behaviors in `spec/rakelib/release_spec.rb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac442f55f21b0a7633fecb4bb606da6159637d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->