### PR TITLE
ci: bump actions/create-github-app-token to v3

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -9,7 +9,7 @@ jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token@v1` → `@v3` in `.github/workflows/trigger-docs-site.yml`
- v1 runs on Node.js 20, which GitHub Actions deprecated; runners will remove Node 20 on 2026-09-16
- v3.0.0 added Node 24 support; our inputs (`app-id`, `private-key`, `owner`, `repositories`) are unchanged across majors, so no other workflow changes needed

## Context
This silences the Node 20 deprecation warning that the `notify-docs-site` job has been emitting on every docs-touching push to `main` (e.g. https://github.com/shakacode/shakapacker/actions/runs/26208889073).

Note: the 404 failure that workflow has been hitting since #988 was a separate issue — the `reactonrails-docs-dispatch` GitHub App wasn't installed on `shakacode/shakapacker.com`. That's now fixed at the App-installation level (handled out-of-band).

## Test plan
- [ ] Wait for next docs-touching push to `main` to see the workflow run cleanly under v3 with no deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a GitHub Actions dependency version in a docs-site trigger workflow, with no changes to inputs or runtime logic.
> 
> **Overview**
> Updates the docs-site rebuild workflow (`.github/workflows/trigger-docs-site.yml`) to use `actions/create-github-app-token@v3` instead of `@v1` while keeping the same GitHub App inputs and downstream `repository-dispatch` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187df3f1e3a5b33ef887b6702c629c0f0a13f086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->