### PR TITLE
Gitignore Claude Code ScheduleWakeup runtime lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ gemfiles/*.lock
 .DS_Store
 .eslintcache
 
+# Claude Code ScheduleWakeup per-process runtime lock
+.claude/*.lock
+
 .yalc
 yalc.lock
 


### PR DESCRIPTION
## Summary

- `.claude/scheduled_tasks.lock` is Claude Code's per-process lock for the `ScheduleWakeup` mechanism. It holds session-specific state (`sessionId`, `pid`, `procStart`, `acquiredAt`) and gets rewritten on every Claude Code session that uses ScheduleWakeup.
- Without this rule it shows up as an untracked file in every contributor's `git status` (and creates noise in `.context/attachments/...` comments).
- Pattern uses `.claude/*.lock` so any future per-process lock files Claude Code adds are also covered, without ignoring the tracked `.claude/commands/` and `.claude/rules/` content.

## Test plan

- [x] `git check-ignore -v .claude/scheduled_tasks.lock` reports the new rule matches (`.gitignore:18:.claude/*.lock`).
- [x] `git status` no longer shows the lock file as untracked.
- [x] No existing tracked files in `.claude/` match `*.lock` (`git ls-files .claude/` shows only `.md` files), so this rule doesn't accidentally exclude anything currently in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `.gitignore` pattern to exclude transient Claude Code runtime lock files and does not affect application logic or build output.
> 
> **Overview**
> Prevents Claude Code `ScheduleWakeup` per-process runtime lock files from showing up as untracked by ignoring `.claude/*.lock` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ec23cc59e5b7bac8bbc9481910824e80db2e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->