### PR TITLE
Sync stale .tool-versions and validate Node version in setup scripts

### DIFF
--- a/bin/lib/node-version-check.sh
+++ b/bin/lib/node-version-check.sh
@@ -1,15 +1,31 @@
 readonly MIN_NODE_20="20.19.0"
 readonly MIN_NODE_22="22.12.0"
 
+# Compare two MAJOR.MINOR.PATCH version strings. Returns 0 if $1 >= $2, else 1.
+# Uses awk (POSIX) for portability; macOS BSD `sort` lacks `-V` without GNU coreutils.
+version_ge() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, av, ".")
+    split(b, bv, ".")
+    for (i = 1; i <= 3; i++) {
+      ai = (av[i] == "" ? 0 : av[i] + 0)
+      bi = (bv[i] == "" ? 0 : bv[i] + 0)
+      if (ai > bi) exit 0
+      if (ai < bi) exit 1
+    }
+    exit 0
+  }'
+}
+
 node_version_supported() {
   local version="$1"
   version="${version#v}"
   local major
   major=$(echo "$version" | cut -d'.' -f1)
-  if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
+  if [[ "$major" == "20" ]] && version_ge "$version" "$MIN_NODE_20"; then
     return 0
   fi
-  if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
+  if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && version_ge "$version" "$MIN_NODE_22"; then
     return 0
   fi
   return 1

--- a/bin/lib/node-version-check.sh
+++ b/bin/lib/node-version-check.sh
@@ -1,0 +1,15 @@
+MIN_NODE_20="20.19.0"
+MIN_NODE_22="22.12.0"
+
+node_version_supported() {
+  local version="$1"
+  local major
+  major=$(echo "$version" | cut -d'.' -f1)
+  if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
+    return 0
+  fi
+  if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
+    return 0
+  fi
+  return 1
+}

--- a/bin/lib/node-version-check.sh
+++ b/bin/lib/node-version-check.sh
@@ -1,8 +1,9 @@
-MIN_NODE_20="20.19.0"
-MIN_NODE_22="22.12.0"
+readonly MIN_NODE_20="20.19.0"
+readonly MIN_NODE_22="22.12.0"
 
 node_version_supported() {
   local version="$1"
+  version="${version#v}"
   local major
   major=$(echo "$version" | cut -d'.' -f1)
   if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then

--- a/bin/lib/node-version-check.sh
+++ b/bin/lib/node-version-check.sh
@@ -22,8 +22,9 @@ version_ge() {
 node_version_supported() {
   local version="$1"
   version="${version#v}"
-  # Reject non-numeric aliases (e.g. lts/iron used by nvm) before numeric checks.
-  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
+  # Reject non-numeric aliases (e.g. lts/iron) and pre-release/build suffixes (e.g. 22.12.0-rc1).
+  # version_ge uses awk numeric coercion that silently strips suffixes, so guard at the gate.
+  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     return 1
   fi
   local major

--- a/bin/lib/node-version-check.sh
+++ b/bin/lib/node-version-check.sh
@@ -1,3 +1,5 @@
+[[ -n "${_NODE_VERSION_CHECK_LOADED:-}" ]] && return
+readonly _NODE_VERSION_CHECK_LOADED=1
 readonly MIN_NODE_20="20.19.0"
 readonly MIN_NODE_22="22.12.0"
 
@@ -20,6 +22,10 @@ version_ge() {
 node_version_supported() {
   local version="$1"
   version="${version#v}"
+  # Reject non-numeric aliases (e.g. lts/iron used by nvm) before numeric checks.
+  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
+    return 1
+  fi
   local major
   major=$(echo "$version" | cut -d'.' -f1)
   if [[ "$major" == "20" ]] && version_ge "$version" "$MIN_NODE_20"; then

--- a/bin/setup
+++ b/bin/setup
@@ -4,9 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Supported Node range mirrors package.json "engines" (@rspack/core v2 requirement).
-MIN_NODE_20="20.19.0"
-MIN_NODE_22="22.12.0"
+source "$ROOT_DIR/bin/lib/node-version-check.sh"
 
 run_cmd() {
   if [[ -x "$ROOT_DIR/bin/conductor-exec" ]]; then
@@ -22,19 +20,6 @@ ensure_tool() {
     echo "Error: $tool is not available. Install it and run bin/setup again." >&2
     exit 1
   fi
-}
-
-node_version_supported() {
-  local version="$1"
-  local major
-  major=$(echo "$version" | cut -d'.' -f1)
-  if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
-    return 0
-  fi
-  if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
-    return 0
-  fi
-  return 1
 }
 
 echo "Checking required tools..."

--- a/bin/setup
+++ b/bin/setup
@@ -28,9 +28,10 @@ ensure_tool bundle
 ensure_tool node
 ensure_tool yarn
 
-NODE_VERSION=$(run_cmd node -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+NODE_RAW=$(run_cmd node -v 2>&1 || true)
+NODE_VERSION=$(echo "$NODE_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
 if [[ -z "$NODE_VERSION" ]]; then
-  echo "Error: Could not parse Node.js version from \`node -v\`. Got: $(run_cmd node -v)" >&2
+  echo "Error: Could not parse Node.js version from \`node -v\`. Got: $NODE_RAW" >&2
   exit 1
 fi
 if ! node_version_supported "$NODE_VERSION"; then

--- a/bin/setup
+++ b/bin/setup
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Supported Node range mirrors package.json "engines" (@rspack/core v2 requirement).
+MIN_NODE_20="20.19.0"
+MIN_NODE_22="22.12.0"
+
 run_cmd() {
   if [[ -x "$ROOT_DIR/bin/conductor-exec" ]]; then
     "$ROOT_DIR/bin/conductor-exec" "$@"
@@ -20,11 +24,36 @@ ensure_tool() {
   fi
 }
 
+node_version_supported() {
+  local version="$1"
+  local major
+  major=$(echo "$version" | cut -d'.' -f1)
+  if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
+    return 0
+  fi
+  if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 echo "Checking required tools..."
 ensure_tool ruby
 ensure_tool bundle
 ensure_tool node
 ensure_tool yarn
+
+NODE_VERSION=$(run_cmd node -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+if [[ -z "$NODE_VERSION" ]]; then
+  echo "Error: Could not parse Node.js version from \`node -v\`. Got: $(run_cmd node -v)" >&2
+  exit 1
+fi
+if ! node_version_supported "$NODE_VERSION"; then
+  echo "Error: Node.js v$NODE_VERSION is unsupported. Shakapacker requires Node ^20.19.0 || >=22.12.0." >&2
+  echo "  This matches the engines field in package.json (and @rspack/core v2)." >&2
+  echo "  Upgrade Node via your version manager, then rerun bin/setup." >&2
+  exit 1
+fi
 
 echo "Installing Ruby dependencies..."
 run_cmd bundle install

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -3,6 +3,47 @@ set -euo pipefail
 
 echo "🔧 Setting up Shakapacker workspace..."
 
+# Engine requirements (kept in sync with package.json "engines" and lib/install/templates).
+# @rspack/core v2 (Shakapacker v10+) requires Node ^20.19.0 || >=22.12.0.
+MIN_RUBY_VERSION="2.7.0"
+DEFAULT_RUBY_VERSION="3.3.4"
+DEFAULT_NODE_VERSION="22.20.0"
+MIN_NODE_20="20.19.0"
+MIN_NODE_22="22.12.0"
+
+# Returns 0 if $1 is a Node version inside ^20.19.0 || >=22.12.0.
+node_version_supported() {
+    local version="$1"
+    local major
+    major=$(echo "$version" | cut -d'.' -f1)
+    if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
+        return 0
+    fi
+    if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Set or update a `<tool> <version>` line in .tool-versions, preserving other entries.
+upsert_tool_versions_line() {
+    local tool="$1"
+    local version="$2"
+    local file=".tool-versions"
+    if [[ ! -f "$file" ]]; then
+        echo "$tool $version" > "$file"
+        return
+    fi
+    if grep -qE "^${tool}[[:space:]]" "$file"; then
+        awk -v tool="$tool" -v ver="$version" '
+            $1 == tool { print tool " " ver; next }
+            { print }
+        ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    else
+        echo "$tool $version" >> "$file"
+    fi
+}
+
 # Detect and initialize version manager
 # Supports: mise, asdf, or direct PATH (rbenv/nvm/nodenv already in PATH)
 VERSION_MANAGER="none"
@@ -30,28 +71,44 @@ else
     echo "   (Assuming rbenv/nvm/nodenv or system tools are already configured)"
 fi
 
-# Ensure version config exists for asdf/mise users
-if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .tool-versions ]] && [[ ! -f .mise.toml ]]; then
-    echo "📝 Creating .tool-versions from project version files..."
-
-    # Read Ruby version from .ruby-version or use default
+# Sync .tool-versions with project version files (asdf/mise only; skip when .mise.toml is authoritative)
+if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
     if [[ -f .ruby-version ]]; then
         RUBY_VER=$(cat .ruby-version | tr -d '[:space:]')
     else
-        RUBY_VER="3.3.4"  # Default: recent stable Ruby
+        RUBY_VER="$DEFAULT_RUBY_VERSION"
     fi
 
-    # Read Node version from .node-version or use default
     if [[ -f .node-version ]]; then
         NODE_VER=$(cat .node-version | tr -d '[:space:]')
     else
-        NODE_VER="22.20.0"  # Default: LTS Node (>=22.12.0 required by @rspack/core)
+        NODE_VER="$DEFAULT_NODE_VERSION"
     fi
 
-    cat > .tool-versions << EOF
-ruby $RUBY_VER
-nodejs $NODE_VER
-EOF
+    # Fail fast if .node-version pins an unsupported Node, before mise installs the wrong version.
+    if ! node_version_supported "$NODE_VER"; then
+        echo "❌ Error: Node version $NODE_VER (from .node-version) is unsupported."
+        echo "   Shakapacker requires Node ^20.19.0 || >=22.12.0 (matches package.json engines)."
+        echo "   Fix: update .node-version to a supported version (e.g. $DEFAULT_NODE_VERSION), then rerun setup."
+        exit 1
+    fi
+
+    if [[ ! -f .tool-versions ]]; then
+        echo "📝 Creating .tool-versions from project version files..."
+    else
+        existing_node=$(awk '$1 == "nodejs" { print $2; exit }' .tool-versions)
+        existing_ruby=$(awk '$1 == "ruby" { print $2; exit }' .tool-versions)
+        if [[ "$existing_node" != "$NODE_VER" ]] || [[ "$existing_ruby" != "$RUBY_VER" ]]; then
+            echo "📝 Updating .tool-versions to match .node-version/.ruby-version..."
+            [[ -n "$existing_node" ]] && [[ "$existing_node" != "$NODE_VER" ]] && \
+                echo "   nodejs: $existing_node → $NODE_VER"
+            [[ -n "$existing_ruby" ]] && [[ "$existing_ruby" != "$RUBY_VER" ]] && \
+                echo "   ruby:   $existing_ruby → $RUBY_VER"
+        fi
+    fi
+
+    upsert_tool_versions_line "ruby" "$RUBY_VER"
+    upsert_tool_versions_line "nodejs" "$NODE_VER"
     echo "   Using Ruby $RUBY_VER, Node $NODE_VER"
 fi
 
@@ -82,37 +139,28 @@ if [[ -z "$RUBY_VERSION" ]]; then
     echo "❌ Error: Could not parse Ruby version from \`ruby -v\`. Got: $(run_cmd ruby -v)"
     exit 1
 fi
-MIN_RUBY_VERSION="2.7.0"
 if [[ $(printf '%s\n' "$MIN_RUBY_VERSION" "$RUBY_VERSION" | sort -V | head -n1) != "$MIN_RUBY_VERSION" ]]; then
-    echo "❌ Error: Ruby version $RUBY_VERSION is too old. Shakapacker requires Ruby >= 2.7.0"
+    echo "❌ Error: Ruby version $RUBY_VERSION is too old. Shakapacker requires Ruby >= $MIN_RUBY_VERSION"
     echo "   Please upgrade Ruby using your version manager or system package manager."
     exit 1
 fi
 echo "✅ Ruby version: $RUBY_VERSION"
 
-# Check Node version
-# @rspack/core v2 (used by Shakapacker v10+) requires ^20.19.0 || >=22.12.0.
-# Reject unsupported ranges (21.x, 22.0.0–22.11.x) up front so they fail before yarn install.
-# The >=22.12.0 branch intentionally accepts future majors (23.x, 24.x, …) — matching the
-# upstream rspack engine constraint.
+# Check Node version against ^20.19.0 || >=22.12.0 (rspack v2 engine constraint).
 # Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "v22.20.0+custom") so sort -V compares cleanly.
 NODE_VERSION=$(run_cmd node -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
 if [[ -z "$NODE_VERSION" ]]; then
     echo "❌ Error: Could not parse Node.js version from \`node -v\`. Got: $(run_cmd node -v)"
     exit 1
 fi
-NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d'.' -f1)
-MIN_NODE_20="20.19.0"
-MIN_NODE_22="22.12.0"
-node_supported=false
-if [[ "$NODE_MAJOR" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$NODE_VERSION" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
-    node_supported=true
-elif [[ "$NODE_MAJOR" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$NODE_VERSION" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
-    node_supported=true
-fi
-if [[ "$node_supported" != "true" ]]; then
+if ! node_version_supported "$NODE_VERSION"; then
     echo "❌ Error: Node.js version v$NODE_VERSION is unsupported. Shakapacker requires Node.js ^20.19.0 || >=22.12.0"
-    echo "   Please upgrade Node.js using your version manager or system package manager."
+    if [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .tool-versions ]]; then
+        echo "   Hint: .tool-versions pins nodejs $(awk '$1 == "nodejs" { print $2; exit }' .tool-versions || echo '?')."
+        echo "   Update .node-version and rerun setup, or run \`mise install\` after fixing .tool-versions."
+    else
+        echo "   Please upgrade Node.js using your version manager or system package manager."
+    fi
     exit 1
 fi
 echo "✅ Node.js version: v$NODE_VERSION"

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -28,6 +28,11 @@ upsert_tool_versions_line() {
         ' "$file" > "$tmpfile" || { rm -f "$tmpfile"; return 1; }
         mv "$tmpfile" "$file" || { rm -f "$tmpfile"; return 1; }
     else
+        # Ensure the file ends with a newline before appending, so the new entry doesn't
+        # concatenate onto the last line of a hand-edited file missing its trailing \n.
+        if [[ -s "$file" ]] && [[ "$(tail -c1 "$file"; echo x)" != $'\nx' ]]; then
+            printf '\n' >> "$file"
+        fi
         echo "$tool $version" >> "$file"
     fi
 }
@@ -61,26 +66,43 @@ fi
 
 # Sync .tool-versions with project version files (asdf/mise only; skip when .mise.toml is authoritative)
 if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
+    # Read any existing .tool-versions pins up front so we can prefer a supported value there
+    # over the hard-coded default when .ruby-version / .node-version aren't present.
+    existing_node=""
+    existing_ruby=""
+    if [[ -f .tool-versions ]]; then
+        existing_node=$(awk '$1 == "nodejs" { print $2; exit }' .tool-versions)
+        existing_ruby=$(awk '$1 == "ruby" { print $2; exit }' .tool-versions)
+    fi
+
     if [[ -f .ruby-version ]]; then
         RUBY_VER=$(cat .ruby-version | tr -d '[:space:]')
+    elif [[ -n "$existing_ruby" ]] && version_ge "$existing_ruby" "$MIN_RUBY_VERSION"; then
+        RUBY_VER="$existing_ruby"
     else
         RUBY_VER="$DEFAULT_RUBY_VERSION"
     fi
 
+    # Track the source so the unsupported-Node error message points at the right file to edit.
     if [[ -f .node-version ]]; then
         NODE_VER=$(cat .node-version | tr -d '[:space:]')
         # Strip leading `v` (valid nvm/nodenv format) so mise/asdf accept the value in .tool-versions
         # and the idempotency check below compares against the unprefixed value awk reads back.
         NODE_VER="${NODE_VER#v}"
+        NODE_VER_SOURCE=".node-version"
+    elif [[ -n "$existing_node" ]] && node_version_supported "$existing_node"; then
+        NODE_VER="$existing_node"
+        NODE_VER_SOURCE=".tool-versions"
     else
         NODE_VER="$DEFAULT_NODE_VERSION"
+        NODE_VER_SOURCE="default"
     fi
 
-    # Fail fast if .node-version pins an unsupported Node, before mise installs the wrong version.
+    # Fail fast if the resolved Node version is unsupported, before mise installs the wrong version.
     if ! node_version_supported "$NODE_VER"; then
-        echo "❌ Error: Node version $NODE_VER (from .node-version) is unsupported." >&2
+        echo "❌ Error: Node version $NODE_VER (from $NODE_VER_SOURCE) is unsupported." >&2
         echo "   Shakapacker requires Node ^20.19.0 || >=22.12.0 (matches package.json engines)." >&2
-        echo "   Fix: update .node-version to a supported version (e.g. $DEFAULT_NODE_VERSION), then rerun setup." >&2
+        echo "   Fix: update $NODE_VER_SOURCE to a supported version (e.g. $DEFAULT_NODE_VERSION), then rerun setup." >&2
         exit 1
     fi
 
@@ -88,24 +110,23 @@ if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
         echo "📝 Creating .tool-versions from project version files..."
         upsert_tool_versions_line "ruby" "$RUBY_VER"
         upsert_tool_versions_line "nodejs" "$NODE_VER"
+        echo "   Using Ruby $RUBY_VER, Node $NODE_VER"
+    elif [[ "$existing_node" != "$NODE_VER" ]] || [[ "$existing_ruby" != "$RUBY_VER" ]]; then
+        echo "📝 Updating .tool-versions to match resolved versions..."
+        [[ -z "$existing_node" ]] && \
+            echo "   nodejs: (new) $NODE_VER"
+        [[ -n "$existing_node" ]] && [[ "$existing_node" != "$NODE_VER" ]] && \
+            echo "   nodejs: $existing_node → $NODE_VER"
+        [[ -z "$existing_ruby" ]] && \
+            echo "   ruby:   (new) $RUBY_VER"
+        [[ -n "$existing_ruby" ]] && [[ "$existing_ruby" != "$RUBY_VER" ]] && \
+            echo "   ruby:   $existing_ruby → $RUBY_VER"
+        upsert_tool_versions_line "ruby" "$RUBY_VER"
+        upsert_tool_versions_line "nodejs" "$NODE_VER"
+        echo "   Using Ruby $RUBY_VER, Node $NODE_VER"
     else
-        existing_node=$(awk '$1 == "nodejs" { print $2; exit }' .tool-versions)
-        existing_ruby=$(awk '$1 == "ruby" { print $2; exit }' .tool-versions)
-        if [[ "$existing_node" != "$NODE_VER" ]] || [[ "$existing_ruby" != "$RUBY_VER" ]]; then
-            echo "📝 Updating .tool-versions to match .node-version/.ruby-version..."
-            [[ -z "$existing_node" ]] && \
-                echo "   nodejs: (new) $NODE_VER"
-            [[ -n "$existing_node" ]] && [[ "$existing_node" != "$NODE_VER" ]] && \
-                echo "   nodejs: $existing_node → $NODE_VER"
-            [[ -z "$existing_ruby" ]] && \
-                echo "   ruby:   (new) $RUBY_VER"
-            [[ -n "$existing_ruby" ]] && [[ "$existing_ruby" != "$RUBY_VER" ]] && \
-                echo "   ruby:   $existing_ruby → $RUBY_VER"
-            upsert_tool_versions_line "ruby" "$RUBY_VER"
-            upsert_tool_versions_line "nodejs" "$NODE_VER"
-        fi
+        echo "✅ .tool-versions already in sync (Ruby $RUBY_VER, Node $NODE_VER)"
     fi
-    echo "   Using Ruby $RUBY_VER, Node $NODE_VER"
 fi
 
 # Install tools via mise (after .tool-versions exists)

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -69,15 +69,18 @@ if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
 
     if [[ -f .node-version ]]; then
         NODE_VER=$(cat .node-version | tr -d '[:space:]')
+        # Strip leading `v` (valid nvm/nodenv format) so mise/asdf accept the value in .tool-versions
+        # and the idempotency check below compares against the unprefixed value awk reads back.
+        NODE_VER="${NODE_VER#v}"
     else
         NODE_VER="$DEFAULT_NODE_VERSION"
     fi
 
     # Fail fast if .node-version pins an unsupported Node, before mise installs the wrong version.
     if ! node_version_supported "$NODE_VER"; then
-        echo "❌ Error: Node version $NODE_VER (from .node-version) is unsupported."
-        echo "   Shakapacker requires Node ^20.19.0 || >=22.12.0 (matches package.json engines)."
-        echo "   Fix: update .node-version to a supported version (e.g. $DEFAULT_NODE_VERSION), then rerun setup."
+        echo "❌ Error: Node version $NODE_VER (from .node-version) is unsupported." >&2
+        echo "   Shakapacker requires Node ^20.19.0 || >=22.12.0 (matches package.json engines)." >&2
+        echo "   Fix: update .node-version to a supported version (e.g. $DEFAULT_NODE_VERSION), then rerun setup." >&2
         exit 1
     fi
 
@@ -122,42 +125,42 @@ run_cmd() {
 
 # Check required tools
 echo "📋 Checking required tools..."
-run_cmd ruby --version >/dev/null 2>&1 || { echo "❌ Error: Ruby is not installed or not in PATH."; exit 1; }
-run_cmd node --version >/dev/null 2>&1 || { echo "❌ Error: Node.js is not installed or not in PATH."; exit 1; }
+run_cmd ruby --version >/dev/null 2>&1 || { echo "❌ Error: Ruby is not installed or not in PATH." >&2; exit 1; }
+run_cmd node --version >/dev/null 2>&1 || { echo "❌ Error: Node.js is not installed or not in PATH." >&2; exit 1; }
 
 # Check Ruby version
-# Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "+custom") so sort -V compares cleanly.
+# Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "+custom") so comparison is clean.
 RUBY_RAW=$(run_cmd ruby -v 2>&1 || true)
 RUBY_VERSION=$(echo "$RUBY_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
 if [[ -z "$RUBY_VERSION" ]]; then
-    echo "❌ Error: Could not parse Ruby version from \`ruby -v\`. Got: $RUBY_RAW"
+    echo "❌ Error: Could not parse Ruby version from \`ruby -v\`. Got: $RUBY_RAW" >&2
     exit 1
 fi
-if [[ $(printf '%s\n' "$MIN_RUBY_VERSION" "$RUBY_VERSION" | sort -V | head -n1) != "$MIN_RUBY_VERSION" ]]; then
-    echo "❌ Error: Ruby version $RUBY_VERSION is too old. Shakapacker requires Ruby >= $MIN_RUBY_VERSION"
-    echo "   Please upgrade Ruby using your version manager or system package manager."
+if ! version_ge "$RUBY_VERSION" "$MIN_RUBY_VERSION"; then
+    echo "❌ Error: Ruby version $RUBY_VERSION is too old. Shakapacker requires Ruby >= $MIN_RUBY_VERSION" >&2
+    echo "   Please upgrade Ruby using your version manager or system package manager." >&2
     exit 1
 fi
 echo "✅ Ruby version: $RUBY_VERSION"
 
 # Check Node version against ^20.19.0 || >=22.12.0 (rspack v2 engine constraint).
-# Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "v22.20.0+custom") so sort -V compares cleanly.
+# Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "v22.20.0+custom") so comparison is clean.
 NODE_RAW=$(run_cmd node -v 2>&1 || true)
 NODE_VERSION=$(echo "$NODE_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
 if [[ -z "$NODE_VERSION" ]]; then
-    echo "❌ Error: Could not parse Node.js version from \`node -v\`. Got: $NODE_RAW"
+    echo "❌ Error: Could not parse Node.js version from \`node -v\`. Got: $NODE_RAW" >&2
     exit 1
 fi
 if ! node_version_supported "$NODE_VERSION"; then
-    echo "❌ Error: Node.js version v$NODE_VERSION is unsupported. Shakapacker requires Node.js ^20.19.0 || >=22.12.0"
+    echo "❌ Error: Node.js version v$NODE_VERSION is unsupported. Shakapacker requires Node.js ^20.19.0 || >=22.12.0" >&2
     if [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .mise.toml ]]; then
-        echo "   Hint: .mise.toml is the authoritative mise config for this workspace."
-        echo "   Update the Node version in .mise.toml, then run \`mise install\` and rerun setup."
+        echo "   Hint: .mise.toml is the authoritative mise config for this workspace." >&2
+        echo "   Update the Node version in .mise.toml, then run \`mise install\` and rerun setup." >&2
     elif [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .tool-versions ]]; then
-        echo "   Hint: .tool-versions pins nodejs $(awk '$1 == "nodejs" { print $2; exit }' .tool-versions || echo '?')."
-        echo "   Update .node-version and rerun setup, or run \`mise install\` after fixing .tool-versions."
+        echo "   Hint: .tool-versions pins nodejs $(awk '$1 == "nodejs" { print $2; exit }' .tool-versions || echo '?')." >&2
+        echo "   Update .node-version and rerun setup, or run \`mise install\` after fixing .tool-versions." >&2
     else
-        echo "   Please upgrade Node.js using your version manager or system package manager."
+        echo "   Please upgrade Node.js using your version manager or system package manager." >&2
     fi
     exit 1
 fi

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -22,13 +22,11 @@ upsert_tool_versions_line() {
     fi
     if grep -qE "^${tool}[[:space:]]" "$file"; then
         local tmpfile="$file.tmp"
-        trap 'rm -f "$tmpfile"' EXIT
         awk -v tool="$tool" -v ver="$version" '
             $1 == tool { print tool " " ver; next }
             { print }
-        ' "$file" > "$tmpfile"
-        mv "$tmpfile" "$file"
-        trap - EXIT
+        ' "$file" > "$tmpfile" || { rm -f "$tmpfile"; return 1; }
+        mv "$tmpfile" "$file" || { rm -f "$tmpfile"; return 1; }
     else
         echo "$tool $version" >> "$file"
     fi
@@ -85,6 +83,8 @@ if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
 
     if [[ ! -f .tool-versions ]]; then
         echo "📝 Creating .tool-versions from project version files..."
+        upsert_tool_versions_line "ruby" "$RUBY_VER"
+        upsert_tool_versions_line "nodejs" "$NODE_VER"
     else
         existing_node=$(awk '$1 == "nodejs" { print $2; exit }' .tool-versions)
         existing_ruby=$(awk '$1 == "ruby" { print $2; exit }' .tool-versions)
@@ -98,11 +98,10 @@ if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
                 echo "   ruby:   (new) $RUBY_VER"
             [[ -n "$existing_ruby" ]] && [[ "$existing_ruby" != "$RUBY_VER" ]] && \
                 echo "   ruby:   $existing_ruby → $RUBY_VER"
+            upsert_tool_versions_line "ruby" "$RUBY_VER"
+            upsert_tool_versions_line "nodejs" "$NODE_VER"
         fi
     fi
-
-    upsert_tool_versions_line "ruby" "$RUBY_VER"
-    upsert_tool_versions_line "nodejs" "$NODE_VER"
     echo "   Using Ruby $RUBY_VER, Node $NODE_VER"
 fi
 
@@ -128,9 +127,10 @@ run_cmd node --version >/dev/null 2>&1 || { echo "❌ Error: Node.js is not inst
 
 # Check Ruby version
 # Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "+custom") so sort -V compares cleanly.
-RUBY_VERSION=$(run_cmd ruby -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+RUBY_RAW=$(run_cmd ruby -v 2>&1 || true)
+RUBY_VERSION=$(echo "$RUBY_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
 if [[ -z "$RUBY_VERSION" ]]; then
-    echo "❌ Error: Could not parse Ruby version from \`ruby -v\`. Got: $(run_cmd ruby -v)"
+    echo "❌ Error: Could not parse Ruby version from \`ruby -v\`. Got: $RUBY_RAW"
     exit 1
 fi
 if [[ $(printf '%s\n' "$MIN_RUBY_VERSION" "$RUBY_VERSION" | sort -V | head -n1) != "$MIN_RUBY_VERSION" ]]; then
@@ -142,9 +142,10 @@ echo "✅ Ruby version: $RUBY_VERSION"
 
 # Check Node version against ^20.19.0 || >=22.12.0 (rspack v2 engine constraint).
 # Extract MAJOR.MINOR.PATCH; ignores any distro patch suffix (e.g., "v22.20.0+custom") so sort -V compares cleanly.
-NODE_VERSION=$(run_cmd node -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+NODE_RAW=$(run_cmd node -v 2>&1 || true)
+NODE_VERSION=$(echo "$NODE_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
 if [[ -z "$NODE_VERSION" ]]; then
-    echo "❌ Error: Could not parse Node.js version from \`node -v\`. Got: $(run_cmd node -v)"
+    echo "❌ Error: Could not parse Node.js version from \`node -v\`. Got: $NODE_RAW"
     exit 1
 fi
 if ! node_version_supported "$NODE_VERSION"; then

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -5,25 +5,11 @@ echo "🔧 Setting up Shakapacker workspace..."
 
 # Engine requirements (kept in sync with package.json "engines" and lib/install/templates).
 # @rspack/core v2 (Shakapacker v10+) requires Node ^20.19.0 || >=22.12.0.
+SCRIPT_DIR="${0:A:h}"
 MIN_RUBY_VERSION="2.7.0"
 DEFAULT_RUBY_VERSION="3.3.4"
 DEFAULT_NODE_VERSION="22.20.0"
-MIN_NODE_20="20.19.0"
-MIN_NODE_22="22.12.0"
-
-# Returns 0 if $1 is a Node version inside ^20.19.0 || >=22.12.0.
-node_version_supported() {
-    local version="$1"
-    local major
-    major=$(echo "$version" | cut -d'.' -f1)
-    if [[ "$major" == "20" ]] && [[ $(printf '%s\n' "$MIN_NODE_20" "$version" | sort -V | head -n1) == "$MIN_NODE_20" ]]; then
-        return 0
-    fi
-    if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -ge 22 ]] && [[ $(printf '%s\n' "$MIN_NODE_22" "$version" | sort -V | head -n1) == "$MIN_NODE_22" ]]; then
-        return 0
-    fi
-    return 1
-}
+source "$SCRIPT_DIR/bin/lib/node-version-check.sh"
 
 # Set or update a `<tool> <version>` line in .tool-versions, preserving other entries.
 upsert_tool_versions_line() {
@@ -35,10 +21,14 @@ upsert_tool_versions_line() {
         return
     fi
     if grep -qE "^${tool}[[:space:]]" "$file"; then
+        local tmpfile="$file.tmp"
+        trap 'rm -f "$tmpfile"' EXIT
         awk -v tool="$tool" -v ver="$version" '
             $1 == tool { print tool " " ver; next }
             { print }
-        ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+        ' "$file" > "$tmpfile"
+        mv "$tmpfile" "$file"
+        trap - EXIT
     else
         echo "$tool $version" >> "$file"
     fi
@@ -100,8 +90,12 @@ if [[ "$VERSION_MANAGER" != "none" ]] && [[ ! -f .mise.toml ]]; then
         existing_ruby=$(awk '$1 == "ruby" { print $2; exit }' .tool-versions)
         if [[ "$existing_node" != "$NODE_VER" ]] || [[ "$existing_ruby" != "$RUBY_VER" ]]; then
             echo "📝 Updating .tool-versions to match .node-version/.ruby-version..."
+            [[ -z "$existing_node" ]] && \
+                echo "   nodejs: (new) $NODE_VER"
             [[ -n "$existing_node" ]] && [[ "$existing_node" != "$NODE_VER" ]] && \
                 echo "   nodejs: $existing_node → $NODE_VER"
+            [[ -z "$existing_ruby" ]] && \
+                echo "   ruby:   (new) $RUBY_VER"
             [[ -n "$existing_ruby" ]] && [[ "$existing_ruby" != "$RUBY_VER" ]] && \
                 echo "   ruby:   $existing_ruby → $RUBY_VER"
         fi
@@ -155,7 +149,10 @@ if [[ -z "$NODE_VERSION" ]]; then
 fi
 if ! node_version_supported "$NODE_VERSION"; then
     echo "❌ Error: Node.js version v$NODE_VERSION is unsupported. Shakapacker requires Node.js ^20.19.0 || >=22.12.0"
-    if [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .tool-versions ]]; then
+    if [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .mise.toml ]]; then
+        echo "   Hint: .mise.toml is the authoritative mise config for this workspace."
+        echo "   Update the Node version in .mise.toml, then run \`mise install\` and rerun setup."
+    elif [[ "$VERSION_MANAGER" == "mise" ]] && [[ -f .tool-versions ]]; then
         echo "   Hint: .tool-versions pins nodejs $(awk '$1 == "nodejs" { print $2; exit }' .tool-versions || echo '?')."
         echo "   Update .node-version and rerun setup, or run \`mise install\` after fixing .tool-versions."
     else

--- a/test/packages/warning-codes.test.js
+++ b/test/packages/warning-codes.test.js
@@ -11,10 +11,7 @@ const webpackWrapperPath = join(
   repoRoot,
   "packages/shakapacker-webpack/index.js"
 )
-const rspackWrapperPath = join(
-  repoRoot,
-  "packages/shakapacker-rspack/index.js"
-)
+const rspackWrapperPath = join(repoRoot, "packages/shakapacker-rspack/index.js")
 
 const extractCodes = (path) => {
   const source = readFileSync(path, "utf8")

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -187,20 +187,60 @@ describe("setup scripts", () => {
       fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
       fs.writeFileSync(path.join(tempDir, ".node-version"), "22.20.0\n")
       const toolVersionsPath = path.join(tempDir, ".tool-versions")
-      fs.writeFileSync(toolVersionsPath, "ruby 3.3.4\nnodejs 22.20.0\n")
-      const mtimeBefore = fs.statSync(toolVersionsPath).mtimeMs
-
-      // Wait a touch to ensure any rewrite would change mtime.
-      const waitUntil = Date.now() + 20
-      while (Date.now() < waitUntil) {
-        // busy-wait briefly
-      }
+      // Compare contents instead of mtime — mtime granularity varies by filesystem
+      // (1s on HFS+ and some Docker volumes) and would let a same-second rewrite slip through.
+      const contentsBefore = "ruby 3.3.4\nnodejs 22.20.0\n"
+      fs.writeFileSync(toolVersionsPath, contentsBefore)
 
       const result = runConductorSetup()
 
       expect(result.status).toBe(0)
       expect(result.stdout).not.toContain("Updating .tool-versions")
-      expect(fs.statSync(toolVersionsPath).mtimeMs).toBe(mtimeBefore)
+      expect(result.stdout).toContain(".tool-versions already in sync")
+      expect(fs.readFileSync(toolVersionsPath, "utf8")).toBe(contentsBefore)
+    })
+
+    it("preserves a supported nodejs pin in .tool-versions when .node-version is absent", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      // No .node-version — the supported pin in .tool-versions should be authoritative
+      // instead of being silently downgraded to DEFAULT_NODE_VERSION.
+      const contentsBefore = "ruby 3.3.4\nnodejs 23.5.0\n"
+      fs.writeFileSync(path.join(tempDir, ".tool-versions"), contentsBefore)
+
+      const result = runConductorSetup({ FAKE_NODE_VERSION: "v23.5.0" })
+
+      expect(result.status).toBe(0)
+      expect(
+        fs.readFileSync(path.join(tempDir, ".tool-versions"), "utf8")
+      ).toBe(contentsBefore)
+    })
+
+    it("rejects a malformed pre-release Node version like 22.12.0-rc1", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "22.12.0-rc1\n")
+
+      const result = runConductorSetup({ FAKE_NODE_VERSION: "v22.12.0-rc1" })
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain("unsupported")
+      expect(result.stderr).toContain(".node-version")
+    })
+
+    it("appends a new entry on its own line when .tool-versions lacks a trailing newline", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      // No .node-version; a supported nodejs pin in .tool-versions stays authoritative.
+      // Seed .tool-versions WITHOUT a trailing newline so the append path is exercised.
+      fs.writeFileSync(path.join(tempDir, ".tool-versions"), "nodejs 22.20.0")
+
+      const result = runConductorSetup()
+
+      expect(result.status).toBe(0)
+      expect(
+        fs.readFileSync(path.join(tempDir, ".tool-versions"), "utf8")
+      ).toBe("nodejs 22.20.0\nruby 3.3.4\n")
     })
   })
 

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -1,0 +1,144 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { spawnSync } = require("child_process")
+
+const rootDir = path.resolve(__dirname, "../..")
+const conductorSetupPath = path.join(rootDir, "conductor-setup.sh")
+const nodeVersionCheckPath = path.join(rootDir, "bin/lib/node-version-check.sh")
+const binSetupPath = path.join(rootDir, "bin/setup")
+
+const hasZsh =
+  spawnSync("zsh", ["--version"], { encoding: "utf8" }).status === 0
+const zshDescribe = hasZsh ? describe : describe.skip
+
+describe("setup scripts", () => {
+  let tempDir
+  let fakeBin
+
+  function copyScript(relativePath) {
+    const source = path.join(rootDir, relativePath)
+    const destination = path.join(tempDir, relativePath)
+    fs.mkdirSync(path.dirname(destination), { recursive: true })
+    fs.copyFileSync(source, destination)
+    fs.chmodSync(destination, 0o755)
+  }
+
+  function writeExecutable(name, content) {
+    const filePath = path.join(fakeBin, name)
+    fs.writeFileSync(filePath, content, "utf8")
+    fs.chmodSync(filePath, 0o755)
+  }
+
+  function installFakeTools({ failMv = false } = {}) {
+    writeExecutable(
+      "mise",
+      '#!/usr/bin/env bash\ncase "$1" in\n  trust|install) exit 0 ;;\n  *) exit 0 ;;\nesac\n'
+    )
+    writeExecutable(
+      "ruby",
+      '#!/usr/bin/env bash\necho "ruby 3.3.4 (2024-07-09 revision be1089c8ec)"\n'
+    )
+    writeExecutable(
+      "node",
+      '#!/usr/bin/env bash\necho "$' + '{FAKE_NODE_VERSION:-v22.20.0}"\n'
+    )
+    writeExecutable("bundle", "#!/usr/bin/env bash\nexit 0\n")
+    writeExecutable("yarn", "#!/usr/bin/env bash\nexit 0\n")
+    writeExecutable("npx", "#!/usr/bin/env bash\nexit 0\n")
+    if (failMv) {
+      writeExecutable(
+        "mv",
+        '#!/usr/bin/env bash\nif [[ "$1" == ".tool-versions.tmp" ]]; then\n  exit 1\nfi\n/bin/mv "$@"\n'
+      )
+    }
+  }
+
+  function runConductorSetup(extraEnv = {}) {
+    return spawnSync("zsh", ["-f", "conductor-setup.sh"], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        ...extraEnv,
+        PATH: `${fakeBin}:${process.env.PATH}`
+      },
+      encoding: "utf8"
+    })
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "setup-scripts-test-"))
+    fakeBin = path.join(tempDir, "fake-bin")
+    fs.mkdirSync(fakeBin)
+    fs.mkdirSync(path.join(tempDir, ".husky"))
+    copyScript("conductor-setup.sh")
+    copyScript("bin/setup")
+    if (fs.existsSync(nodeVersionCheckPath)) {
+      copyScript("bin/lib/node-version-check.sh")
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  zshDescribe("conductor-setup.sh", () => {
+    it("points mise users at .mise.toml when it controls an unsupported Node version", () => {
+      installFakeTools()
+      fs.writeFileSync(
+        path.join(tempDir, ".mise.toml"),
+        '[tools]\nnode = "21.0.0"\n'
+      )
+      fs.writeFileSync(path.join(tempDir, ".tool-versions"), "nodejs 22.20.0\n")
+
+      const result = runConductorSetup({ FAKE_NODE_VERSION: "v21.0.0" })
+
+      expect(result.status).toBe(1)
+      expect(result.stdout).toContain(".mise.toml")
+      expect(result.stdout).not.toContain("after fixing .tool-versions")
+    })
+
+    it("prints new .tool-versions entries when adding missing tools", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "22.20.0\n")
+      fs.writeFileSync(path.join(tempDir, ".tool-versions"), "ruby 3.3.4\n")
+
+      const result = runConductorSetup()
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain("nodejs: (new) 22.20.0")
+      expect(
+        fs.readFileSync(path.join(tempDir, ".tool-versions"), "utf8")
+      ).toBe("ruby 3.3.4\nnodejs 22.20.0\n")
+    })
+
+    it("removes .tool-versions.tmp if replacing an existing tool line fails", () => {
+      installFakeTools({ failMv: true })
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "22.20.0\n")
+      fs.writeFileSync(
+        path.join(tempDir, ".tool-versions"),
+        "ruby 3.2.2\nnodejs 22.20.0\n"
+      )
+
+      const result = runConductorSetup()
+
+      expect(result.status).not.toBe(0)
+      expect(fs.existsSync(path.join(tempDir, ".tool-versions.tmp"))).toBe(
+        false
+      )
+    })
+  })
+
+  it("keeps the Node engine check in a shared sourced script", () => {
+    const conductorSetup = fs.readFileSync(conductorSetupPath, "utf8")
+    const binSetup = fs.readFileSync(binSetupPath, "utf8")
+
+    expect(fs.existsSync(nodeVersionCheckPath)).toBe(true)
+    expect(conductorSetup).toContain("bin/lib/node-version-check.sh")
+    expect(binSetup).toContain("bin/lib/node-version-check.sh")
+    expect(conductorSetup).not.toMatch(/^node_version_supported\(\)/m)
+    expect(binSetup).not.toMatch(/^node_version_supported\(\)/m)
+  })
+})

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -66,6 +66,19 @@ describe("setup scripts", () => {
     })
   }
 
+  function runBinSetup(extraEnv = {}) {
+    return spawnSync("bash", ["bin/setup"], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        ...extraEnv,
+        BASH_ENV: "",
+        PATH: `${fakeBin}:${process.env.PATH}`
+      },
+      encoding: "utf8"
+    })
+  }
+
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "setup-scripts-test-"))
     fakeBin = path.join(tempDir, "fake-bin")
@@ -128,6 +141,83 @@ describe("setup scripts", () => {
       expect(fs.existsSync(path.join(tempDir, ".tool-versions.tmp"))).toBe(
         false
       )
+    })
+
+    it("updates a stale nodejs entry in .tool-versions to match .node-version", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "22.20.0\n")
+      fs.writeFileSync(
+        path.join(tempDir, ".tool-versions"),
+        "ruby 3.3.4\nnodejs 22.2.0\n"
+      )
+
+      const result = runConductorSetup()
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain("nodejs: 22.2.0 → 22.20.0")
+      expect(
+        fs.readFileSync(path.join(tempDir, ".tool-versions"), "utf8")
+      ).toBe("ruby 3.3.4\nnodejs 22.20.0\n")
+    })
+
+    it("accepts a v-prefixed .node-version", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "v22.20.0\n")
+
+      const result = runConductorSetup()
+
+      expect(result.status).toBe(0)
+    })
+
+    it("does not rewrite .tool-versions when versions already match", () => {
+      installFakeTools()
+      fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
+      fs.writeFileSync(path.join(tempDir, ".node-version"), "22.20.0\n")
+      const toolVersionsPath = path.join(tempDir, ".tool-versions")
+      fs.writeFileSync(toolVersionsPath, "ruby 3.3.4\nnodejs 22.20.0\n")
+      const mtimeBefore = fs.statSync(toolVersionsPath).mtimeMs
+
+      // Wait a touch to ensure any rewrite would change mtime.
+      const waitUntil = Date.now() + 20
+      while (Date.now() < waitUntil) {
+        // busy-wait briefly
+      }
+
+      const result = runConductorSetup()
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).not.toContain("Updating .tool-versions")
+      expect(fs.statSync(toolVersionsPath).mtimeMs).toBe(mtimeBefore)
+    })
+  })
+
+  describe("bin/setup", () => {
+    it("rejects an unsupported Node version", () => {
+      installFakeTools()
+      const result = runBinSetup({ FAKE_NODE_VERSION: "v21.0.0" })
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain("unsupported")
+    })
+
+    it("accepts a v-prefixed supported Node version", () => {
+      installFakeTools()
+      const result = runBinSetup({ FAKE_NODE_VERSION: "v22.20.0" })
+
+      expect(result.status).toBe(0)
+    })
+
+    it("surfaces the raw output when node -v cannot be parsed", () => {
+      installFakeTools()
+      writeExecutable("node", '#!/usr/bin/env bash\necho "garbage output"\n')
+
+      const result = runBinSetup()
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain("Could not parse Node.js version")
+      expect(result.stderr).toContain("garbage output")
     })
   })
 

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -107,8 +107,8 @@ describe("setup scripts", () => {
       const result = runConductorSetup({ FAKE_NODE_VERSION: "v21.0.0" })
 
       expect(result.status).toBe(1)
-      expect(result.stdout).toContain(".mise.toml")
-      expect(result.stdout).not.toContain("after fixing .tool-versions")
+      expect(result.stderr).toContain(".mise.toml")
+      expect(result.stderr).not.toContain("after fixing .tool-versions")
     })
 
     it("prints new .tool-versions entries when adding missing tools", () => {
@@ -161,7 +161,7 @@ describe("setup scripts", () => {
       ).toBe("ruby 3.3.4\nnodejs 22.20.0\n")
     })
 
-    it("accepts a v-prefixed .node-version", () => {
+    it("accepts a v-prefixed .node-version and writes the version without the prefix to .tool-versions", () => {
       installFakeTools()
       fs.writeFileSync(path.join(tempDir, ".ruby-version"), "3.3.4\n")
       fs.writeFileSync(path.join(tempDir, ".node-version"), "v22.20.0\n")
@@ -169,6 +169,12 @@ describe("setup scripts", () => {
       const result = runConductorSetup()
 
       expect(result.status).toBe(0)
+      const toolVersions = fs.readFileSync(
+        path.join(tempDir, ".tool-versions"),
+        "utf8"
+      )
+      expect(toolVersions).toContain("nodejs 22.20.0")
+      expect(toolVersions).not.toContain("nodejs v22.20.0")
     })
 
     it("does not rewrite .tool-versions when versions already match", () => {

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -41,7 +41,7 @@ describe("setup scripts", () => {
     )
     writeExecutable(
       "node",
-      '#!/usr/bin/env bash\necho "$' + '{FAKE_NODE_VERSION:-v22.20.0}"\n'
+      `#!/usr/bin/env bash\necho "\${FAKE_NODE_VERSION:-v22.20.0}"\n`
     )
     writeExecutable("bundle", "#!/usr/bin/env bash\nexit 0\n")
     writeExecutable("yarn", "#!/usr/bin/env bash\nexit 0\n")

--- a/test/scripts/setup-scripts.test.js
+++ b/test/scripts/setup-scripts.test.js
@@ -10,6 +10,11 @@ const binSetupPath = path.join(rootDir, "bin/setup")
 
 const hasZsh =
   spawnSync("zsh", ["--version"], { encoding: "utf8" }).status === 0
+if (!hasZsh) {
+  console.warn(
+    "[setup-scripts.test.js] zsh not found — conductor-setup.sh tests will be skipped. Install zsh to run them."
+  )
+}
 const zshDescribe = hasZsh ? describe : describe.skip
 
 describe("setup scripts", () => {


### PR DESCRIPTION
### Summary

After #1099 bumped the Node engine to `^20.19.0 || >=22.12.0`, users whose `.tool-versions` was generated by an earlier setup run were stuck on `nodejs 22.2.0` — `conductor-setup.sh` only created the file when missing, so the stale pin kept making mise install an unsupported Node and `yarn install` failed at the `@rspack/core` engine check instead of at a clear setup-time message. `conductor-setup.sh` now syncs the `nodejs`/`ruby` lines on every run (preserving other entries via an in-place awk update) and validates the resolved Node version against the engine range **before** touching `.tool-versions`, so an unsupported `.node-version` fails fast with fix instructions. `bin/setup` previously only checked that `node --version` succeeded; it now performs the same engine-range validation so direct (non-Conductor) users get the same clear error.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (shell-only setup scripts; manually verified across clean, stale, and unsupported `.node-version`/`.tool-versions` scenarios)
- ~[ ] Update documentation~ (no user-facing docs reference these scripts)
- ~[ ] Update CHANGELOG file~ (per project convention, internal/dev-tooling fixes are not user-visible)

### Other Information

Both scripts share the same `node_version_supported()` helper (matches `package.json` `engines`). Validated scenarios: clean state creates `.tool-versions`; stale `.tool-versions` (`nodejs 22.2.0`) with current `.node-version` (`22.20.0`) updates the stale line and prints the `22.2.0 → 22.20.0` transition; unsupported `.node-version` exits before mise install with fix instructions; `bin/setup` exits 1 with a clear error on unsupported Node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-tooling change that only affects local setup flows; main risk is false positives/negatives in the new shell version parsing/comparison on edge-case Node/Ruby version strings.
> 
> **Overview**
> **Setup scripts now fail fast on unsupported Node and keep tool pins current.** A new shared `bin/lib/node-version-check.sh` provides `version_ge`/`node_version_supported` and is sourced by both `bin/setup` and `conductor-setup.sh`.
> 
> `conductor-setup.sh` now *syncs* the `ruby`/`nodejs` entries in `.tool-versions` on every run (in-place upsert while preserving other tools), normalizes `v`-prefixed `.node-version`, and errors early with actionable hints (including `.mise.toml` guidance) when the resolved Node version is outside `^20.19.0 || >=22.12.0`. `bin/setup` adds the same Node engine-range validation and improved parse-error output.
> 
> Adds Jest coverage for these setup-script behaviors (stale pins, missing newline, mv failure cleanup, pre-release rejection) and a tiny formatting tweak in `warning-codes.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bc62abf5405c2034ef0614b94764de95ffa5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced Node.js minimums (20.19.0+ or 22.12.0+) during setup and workspace provisioning.
  * Idempotent tool-version synchronization that inserts/updates only ruby/node entries and preserves other lines.

* **Bug Fixes**
  * Accepts and normalizes v-prefixed Node versions when reading inputs; rejects malformed pre-release versions.
  * Clearer, actionable error messages when Node is unsupported or unparsable.

* **Tests**
  * Expanded tests covering setup, workspace tool/version behaviors, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->