### PR TITLE
Tighten helper binstub parity and PATH lookup

### DIFF
--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -29,8 +29,10 @@ end
 
 def shakapacker_find_executable(executable)
   ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    search_path = path.empty? ? Dir.pwd : path
+
     shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(path, candidate)
+      executable_path = File.join(search_path, candidate)
       return executable_path if File.file?(executable_path) && File.executable?(executable_path)
     end
   end

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -28,7 +28,7 @@ def shakapacker_executable_candidates(executable)
 end
 
 def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
     search_path = path.empty? ? Dir.pwd : path
 
     shakapacker_executable_candidates(executable).each do |candidate|

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -29,8 +29,10 @@ end
 
 def shakapacker_find_executable(executable)
   ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    search_path = path.empty? ? Dir.pwd : path
+
     shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(path, candidate)
+      executable_path = File.join(search_path, candidate)
       return executable_path if File.file?(executable_path) && File.executable?(executable_path)
     end
   end

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -28,7 +28,7 @@ def shakapacker_executable_candidates(executable)
 end
 
 def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
     search_path = path.empty? ? Dir.pwd : path
 
     shakapacker_executable_candidates(executable).each do |candidate|

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -556,7 +556,7 @@ def shakapacker_executable_candidates(executable)
 end
 
 def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
     search_path = path.empty? ? Dir.pwd : path
 
     shakapacker_executable_candidates(executable).each do |candidate|

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -516,7 +516,8 @@ function runInitCommand(options: ExportOptions): number {
   return 0
 }
 
-// Exported for test use only: verifies generated content matches lib/install/bin/* binstubs.
+// Exported for test/configExporter/createBinStub.test.js, which verifies the
+// generated content matches the checked-in lib/install/bin/* binstubs.
 export function createBinStub(binStubPath: string): void {
   const binDir = dirname(binStubPath)
   const packageScript = `${basename(binStubPath)}.cjs`

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1,7 +1,13 @@
 // This will be a substantial file - the main CLI entry point
 // Originally migrated from bin/export-bundler-config, now bin/shakapacker-config
 
-import { existsSync, readFileSync, writeFileSync } from "fs"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync
+} from "fs"
 import { resolve, dirname, sep, delimiter, basename } from "path"
 import { inspect } from "util"
 import { load as loadYaml } from "js-yaml"
@@ -510,10 +516,10 @@ function runInitCommand(options: ExportOptions): number {
   return 0
 }
 
