### PR TITLE
Update spec/dummy Gemfile.lock for shakapacker 10.1.0-rc.1

### DIFF
--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (10.1.0.rc.0)
+    shakapacker (10.1.0.rc.1)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)


### PR DESCRIPTION
## Summary

Regenerate `spec/dummy/Gemfile.lock` so its PATH entry references the current gem version (`10.1.0.rc.1` instead of `10.1.0.rc.0`).

The 10.1.0-rc.1 release commit ([a54f879c](https://github.com/shakacode/shakapacker/commit/a54f879c)) bumped `Shakapacker::VERSION` and the root `Gemfile.lock` but missed `spec/dummy/Gemfile.lock`. CI runs `bundle install` with `bundler-cache: true`, which uses frozen mode; bundler detects the path-gem version drift and fails:

```
The gemspecs for path gems changed, but the lockfile can't be updated
because frozen mode is set
```

This breaks **Test Bundler Switching / Test with Webpack / Test with RSpack** on every PR until the dummy lockfile is regenerated.

This is the exact same gap [PR #1121](https://github.com/shakacode/shakapacker/pull/1121) fixed for 10.1.0-rc.0. The release-script automation referenced in that PR's "prior art" section still isn't keeping the dummy lockfile in sync during version bumps.

## Changes

- `spec/dummy/Gemfile.lock`: PATH spec bumped from `shakapacker (10.1.0.rc.0)` → `shakapacker (10.1.0.rc.1)`. One-line diff.

Bundler renders the pre-release version with a dot (`10.1.0.rc.1`) rather than a dash, matching the existing format.

## Scope note

Diagnosing/fixing the release-script gap that keeps causing this is **intentionally out of scope** here — same call PR #1121 made. This PR is lockfile-only to unblock CI immediately.

## Test plan

- [x] `(cd spec/dummy && BUNDLE_FROZEN=true bundle check)` exits 0 — this is the same check CI's frozen install performs
- [x] `git diff origin/main -- spec/dummy/Gemfile.lock` shows only the shakapacker PATH version line
- [x] Root `Gemfile.lock` untouched (already on `10.1.0.rc.1` from the release commit)
- [ ] CI green on Test Bundler Switching / Test with Webpack / Test with RSpack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: lockfile-only change updating the dummy app’s PATH gem version, with no runtime code changes.
> 
> **Overview**
> Updates `spec/dummy/Gemfile.lock` to bump the PATH dependency entry for `shakapacker` from `10.1.0.rc.0` to `10.1.0.rc.1`, keeping the dummy app lockfile in sync with the current gem version (and avoiding frozen-bundler install drift).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5050c180d3677a16f08bac7a2e37c2adfdeb91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->