### PR TITLE
docs: prettier --write three docs files to unblock CI

### DIFF
--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -685,7 +685,6 @@ For maximum performance improvements, you can combine multiple migrations:
 This combination provides the largest end-to-end build performance improvement available in Shakapacker: SWC handles transpilation in Rust (upstream reports up to [20x/70x vs Babel](https://swc.rs/)) and Rspack handles the rest of the bundler pipeline in Rust (upstream reports roughly [8–17x vs webpack on its own benchmark](https://rspack.rs/)). Apply them in order so you can attribute any regression to the right layer:
 
 1. **First, migrate to SWC** (while still on webpack)
-
    - Follow [Migrating from Babel to SWC](#migrating-from-babel-to-swc)
    - Test thoroughly
    - This is a smaller change to validate first

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -425,7 +425,6 @@ baseConfig.module.rules.forEach((rule) => {
 When upgrading to Shakapacker v10 with Rspack (or any v9+ app):
 
 1. **CSS Modules default exports → named exports**: This is a breaking change. Either:
-
    - Update your code to use named imports (recommended for new projects)
    - Override the configuration to keep default exports (easier for existing large codebases)
 

--- a/docs/v9_upgrade.md
+++ b/docs/v9_upgrade.md
@@ -141,7 +141,6 @@ import * as styles from './Component.module.css';
 **Migration Options:**
 
 1. **Update your code** (Recommended):
-
    - JavaScript: Change to named imports (`import { className }`)
    - TypeScript: Change to namespace imports (`import * as styles`)
    - Kebab-case class names are automatically converted to camelCase
@@ -199,7 +198,6 @@ import * as styles from './Component.module.css';
    ```
 
    **Key points:**
-
    - Test both `.module.scss` and `.module.css` file extensions
    - Validate all loader properties exist before accessing them
    - Use `.includes('css-loader')` since the loader path may vary


### PR DESCRIPTION
## Summary

The `Prettier format check` step in the `Node based checks` workflow has been failing on `main` itself (and on every downstream branch, e.g. [this run](https://github.com/shakacode/shakapacker/actions/runs/26209980435/job/77118323115)). Three files have blank lines inside numbered lists that prettier 3.6.2 does not allow:

- `docs/common-upgrades.md`
- `docs/rspack_migration_guide.md`
- `docs/v9_upgrade.md`

Root cause: PR #1109 (`[codex] Rewrite transpiler performance guide qualitatively`) was authored in the codex cloud workflow and bypassed the local husky `pre-commit` + `lint-staged` (`*.md` → `prettier --write`) hook, so the formatting drift landed on `main` and broke `prettier --check .` for every subsequent run.

This PR runs `yarn prettier --write` on just those three files. The diff is **4 deletions, 0 additions** — only blank lines between a numbered list item and its sub-bullets are removed. No prose is touched.

## Verification

```
$ yarn prettier --check .
Checking formatting...
All matched files use Prettier code style!
```

## Test plan

- [x] `yarn prettier --check .` passes locally
- [x] Diff inspected — formatting only, no content changes
- [ ] `Node based checks → Linting → Prettier format check` passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only whitespace/formatting changes with no code or behavioral impact.
> 
> **Overview**
> Fixes Prettier check failures by removing disallowed blank lines between numbered list items and their nested bullet points in `docs/common-upgrades.md`, `docs/rspack_migration_guide.md`, and `docs/v9_upgrade.md`.
> 
> No prose or guidance is changed; this is strictly markdown formatting to align with Prettier 3.6.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2bace80420fd89a16f3cce4177432f853461a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and structure across migration guides for better readability.
  * Enhanced clarity in CSS Modules migration options and combined migration path sections.
  * Better organized step-by-step instructions to simplify the upgrade process.
  * Refined bullet-point organization throughout migration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->