-function createBinStub(binStubPath: string): void {
+// Exported for test use only: verifies generated content matches lib/install/bin/* binstubs.
+export function createBinStub(binStubPath: string): void {
   const binDir = dirname(binStubPath)
   const packageScript = `${basename(binStubPath)}.cjs`
-  const { mkdirSync, chmodSync } = require("fs")
 
   // Ensure bin directory exists
   if (!existsSync(binDir)) {

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -557,8 +557,10 @@ end
 
 def shakapacker_find_executable(executable)
   ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    search_path = path.empty? ? Dir.pwd : path
+
     shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(path, candidate)
+      executable_path = File.join(search_path, candidate)
       return executable_path if File.file?(executable_path) && File.executable?(executable_path)
     end
   end

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -516,8 +516,7 @@ function runInitCommand(options: ExportOptions): number {
   return 0
 }
 
-// Exported for test/configExporter/createBinStub.test.js, which verifies the
-// generated content matches the checked-in lib/install/bin/* binstubs.
+// Exported for test use only: verifies generated content matches lib/install/bin/* binstubs.
 export function createBinStub(binStubPath: string): void {
   const binDir = dirname(binStubPath)
   const packageScript = `${basename(binStubPath)}.cjs`

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -516,7 +516,12 @@ function runInitCommand(options: ExportOptions): number {
   return 0
 }
 
-// Exported for test use only: verifies generated content matches lib/install/bin/* binstubs.
+/**
+ * Exported for test use only: verifies generated content matches
+ * lib/install/bin/* binstubs. Not part of the public API.
+ *
+ * @internal
+ */
 export function createBinStub(binStubPath: string): void {
   const binDir = dirname(binStubPath)
   const packageScript = `${basename(binStubPath)}.cjs`

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -29,8 +29,10 @@ end
 
 def shakapacker_find_executable(executable)
   ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    search_path = path.empty? ? Dir.pwd : path
+
     shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(path, candidate)
+      executable_path = File.join(search_path, candidate)
       return executable_path if File.file?(executable_path) && File.executable?(executable_path)
     end
   end

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -28,7 +28,7 @@ def shakapacker_executable_candidates(executable)
 end
 
 def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
     search_path = path.empty? ? Dir.pwd : path
 
     shakapacker_executable_candidates(executable).each do |candidate|

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -55,9 +55,9 @@ describe "binstub synchronization" do
 
     expect(dummy_content).to eq(install_content),
       "spec/dummy/bin/shakapacker-config and lib/install/bin/shakapacker-config have diverged. " \
-      "Update all four copies (lib/install/bin/shakapacker-config, lib/install/bin/diff-bundler-config, " \
-      "spec/dummy/bin/shakapacker-config, and the createBinStub template in package/configExporter/cli.ts) " \
-      "to keep them in sync."
+      "All four copies must stay byte-for-byte identical — update each one: " \
+      "lib/install/bin/shakapacker-config, lib/install/bin/diff-bundler-config, " \
+      "spec/dummy/bin/shakapacker-config, and the createBinStub template in package/configExporter/cli.ts."
   end
 
   # lib/install/bin/diff-bundler-config and lib/install/bin/shakapacker-config share

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -55,7 +55,9 @@ describe "binstub synchronization" do
 
     expect(dummy_content).to eq(install_content),
       "spec/dummy/bin/shakapacker-config and lib/install/bin/shakapacker-config have diverged. " \
-      "Update both files to keep them in sync."
+      "Update all four copies (lib/install/bin/shakapacker-config, lib/install/bin/diff-bundler-config, " \
+      "spec/dummy/bin/shakapacker-config, and the createBinStub template in package/configExporter/cli.ts) " \
+      "to keep them in sync."
   end
 
   # lib/install/bin/diff-bundler-config and lib/install/bin/shakapacker-config share

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "helper binstubs" do
   end
 
   def real_node_path
-    ENV.fetch("PATH").split(File::PATH_SEPARATOR)
+    ENV.fetch("PATH", "").split(File::PATH_SEPARATOR)
       .map { |dir| File.join(dir, "node") }
       .find { |candidate| File.file?(candidate) && File.executable?(candidate) }
   end

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe "helper binstubs" do
     FileUtils.chmod(0o755, script_path)
   end
 
+  def real_node_path
+    ENV.fetch("PATH").split(File::PATH_SEPARATOR)
+      .map { |dir| File.join(dir, "node") }
+      .find { |candidate| File.file?(candidate) && File.executable?(candidate) }
+  end
+
   %w[shakapacker-config diff-bundler-config].each do |command|
     it "runs #{command} through a CommonJS package script when the app is ESM" do
       Dir.mktmpdir("shakapacker-binstub-") do |app_path|
@@ -160,11 +166,9 @@ RSpec.describe "helper binstubs" do
         FileUtils.mkdir_p(File.join(app_path, "bin"))
         install_fake_node_script(app_path, command)
 
-        real_node_path = ENV.fetch("PATH").split(File::PATH_SEPARATOR).map { |path| File.join(path, "node") }.find do |path|
-          File.file?(path) && File.executable?(path)
-        end
+        node_path = real_node_path
 
-        skip "node not found in PATH" unless real_node_path
+        skip "node not found in PATH" unless node_path
 
         fake_bin_path = File.join(app_path, "fake-bin")
         FileUtils.mkdir_p(fake_bin_path)
@@ -176,7 +180,7 @@ RSpec.describe "helper binstubs" do
             echo probed >> "$SHAKAPACKER_NODE_PROBE_OUTPUT"
             exit 0
           fi
-          exec #{real_node_path.shellescape} "$@"
+          exec #{node_path.shellescape} "$@"
         SH
         FileUtils.chmod(0o755, fake_node_path)
 
@@ -200,48 +204,52 @@ RSpec.describe "helper binstubs" do
       end
     end
 
-    it "honors an empty PATH entry as the current directory for #{command}" do
-      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
-        File.write(File.join(app_path, "Gemfile"), "")
-        FileUtils.mkdir_p(File.join(app_path, "bin"))
-        install_fake_node_script(app_path, command)
+    {
+      "leading" => "#{File::PATH_SEPARATOR}/nonexistent",
+      "trailing" => "/nonexistent#{File::PATH_SEPARATOR}"
+    }.each do |position, path_value|
+      it "honors a #{position} empty PATH entry as the current directory for #{command}" do
+        Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+          File.write(File.join(app_path, "Gemfile"), "")
+          FileUtils.mkdir_p(File.join(app_path, "bin"))
+          install_fake_node_script(app_path, command)
 
-        real_node_path = ENV.fetch("PATH").split(File::PATH_SEPARATOR).map { |path| File.join(path, "node") }.find do |path|
-          File.file?(path) && File.executable?(path)
+          node_path = real_node_path
+          skip "node not found in PATH" unless node_path
+
+          launch_path = File.join(app_path, "launch")
+          FileUtils.mkdir_p(launch_path)
+          fake_node_path = File.join(launch_path, "node")
+          File.write(fake_node_path, <<~SH)
+            #!/bin/sh
+            exec #{node_path.shellescape} "$@"
+          SH
+          FileUtils.chmod(0o755, fake_node_path)
+
+          binstub_path = File.join(app_path, "bin", command)
+          FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+          FileUtils.chmod(0o755, binstub_path)
+
+          output_path = File.join(app_path, "binstub-output.json")
+          _stdout, stderr, status = Bundler.with_unbundled_env do
+            Open3.capture3(
+              {
+                "BUNDLE_GEMFILE" => nil,
+                "PATH" => path_value,
+                "RUBYOPT" => nil,
+                "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
+              },
+              RbConfig.ruby,
+              binstub_path,
+              chdir: launch_path
+            )
+          end
+
+          expect(status).to be_success, stderr
+          expect(JSON.parse(File.read(output_path))).to include(
+            "cwd" => File.realpath(app_path)
+          )
         end
-
-        skip "node not found in PATH" unless real_node_path
-
-        launch_path = File.join(app_path, "launch")
-        FileUtils.mkdir_p(launch_path)
-        fake_node_path = File.join(launch_path, "node")
-        File.write(fake_node_path, <<~SH)
-          #!/bin/sh
-          exec #{real_node_path.shellescape} "$@"
-        SH
-        FileUtils.chmod(0o755, fake_node_path)
-
-        binstub_path = File.join(app_path, "bin", command)
-        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
-        FileUtils.chmod(0o755, binstub_path)
-
-        output_path = File.join(app_path, "binstub-output.json")
-        _stdout, stderr, status = Open3.capture3(
-          {
-            "BUNDLE_GEMFILE" => nil,
-            "PATH" => "#{File::PATH_SEPARATOR}/nonexistent",
-            "RUBYOPT" => nil,
-            "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
-          },
-          RbConfig.ruby,
-          binstub_path,
-          chdir: launch_path
-        )
-
-        expect(status).to be_success, stderr
-        expect(JSON.parse(File.read(output_path))).to include(
-          "cwd" => File.realpath(app_path)
-        )
       end
     end
 
@@ -277,12 +285,14 @@ RSpec.describe "helper binstubs" do
         FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
         FileUtils.chmod(0o755, binstub_path)
 
-        _stdout, stderr, status = Open3.capture3(
-          { "BUNDLE_GEMFILE" => nil, "RUBYOPT" => nil, "PATH" => "/nonexistent" },
-          RbConfig.ruby,
-          binstub_path,
-          chdir: app_path
-        )
+        _stdout, stderr, status = Bundler.with_unbundled_env do
+          Open3.capture3(
+            { "BUNDLE_GEMFILE" => nil, "RUBYOPT" => nil, "PATH" => "/nonexistent" },
+            RbConfig.ruby,
+            binstub_path,
+            chdir: app_path
+          )
+        end
 
         expect(status.exitstatus).to eq(1)
         expect(stderr).to include('[Shakapacker] Could not find Node.js executable "node"')

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -200,6 +200,51 @@ RSpec.describe "helper binstubs" do
       end
     end
 
+    it "honors an empty PATH entry as the current directory for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        real_node_path = ENV.fetch("PATH").split(File::PATH_SEPARATOR).map { |path| File.join(path, "node") }.find do |path|
+          File.file?(path) && File.executable?(path)
+        end
+
+        skip "node not found in PATH" unless real_node_path
+
+        launch_path = File.join(app_path, "launch")
+        FileUtils.mkdir_p(launch_path)
+        fake_node_path = File.join(launch_path, "node")
+        File.write(fake_node_path, <<~SH)
+          #!/bin/sh
+          exec #{real_node_path.shellescape} "$@"
+        SH
+        FileUtils.chmod(0o755, fake_node_path)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        output_path = File.join(app_path, "binstub-output.json")
+        _stdout, stderr, status = Open3.capture3(
+          {
+            "BUNDLE_GEMFILE" => nil,
+            "PATH" => "#{File::PATH_SEPARATOR}/nonexistent",
+            "RUBYOPT" => nil,
+            "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
+          },
+          RbConfig.ruby,
+          binstub_path,
+          chdir: launch_path
+        )
+
+        expect(status).to be_success, stderr
+        expect(JSON.parse(File.read(output_path))).to include(
+          "cwd" => File.realpath(app_path)
+        )
+      end
+    end
+
     it "exits with an error when #{command}'s package script is missing" do
       Dir.mktmpdir("shakapacker-binstub-") do |app_path|
         File.write(File.join(app_path, "Gemfile"), "")

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -24,6 +24,8 @@ describe("createBinStub template parity", () => {
     rmSync(tmp, { recursive: true, force: true })
   })
 
+  // diff-bundler-config is a white-box parity case; production init only
+  // generates shakapacker-config.
   test.each(["shakapacker-config", "diff-bundler-config"])(
     "generates lib/install/bin/%s byte-for-byte",
     (binstubName) => {

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -26,7 +26,7 @@ describe("createBinStub template parity", () => {
     }
   })
 
-  test.each([["shakapacker-config"], ["diff-bundler-config"]])(
+  test.each(["shakapacker-config", "diff-bundler-config"])(
     "generates lib/install/bin/%s byte-for-byte",
     (binstubName) => {
       const generatedPath = join(tmp, "bin", binstubName)

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -21,9 +21,7 @@ describe("createBinStub template parity", () => {
   })
 
   afterEach(() => {
-    if (tmp) {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    rmSync(tmp, { recursive: true, force: true })
   })
 
   test.each(["shakapacker-config", "diff-bundler-config"])(

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -1,0 +1,44 @@
+const { mkdtempSync, readFileSync, rmSync } = require("fs")
+const { join, resolve } = require("path")
+const { tmpdir } = require("os")
+const { createBinStub } = require("../../package/configExporter/cli")
+
+const gemRoot = resolve(__dirname, "../..")
+
+// The Ruby logic in lib/install/bin/shakapacker-config and
+// lib/install/bin/diff-bundler-config is also duplicated inside the
+// `createBinStub` template in package/configExporter/cli.ts. The Ruby spec
+// (spec/shakapacker/binstub_sync_spec.rb) keeps the three checked-in copies
+// (install template, install diff template, and the dummy app's binstub)
+// honest, but it cannot reach into the JS template. This test closes that
+// gap by invoking createBinStub for both helper names and asserting the
+// generated content matches the corresponding lib/install/bin/* file.
+describe("createBinStub template parity", () => {
+  let tmp
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "shakapacker-createBinStub-"))
+  })
+
+  afterEach(() => {
+    if (tmp) {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test.each([["shakapacker-config"], ["diff-bundler-config"]])(
+    "generates lib/install/bin/%s byte-for-byte",
+    (binstubName) => {
+      const generatedPath = join(tmp, "bin", binstubName)
+      createBinStub(generatedPath)
+
+      const generated = readFileSync(generatedPath, "utf8")
+      const installed = readFileSync(
+        join(gemRoot, "lib", "install", "bin", binstubName),
+        "utf8"
+      )
+
+      expect(generated).toBe(installed)
+    }
+  )
+})

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -1,4 +1,10 @@
-const { mkdtempSync, readFileSync, rmSync } = require("fs")
+const {
+  accessSync,
+  constants,
+  mkdtempSync,
+  readFileSync,
+  rmSync
+} = require("fs")
 const { join, resolve } = require("path")
 const { tmpdir } = require("os")
 const { createBinStub } = require("../../package/configExporter/cli")
@@ -39,6 +45,7 @@ describe("createBinStub template parity", () => {
       )
 
       expect(generated).toBe(installed)
+      expect(() => accessSync(generatedPath, constants.X_OK)).not.toThrow()
     }
   )
 })


### PR DESCRIPTION
## Summary

Adds focused parity coverage for the helper binstub contract introduced in #1123.

The PR keeps the checked-in Ruby helper wrappers, the dummy app wrapper, and the `createBinStub` TypeScript template aligned so future helper drift fails CI quickly.

## Changes

- Export `createBinStub` from `package/configExporter/cli.ts` for test use.
- Add `test/configExporter/createBinStub.test.js`, which generates `shakapacker-config` and `diff-bundler-config` and byte-compares them with `lib/install/bin/*`.
- Assert generated helper binstubs are executable.
- Keep `mkdirSync` and `chmodSync` in the top-level `fs` import instead of using inline `require("fs")`.
- Improve `spec/shakapacker/binstub_sync_spec.rb` failure guidance so contributors are told to update all synchronized copies.

## Review follow-up

Addressed the current actionable review threads:

- Switched to flat `test.each(["shakapacker-config", "diff-bundler-config"])`.
- Removed the dead `if (tmp)` cleanup guard.
- Added a note explaining why `diff-bundler-config` is covered even though production init only generates `shakapacker-config`.
- Added executable-permission coverage for generated binstubs.
- Expanded the Ruby sync failure message to name all synchronized copies.
- Moved `mkdirSync` and `chmodSync` into the module-level `fs` import.
- Fixed leading and trailing empty `PATH` segment handling so helper binstubs honor the current directory during Node lookup, and added RSpec coverage for both helper commands.

Discussion/advice:

- The generated-user-binstub comment concern is intentionally left as discussion-only for this PR. This parity test is meant to prove the generated template matches the checked-in install files byte-for-byte; changing generated comments separately would weaken that contract.
- Empty `PATH` segment handling turned out to be a real edge case: Ruby `File.join("", "node")` checks `/node`, not the current directory, and Ruby `String#split` drops trailing empty fields unless called with a negative limit. The helper now preserves trailing entries and maps empty segments to `Dir.pwd` before joining, preserving normal PATH semantics even though the binstub later `chdir`s to the app root.

## CI note

This branch is rebased onto current `origin/main`.

The earlier `Test Both Bundlers` failure was Bundler frozen-mode lockfile drift in `spec/dummy/Gemfile.lock`: the lockfile still recorded `shakapacker (10.1.0.rc.1)` while the current gemspec resolves to `10.1.0`. That lockfile fix is now already included in current `origin/main`, and this branch has been rebased on top of it, so the PR diff no longer carries a lockfile change.

The previous `claude-review` failure was due to the external Claude weekly limit, not the repository diff.

## Test plan

- [x] `bundle exec rspec spec/shakapacker/helper_binstubs_spec.rb:211 --format documentation` - 4 empty-`PATH` examples pass for leading and trailing entries across both helper commands
- [x] `bundle exec rspec spec/shakapacker/binstub_sync_spec.rb spec/shakapacker/helper_binstubs_spec.rb` - 21 examples, 0 failures
- [x] `yarn jest test/configExporter/createBinStub.test.js` - 2 tests passed
- [x] `yarn eslint package/configExporter/cli.ts test/configExporter/createBinStub.test.js`
- [x] `bundle exec rubocop spec/shakapacker/helper_binstubs_spec.rb spec/shakapacker/binstub_sync_spec.rb` - no offenses
- [x] `git diff --check origin/main...HEAD`

Refs #1123.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to install/helper binstub templates and test tooling; behavior fix is narrow (PATH parsing) with new regression coverage.
> 
> **Overview**
> Tightens **helper binstub** parity and fixes **Node lookup** when `PATH` contains empty segments (leading/trailing `:`).
> 
> **PATH lookup:** `shakapacker_find_executable` now splits `PATH` with a negative limit so trailing empty entries are kept, and treats an empty segment as **`Dir.pwd`** instead of joining to `/node`. The same Ruby logic is updated in `lib/install/bin/*`, `spec/dummy/bin/shakapacker-config`, and the **`createBinStub`** template in `package/configExporter/cli.ts`.
> 
> **Parity & CI:** **`createBinStub`** is exported (test-only) and uses top-level `fs` imports; **`test/configExporter/createBinStub.test.js`** byte-compares generated `shakapacker-config` / `diff-bundler-config` stubs to `lib/install/bin/*` and checks execute bits. **`binstub_sync_spec`** failure text lists all four sync targets. **`helper_binstubs_spec`** adds RSpec for leading/trailing empty `PATH` entries, refactors `real_node_path`, and wraps some cases in **`Bundler.with_unbundled_env`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a44c92d2035e1e2e7ba29a33ab2b44478ec02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

