### PR TITLE
Changed typo `ReactRefreshPlugin` to `ReactRefreshRspackPlugin` as part of the 2.0.0 upgrade from RsPack

### DIFF
--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -574,7 +574,7 @@ yarn add --dev @rspack/plugin-react-refresh
 Update your config:
 
 ```javascript
-const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
+const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
 const { rspack } = require("@rspack/core")
 
 module.exports = {

--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -574,11 +574,11 @@ yarn add --dev @rspack/plugin-react-refresh
 Update your config:
 
 ```javascript
-const ReactRefreshPlugin = require("@rspack/plugin-react-refresh")
+const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
 const { rspack } = require("@rspack/core")
 
 module.exports = {
-  plugins: [new ReactRefreshPlugin(), new rspack.HotModuleReplacementPlugin()]
+  plugins: [new ReactRefreshRspackPlugin(), new rspack.HotModuleReplacementPlugin()]
 }
 ```
 

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -151,7 +151,7 @@ Replace file loaders with asset modules:
 
 ```javascript
 // Development configuration
-const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
+const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
 
 module.exports = {
   plugins: [new ReactRefreshRspackPlugin(), new rspack.HotModuleReplacementPlugin()]

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -151,10 +151,10 @@ Replace file loaders with asset modules:
 
 ```javascript
 // Development configuration
-const ReactRefreshPlugin = require("@rspack/plugin-react-refresh")
+const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
 
 module.exports = {
-  plugins: [new ReactRefreshPlugin(), new rspack.HotModuleReplacementPlugin()]
+  plugins: [new ReactRefreshRspackPlugin(), new rspack.HotModuleReplacementPlugin()]
 }
 ```
 

--- a/package/environments/development.ts
+++ b/package/environments/development.ts
@@ -72,7 +72,7 @@ const rspackDevConfig = (): RspackConfigWithDevServer => {
     devServerConfig.hot &&
     moduleExists("@rspack/plugin-react-refresh")
   ) {
-    const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
+    const { ReactRefreshRspackPlugin } = require("@rspack/plugin-react-refresh")
     rspackConfig.plugins = [
       ...(rspackConfig.plugins || []),
       new ReactRefreshRspackPlugin()

--- a/package/environments/development.ts
+++ b/package/environments/development.ts
@@ -72,10 +72,10 @@ const rspackDevConfig = (): RspackConfigWithDevServer => {
     devServerConfig.hot &&
     moduleExists("@rspack/plugin-react-refresh")
   ) {
-    const ReactRefreshPlugin = require("@rspack/plugin-react-refresh")
+    const ReactRefreshRspackPlugin = require("@rspack/plugin-react-refresh")
     rspackConfig.plugins = [
       ...(rspackConfig.plugins || []),
-      new ReactRefreshPlugin()
+      new ReactRefreshRspackPlugin()
     ]
   }
 


### PR DESCRIPTION
### Summary

Changed the usage of `ReactRefreshPlugin` to `ReactRefreshRspackPlugin` as it has now been renamed by 2.0.0 of Rsack.
### Pull Request checklist

<!-- If any of the items on this checklist do not apply to the PR, both check it out and wrap it by `~`. -->

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React Fast Refresh configuration examples to reflect current Rspack integration guidance.

* **Bug Fixes**
  * Fixed development setup to properly use the correct React Fast Refresh plugin for Rspack.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1115)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->