### PR TITLE
Fix shakapacker:check_node misreporting Node as missing in published gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed `shakapacker:check_node` reporting "Node.js not installed" in the published gem**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [justin808](https://github.com/justin808). The gemspec allowlist introduced in [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) dropped the gem-root `package.json` that `check_node.rake` reads for the `engines.node` range, so `Pathname#realpath` raised `Errno::ENOENT` and the outer rescue printed the misleading "Node.js not installed. Exiting!" — most visibly during `rails assets:precompile` via `shakapacker:clean` → `verify_install` → `check_node`. The gemspec now ships `package.json`, and `check_node.rake` skips the engines-range check gracefully if that file is ever missing rather than blaming Node.
+
 ## [v10.1.0-rc.0] - May 20, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- **Fixed `shakapacker:check_node` reporting "Node.js not installed" in the published gem**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [justin808](https://github.com/justin808). The gemspec allowlist introduced in [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) dropped the gem-root `package.json` that `check_node.rake` reads for the `engines.node` range, so `Pathname#realpath` raised `Errno::ENOENT` and the outer rescue printed the misleading "Node.js not installed. Exiting!" — most visibly during `rails assets:precompile` via `shakapacker:clean` → `verify_install` → `check_node`. The gemspec now ships `package.json`, and `check_node.rake` skips the engines-range check gracefully if that file is ever missing rather than blaming Node.
+- **Fixed `shakapacker:check_node` reporting "Node.js not installed" in the published gem**. [PR #1120](https://github.com/shakacode/shakapacker/pull/1120) by [justin808](https://github.com/justin808). The gemspec allowlist introduced in [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) dropped the gem-root `package.json` that `check_node.rake` reads for the `engines.node` range, so `Pathname#realpath` raised `Errno::ENOENT` and the outer rescue printed the misleading "Node.js not installed. Exiting!" — most visibly during `rails assets:precompile` via `shakapacker:clean` → `verify_install` → `check_node`. The gemspec now ships `package.json`, and `check_node.rake` skips the engines-range check gracefully if that file is ever missing rather than blaming Node.
 
 ## [v10.1.0-rc.0] - May 20, 2026
 

--- a/lib/tasks/shakapacker/check_node.rake
+++ b/lib/tasks/shakapacker/check_node.rake
@@ -6,21 +6,25 @@ namespace :shakapacker do
       node_version = `node -v || nodejs -v`.strip
       raise Errno::ENOENT if node_version.blank?
 
-      pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
-      node_range = JSON.parse(pkg_path.read)["engines"]["node"]
-      is_valid = SemanticRange.satisfies?(node_version, node_range) rescue false
-      semver_major = node_version[/\d+/] rescue nil
-      is_unstable = semver_major.to_i.odd? rescue false
+      # Skip the engines.node range check if the gem-root package.json
+      # isn't shipped, so a missing file doesn't masquerade as Node missing.
+      pkg_path = Pathname.new("#{__dir__}/../../../package.json")
+      if pkg_path.exist?
+        node_range = JSON.parse(pkg_path.read)["engines"]["node"]
+        is_valid = SemanticRange.satisfies?(node_version, node_range) rescue false
+        semver_major = node_version[/\d+/] rescue nil
+        is_unstable = semver_major.to_i.odd? rescue false
 
-      if is_unstable
-        $stderr.puts "Warning: you are using an unstable release of Node.js (#{node_version}). If you encounter issues with Node.js, consider switching to an Active LTS release. More info: https://docs.npmjs.com/try-the-latest-stable-version-of-node"
-      end
+        if is_unstable
+          $stderr.puts "Warning: you are using an unstable release of Node.js (#{node_version}). If you encounter issues with Node.js, consider switching to an Active LTS release. More info: https://docs.npmjs.com/try-the-latest-stable-version-of-node"
+        end
 
-      unless is_valid
-        $stderr.puts "Shakapacker requires Node.js \"#{node_range}\" and you are using #{node_version}"
-        $stderr.puts "Please upgrade Node.js https://nodejs.org/en/download/"
-        $stderr.puts "Exiting!"
-        exit!
+        unless is_valid
+          $stderr.puts "Shakapacker requires Node.js \"#{node_range}\" and you are using #{node_version}"
+          $stderr.puts "Please upgrade Node.js https://nodejs.org/en/download/"
+          $stderr.puts "Exiting!"
+          exit!
+        end
       end
     rescue Errno::ENOENT
       $stderr.puts "Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/"

--- a/shakapacker.gemspec
+++ b/shakapacker.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop"
   s.add_development_dependency "rubocop-performance"
 
-  s.files = `git ls-files -z CHANGELOG.md MIT-LICENSE README.md shakapacker.gemspec lib sig`.split("\x0")
+  s.files = `git ls-files -z CHANGELOG.md MIT-LICENSE README.md package.json shakapacker.gemspec lib sig`.split("\x0")
   s.test_files = []
 end

--- a/spec/shakapacker/gemspec_spec.rb
+++ b/spec/shakapacker/gemspec_spec.rb
@@ -37,6 +37,10 @@ describe "shakapacker.gemspec" do
       expect(lib_files).not_to be_empty
     end
 
+    it "includes the gem-root package.json read by shakapacker:check_node" do
+      expect(gemspec.files).to include("package.json")
+    end
+
     it "includes install assets needed by shakapacker:install" do
       expect(gemspec.files).to include(
         "lib/install/template.rb",


### PR DESCRIPTION
## Summary

- **Root cause:** [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) slimmed `shakapacker.gemspec` to an explicit allowlist (`CHANGELOG.md MIT-LICENSE README.md shakapacker.gemspec lib sig`), which dropped the gem-root `package.json` from the published gem. But `lib/tasks/shakapacker/check_node.rake` still reads it via `Pathname.new("#{__dir__}/../../../package.json").realpath` for the `engines.node` range. In the installed gem `realpath` raises `Errno::ENOENT`, the outer `rescue Errno::ENOENT` swallows it, and the task prints the misleading `Node.js not installed. Exiting!` — most visibly during `bundle exec rails assets:precompile`, since `react_on_rails` enhances that task to invoke `shakapacker:clean` → `verify_install` → `check_node` (and Node had just run the webpack build seconds earlier).
- **Fixes:**
  - `shakapacker.gemspec` — re-add `package.json` to the allowlist so the published gem contains the file `check_node.rake` reads.
  - `lib/tasks/shakapacker/check_node.rake` — drop `.realpath` and gate the engines-range check on `pkg_path.exist?`. If `package.json` is ever absent again, the task skips the version check rather than blaming Node.
  - `spec/shakapacker/gemspec_spec.rb` — regression test asserting `gemspec.files.include?("package.json")`, so a future allowlist trim cannot silently re-break this.
  - `CHANGELOG.md` — Fixed entry under `[Unreleased]`.
- **Gem footprint:** went from 75 files (~121K) to 76 files; `package.json` is ~6.7K, so the slim-gem goal of [#1110](https://github.com/shakacode/shakapacker/pull/1110) is essentially preserved.

## Repro (before fix)

```
$ mv package.json /tmp/ && cd spec/shakapacker/test_app
$ bundle exec rake shakapacker:check_node
Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/
Exiting!
$ node -v
v22.20.0   # Node was here the whole time
```

## Test plan

- [x] Reproduced the bug on baseline (above).
- [x] After fix: same scenario with `package.json` hidden → `rake shakapacker:check_node` exits 0 silently (no false Node error).
- [x] Happy path unchanged: `rake shakapacker:check_node` from `spec/shakapacker/test_app` exits 0.
- [x] `bundle exec rspec spec/shakapacker/gemspec_spec.rb spec/shakapacker/rake_tasks_spec.rb` → 24 examples, 0 failures.
- [x] `bundle exec rubocop shakapacker.gemspec lib/tasks/shakapacker/check_node.rake spec/shakapacker/gemspec_spec.rb` → 0 offenses.
- [x] `bundle exec gem build shakapacker.gemspec` → succeeds; `tar -tz` on the resulting gem confirms both `package.json` and `lib/install/package.json` ship.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small packaging + rake-task guard changes that only affect Node version checking and error messaging when `package.json` is missing.
> 
> **Overview**
> Fixes `shakapacker:check_node` incorrectly reporting Node as missing in the published gem by **shipping the gem-root `package.json`** again and making the task **skip the `engines.node` validation when that file isn’t present**.
> 
> Adds a regression spec to ensure `package.json` remains included in `shakapacker.gemspec`, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f8d4bc07b147008aa69652a28276bf468ecb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `shakapacker:check_node` task incorrectly reporting "Node.js not installed" when the gem package was missing `package.json`.
  * Gem packaging now includes `package.json` to ensure proper Node.js version validation.
  * Task now gracefully skips version range checks when `package.json` is unavailable instead of raising errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->