### PR TITLE
Replace node --version probe with no-fork PATH walk

### DIFF
--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -18,7 +18,24 @@ end
 
 def shakapacker_node_binary
   node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+  # Walk ENV["PATH"] directly instead of forking a `node --version`
+  # subprocess on every binstub invocation. On Windows, also probe
+  # PATHEXT-style extensions because executables there end in
+  # .exe/.cmd/.bat.
+  extensions = if Gem.win_platform?
+    ["", *(ENV["PATHEXT"] || ".COM;.EXE;.BAT;.CMD").split(";")]
+  else
+    [""]
+  end
+
+  ENV["PATH"].to_s.split(File::PATH_SEPARATOR).each do |dir|
+    next if dir.empty?
+
+    extensions.each do |ext|
+      candidate = File.join(dir, "#{node_bin}#{ext}")
+      return node_bin if File.file?(candidate) && File.executable?(candidate)
+    end
+  end
 
   warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
        "Install Node.js and try again."

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -18,7 +18,24 @@ end
 
 def shakapacker_node_binary
   node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+  # Walk ENV["PATH"] directly instead of forking a `node --version`
+  # subprocess on every binstub invocation. On Windows, also probe
+  # PATHEXT-style extensions because executables there end in
+  # .exe/.cmd/.bat.
+  extensions = if Gem.win_platform?
+    ["", *(ENV["PATHEXT"] || ".COM;.EXE;.BAT;.CMD").split(";")]
+  else
+    [""]
+  end
+
+  ENV["PATH"].to_s.split(File::PATH_SEPARATOR).each do |dir|
+    next if dir.empty?
+
+    extensions.each do |ext|
+      candidate = File.join(dir, "#{node_bin}#{ext}")
+      return node_bin if File.file?(candidate) && File.executable?(candidate)
+    end
+  end
 
   warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
        "Install Node.js and try again."

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -542,7 +542,24 @@ end
 
 def shakapacker_node_binary
   node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+  # Walk ENV["PATH"] directly instead of forking a \`node --version\`
+  # subprocess on every binstub invocation. On Windows, also probe
+  # PATHEXT-style extensions because executables there end in
+  # .exe/.cmd/.bat.
+  extensions = if Gem.win_platform?
+    ["", *(ENV["PATHEXT"] || ".COM;.EXE;.BAT;.CMD").split(";")]
+  else
+    [""]
+  end
+
+  ENV["PATH"].to_s.split(File::PATH_SEPARATOR).each do |dir|
+    next if dir.empty?
+
+    extensions.each do |ext|
+      candidate = File.join(dir, "#{node_bin}#{ext}")
+      return node_bin if File.file?(candidate) && File.executable?(candidate)
+    end
+  end
 
   warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \\
        "Install Node.js and try again."

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -18,7 +18,24 @@ end
 
 def shakapacker_node_binary
   node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+  # Walk ENV["PATH"] directly instead of forking a `node --version`
+  # subprocess on every binstub invocation. On Windows, also probe
+  # PATHEXT-style extensions because executables there end in
+  # .exe/.cmd/.bat.
+  extensions = if Gem.win_platform?
+    ["", *(ENV["PATHEXT"] || ".COM;.EXE;.BAT;.CMD").split(";")]
+  else
+    [""]
+  end
+
+  ENV["PATH"].to_s.split(File::PATH_SEPARATOR).each do |dir|
+    next if dir.empty?
+
+    extensions.each do |ext|
+      candidate = File.join(dir, "#{node_bin}#{ext}")
+      return node_bin if File.file?(candidate) && File.executable?(candidate)
+    end
+  end
 
   warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
        "Install Node.js and try again."


### PR DESCRIPTION
## Summary

Address the **low-priority optimization** from the [PR #1104 follow-up review](https://github.com/shakacode/shakapacker/issues/1123).

This is **PR 3 of 3** for #1123 — the smallest of the three, isolated so it can land or be punted independently.

### Change

`shakapacker_node_binary` in the helper binstubs previously verified Node was installed by running `system("node", "--version")` with both streams piped to `/dev/null`. That forks a subprocess on every binstub invocation — just to learn whether Node exists. Replaced with a direct walk of `ENV["PATH"]` that also probes `PATHEXT`-style extensions on Windows (so `node.exe`/`node.cmd` are still discoverable). One fork+exec saved per `bin/shakapacker-config` and `bin/diff-bundler-config` call.

The return value is unchanged (the literal string `"node"`), so the subsequent `exec node_bin, script_path, *ARGV` still goes through the OS's `PATH` resolution exactly as before.

Applied byte-identically across all four copies kept in sync by PR #1128 (`binstub_sync_spec.rb` + `test/configExporter/createBinStub.test.js`):

- `lib/install/bin/shakapacker-config`
- `lib/install/bin/diff-bundler-config`
- `spec/dummy/bin/shakapacker-config`
- the `createBinStub` template in `package/configExporter/cli.ts`

### Stacked on PR #1128

This branch is stacked on top of `jg/1123-binstub-sync-coverage` (PR #1128). GitHub will auto-update the base to `main` once #1128 merges. If #1128 is closed instead, this PR can rebase onto `main` with a trivial change (only the comment header and `NODE_ENV` line differ, and only the comment-header lines need replaying).

Refs #1123.

## Test plan

- [x] `bundle exec rspec spec/shakapacker/binstub_sync_spec.rb` — 2 examples pass (dummy↔install parity preserved)
- [x] `bundle exec rspec spec/shakapacker/helper_binstubs_spec.rb` — 8 examples pass, including the "node unavailable" path that uses `PATH=/nonexistent`
- [x] `yarn jest test/configExporter/createBinStub.test.js` — 2 examples pass (template still matches install templates byte-for-byte)
- [x] `bundle exec rubocop` — no offenses on changed Ruby files
- [x] `yarn eslint` — no errors on changed TS file
- [x] `ruby -c` on all three modified binstubs — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the helper binstubs used to launch Node-based tooling; any bug in the new `PATH`/`PATHEXT` scan could prevent commands from running, especially on Windows.
> 
> **Overview**
> Replaces `shakapacker_node_binary`’s `system("node", "--version")` check with a no-fork scan of `ENV["PATH"]`, including Windows `PATHEXT` extension probing.
> 
> Applies the same updated Node lookup logic across all four synced helper-binstub copies (`lib/install/bin/*`, `spec/dummy/bin/*`, and the `createBinStub` template in `package/configExporter/cli.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1889de42f18c785a4737ad4d1723b1000a057d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->