### PR TITLE
CHANGELOG: merge PR #1120 into PR #1110 entry for v10.1.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 ### Changed
 
 - **Changed `shakapacker:install` to default fresh Rspack installs to v2 (`^2.0.0-0`)**. [PR #1091](https://github.com/shakacode/shakapacker/pull/1091) by [ihabadham](https://github.com/ihabadham). `lib/install/package.json` now declares `@rspack/core` and `@rspack/cli` as `^1.0.0 || ^2.0.0-0`; fresh installs pick the v2 range. Existing apps are unaffected. Note: Rspack v2 requires Node.js 20.19.0+.
-- **Slimmed the published gem from ~486K (294 files) to ~121K (75 files)**. [PR #1110](https://github.com/shakacode/shakapacker/pull/1110) by [justin808](https://github.com/justin808). Replaced the broad `git ls-files` gem manifest with an explicit runtime/install allowlist (`CHANGELOG.md`, `MIT-LICENSE`, `README.md`, gemspec, `lib`, `sig`), excluding repo-only docs, tests, JavaScript package source, CI/tooling files, and `test_files` metadata from the published gem. Fixes [#987](https://github.com/shakacode/shakapacker/issues/987).
+- **Slimmed the published gem from ~486K (294 files) to ~121K (75 files)**. [PR #1110](https://github.com/shakacode/shakapacker/pull/1110), [PR #1120](https://github.com/shakacode/shakapacker/pull/1120) by [justin808](https://github.com/justin808). Replaced the broad `git ls-files` gem manifest with an explicit runtime/install allowlist (`CHANGELOG.md`, `MIT-LICENSE`, `README.md`, gemspec, `lib`, `sig`, `package.json`), excluding repo-only docs, tests, JavaScript package source, CI/tooling files, and `test_files` metadata from the published gem. Fixes [#987](https://github.com/shakacode/shakapacker/issues/987).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Follow-up to #1124. Per maintainer feedback ("we might just merge both entries"), update the `v10.1.0-rc.1` changelog so the PR #1110 entry reflects the **final shipped state** instead of dropping the PR #1120 fix entirely.

- Credit both PRs in the link list: `[PR #1110](…), [PR #1120](…)`
- Add `package.json` to the documented allowlist — that's what actually ships in v10.1.0-rc.1 thanks to PR #1120

This is a docs-only change. The released gem and tag are unaffected. If you want the GitHub release notes for v10.1.0-rc.1 to reflect this too, the release notes need to be edited on GitHub after this merges.

The companion `/update-changelog` command update in #1125 already prefers this "merge into the original PR entry" approach over "drop entirely".

## Test plan

- [ ] Maintainer confirms the merged entry reads correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change updating a single changelog entry; no runtime code or packaging behavior is modified.
> 
> **Overview**
> Updates the `v10.1.0-rc.1` changelog entry for the gem size reduction to reflect the final shipped state by **crediting both** [PR #1110] and [PR #1120] and by **including `package.json`** in the documented gem file allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d3a201dcdfc193582b38794838acaa623436db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->