### PR TITLE
Update spec/dummy Gemfile.lock for shakapacker 10.1.0-rc.0

### DIFF
--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (10.0.0)
+    shakapacker (10.1.0.rc.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)


### PR DESCRIPTION
## Summary

Regenerate `spec/dummy/Gemfile.lock` so its PATH entry references the current
gem version (`10.1.0.rc.0` instead of `10.0.0`).

The 10.1.0-rc.0 release commit ([04e43957](https://github.com/shakacode/shakapacker/commit/04e43957)) bumped `Shakapacker::VERSION` and the root `Gemfile.lock` but missed `spec/dummy/Gemfile.lock`. CI runs `bundle install` with `bundler-cache: true`, which uses frozen mode; bundler detects the path-gem version drift and fails:

```
The gemspecs for path gems changed, but the lockfile can't be updated
because frozen mode is set
```

This breaks **Test Bundler Switching / Test with Webpack / Test with RSpack** on every PR until the dummy lockfile is regenerated.

Evidence this is pre-existing on `main`, not caused by recent PRs:
- [Failed run on main @ 04e43957](https://github.com/shakacode/shakapacker/actions/runs/26214562408)
- Same failure surfaces on unrelated PR #1120

## Changes

- `spec/dummy/Gemfile.lock`: PATH spec bumped from `shakapacker (10.0.0)` → `shakapacker (10.1.0.rc.0)`. One-line diff.

Bundler renders the pre-release version with a dot (`10.1.0.rc.0`) rather than a dash, which matches existing behavior.

## Prior art

PRs #957 and #971 added release-script logic to keep `spec/dummy` in sync during version bumps. That automation evidently didn't fire for the 10.1.0-rc.0 release. **Diagnosing/fixing the release-script gap is intentionally out of scope here** and will be a separate follow-up — this PR is lockfile-only to unblock CI immediately.

## Test plan

- [x] `(cd spec/dummy && BUNDLE_FROZEN=true bundle check)` exits 0 — this is what CI's frozen install actually validates
- [x] `git diff origin/main -- spec/dummy/Gemfile.lock` shows only the shakapacker PATH version line
- [x] `bundle exec rubocop` passes (no-op; no Ruby changes)
- [x] Root `Gemfile.lock` untouched (already on `10.1.0.rc.0`)
- [ ] CI green on Test Both Bundlers / Webpack / RSpack jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change updating the local path gem version; minimal functional risk aside from potential CI/bundler resolution differences if inconsistent with other locks.
> 
> **Overview**
> Updates `spec/dummy/Gemfile.lock` so the PATH dependency on `shakapacker` matches the current prerelease version (`10.1.0.rc.0` instead of `10.0.0`), keeping the dummy app lockfile in sync and avoiding frozen-bundler failures in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f187eda8ea14bddb0e27fe7c3579d26620a400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->