### PR TITLE
Fix syntax error in gemspec_spec.rb from #1110

### DIFF
--- a/spec/shakapacker/gemspec_spec.rb
+++ b/spec/shakapacker/gemspec_spec.rb
@@ -44,13 +44,12 @@ describe "shakapacker.gemspec" do
         "lib/install/package.json",
         "lib/install/config/shakapacker.yml",
         "lib/install/bin/shakapacker",
-        "lib/install/bin/shakapacker-dev-server"
-        "lib/install/bin/shakapacker",
         "lib/install/bin/shakapacker-dev-server",
         "lib/install/config/rspack/rspack.config.js",
         "lib/install/config/rspack/rspack.config.ts",
         "lib/install/config/webpack/webpack.config.js",
         "lib/install/config/webpack/webpack.config.ts"
+      )
     end
 
     it "includes RBS type signatures" do


### PR DESCRIPTION
## Summary

PR #1110 (merged earlier today) introduced a syntax error in `spec/shakapacker/gemspec_spec.rb`. The new "includes install assets needed by shakapacker:install" test duplicated two bin entries (with the first one missing its trailing comma) and omitted the closing `)` for `include(`. The file no longer parses as Ruby.

This breaks CI on every open PR against main:

- **Linting** (`bundle exec rubocop`): `Lint/Syntax: unexpected token tSTRING`
- **Testing** (`bundle exec rspec spec/shakapacker/*_spec.rb`): "1 error occurred outside of examples" — rspec aborts before running any test

## Fix

Removed the duplicated bin lines and added the missing closing paren.

\`\`\`diff
         "lib/install/bin/shakapacker",
-        "lib/install/bin/shakapacker-dev-server"
-        "lib/install/bin/shakapacker",
         "lib/install/bin/shakapacker-dev-server",
         "lib/install/config/rspack/rspack.config.js",
         ...
         "lib/install/config/webpack/webpack.config.ts"
+      )
     end
\`\`\`

## Test plan

- [x] \`bundle exec rubocop\` passes (140 files, no offenses)
- [x] \`bundle exec rspec spec/shakapacker/gemspec_spec.rb\` passes (9 examples, 0 failures)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that fixes a Ruby syntax error which was preventing lint/spec runs, without impacting runtime code paths.
> 
> **Overview**
> Fixes a syntax error in `spec/shakapacker/gemspec_spec.rb` that was breaking parsing/CI by removing duplicated `bin` entries in the `include(...)` list and restoring the missing closing `)` for the expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f02ed1a3ba80474488c5455c8bb133737ff55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->