### PR TITLE
[codex] Fix shakapacker config helper binstubs

### DIFF
--- a/bin/shakapacker-config
+++ b/bin/shakapacker-config
@@ -6,6 +6,6 @@ const { run } = require("shakapacker/configExporter")
 run(process.argv.slice(2))
   .then((exitCode) => process.exit(exitCode))
   .catch((error) => {
-    console.error(error.message)
+    console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Keep in sync with lib/install/bin/shakapacker-config and the template in
-# package/configExporter/cli.ts (createBinStub).
+require "rbconfig"
+
+# Keep helper logic in sync across:
+# - lib/install/bin/shakapacker-config
+# - lib/install/bin/diff-bundler-config
+# - spec/dummy/bin/shakapacker-config
+# - package/configExporter/cli.ts (createBinStub).
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))
@@ -12,17 +17,42 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_node_binary
-  node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+def shakapacker_executable_candidates(executable)
+  extensions = [
+    RbConfig::CONFIG["EXEEXT"],
+    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
+  ].compact.reject(&:empty?)
+  return [executable] if extensions.empty? || File.extname(executable) != ""
 
-  warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
+  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
+end
+
+def shakapacker_find_executable(executable)
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    shakapacker_executable_candidates(executable).each do |candidate|
+      executable_path = File.join(path, candidate)
+      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+    end
+  end
+
+  nil
+end
+
+def shakapacker_node_binary
+  node_bin = shakapacker_find_executable("node")
+  return node_bin if node_bin
+
+  warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
 end
 
+def shakapacker_node_env
+  %w[development test].include?(ENV["RAILS_ENV"]) ? "development" : "production"
+end
+
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"] ||= "development"
+ENV["NODE_ENV"] ||= shakapacker_node_env
 
 app_root = shakapacker_app_root
 node_bin = shakapacker_node_binary

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Keep in sync with lib/install/bin/diff-bundler-config and the template in
-# package/configExporter/cli.ts (createBinStub).
+require "rbconfig"
+
+# Keep helper logic in sync across:
+# - lib/install/bin/shakapacker-config
+# - lib/install/bin/diff-bundler-config
+# - spec/dummy/bin/shakapacker-config
+# - package/configExporter/cli.ts (createBinStub).
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))
@@ -12,17 +17,42 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_node_binary
-  node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+def shakapacker_executable_candidates(executable)
+  extensions = [
+    RbConfig::CONFIG["EXEEXT"],
+    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
+  ].compact.reject(&:empty?)
+  return [executable] if extensions.empty? || File.extname(executable) != ""
 
-  warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
+  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
+end
+
+def shakapacker_find_executable(executable)
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    shakapacker_executable_candidates(executable).each do |candidate|
+      executable_path = File.join(path, candidate)
+      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+    end
+  end
+
+  nil
+end
+
+def shakapacker_node_binary
+  node_bin = shakapacker_find_executable("node")
+  return node_bin if node_bin
+
+  warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
 end
 
+def shakapacker_node_env
+  %w[development test].include?(ENV["RAILS_ENV"]) ? "development" : "production"
+end
+
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"] ||= "development"
+ENV["NODE_ENV"] ||= shakapacker_node_env
 
 app_root = shakapacker_app_root
 node_bin = shakapacker_node_binary

--- a/lib/tasks/shakapacker/export_bundler_config.rake
+++ b/lib/tasks/shakapacker/export_bundler_config.rake
@@ -1,4 +1,16 @@
 namespace :shakapacker do
+  def shakapacker_config_binstub_command(bin_path)
+    shebang = File.open(bin_path, &:gets).to_s
+    command = shebang.delete_prefix("#!").strip.split(/\s+/)
+    executable = File.basename(command.first.to_s)
+
+    if executable == "env"
+      executable = File.basename(command.drop(1).find { |part| !part.start_with?("-") }.to_s)
+    end
+
+    executable == "node" ? ["node", bin_path.to_s] : [RbConfig.ruby, bin_path.to_s]
+  end
+
   desc <<~DESC
     Export webpack or rspack configuration for debugging and analysis
 
@@ -58,10 +70,10 @@ namespace :shakapacker do
       end
     else
       # Pass through command-line arguments after the task name.
-      # Invoke with RbConfig.ruby so the binstub runs under the same Ruby as Rake
-      # (avoids version-manager/shebang mismatches and works on Windows).
+      # Ruby binstubs run under the same Ruby as Rake; legacy JavaScript
+      # binstubs from upgraded apps still need Node until users refresh them.
       Dir.chdir(Rails.root) do
-        exec(RbConfig.ruby, bin_path.to_s, *ARGV[1..])
+        exec(*shakapacker_config_binstub_command(bin_path), *ARGV[1..])
       end
     end
   end

--- a/lib/tasks/shakapacker/export_bundler_config.rake
+++ b/lib/tasks/shakapacker/export_bundler_config.rake
@@ -1,6 +1,7 @@
 namespace :shakapacker do
   def shakapacker_config_binstub_command(bin_path)
-    shebang = File.open(bin_path, &:gets).to_s
+    # Read in binary mode so Windows CRLF line endings do not leak \r into the shebang.
+    shebang = File.open(bin_path, "rb", &:gets).to_s
     command = shebang.delete_prefix("#!").strip.split(/\s+/)
     executable = File.basename(command.first.to_s)
 
@@ -70,14 +71,14 @@ namespace :shakapacker do
       $stderr.puts ""
 
       Dir.chdir(Rails.root) do
-        exec(RbConfig.ruby, gem_bin_path, *ARGV[1..])
+        Kernel.exec(RbConfig.ruby, gem_bin_path, *ARGV[1..])
       end
     else
       # Pass through command-line arguments after the task name.
       # Ruby binstubs run under the same Ruby as Rake; legacy JavaScript
       # binstubs from upgraded apps still need Node until users refresh them.
       Dir.chdir(Rails.root) do
-        exec(*shakapacker_config_binstub_command(bin_path), *ARGV[1..])
+        Kernel.exec(*shakapacker_config_binstub_command(bin_path), *ARGV[1..])
       end
     end
   end

--- a/lib/tasks/shakapacker/export_bundler_config.rake
+++ b/lib/tasks/shakapacker/export_bundler_config.rake
@@ -8,6 +8,10 @@ namespace :shakapacker do
       executable = File.basename(command.drop(1).find { |part| !part.start_with?("-") }.to_s)
     end
 
+    # Legacy JS binstubs are dispatched via PATH lookup; Kernel#exec resolves
+    # "node" through the shell's PATH. The Ruby binstubs perform their own
+    # explicit lookup via shakapacker_find_executable, which matters more on
+    # Windows where PATHEXT is involved.
     executable == "node" ? ["node", bin_path.to_s] : [RbConfig.ruby, bin_path.to_s]
   end
 

--- a/package/bin/shakapacker-config.cjs
+++ b/package/bin/shakapacker-config.cjs
@@ -5,6 +5,6 @@ const { run } = require("../configExporter")
 run(process.argv.slice(2))
   .then((exitCode) => process.exit(exitCode))
   .catch((error) => {
-    console.error(error.message)
+    console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -523,8 +523,13 @@ function createBinStub(binStubPath: string): void {
   const stubContent = `#!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Keep in sync with lib/install/bin/shakapacker-config and
-# lib/install/bin/diff-bundler-config; update all three when changing helpers.
+require "rbconfig"
+
+# Keep helper logic in sync across:
+# - lib/install/bin/shakapacker-config
+# - lib/install/bin/diff-bundler-config
+# - spec/dummy/bin/shakapacker-config
+# - package/configExporter/cli.ts (createBinStub).
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))
@@ -534,17 +539,42 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_node_binary
-  node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+def shakapacker_executable_candidates(executable)
+  extensions = [
+    RbConfig::CONFIG["EXEEXT"],
+    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
+  ].compact.reject(&:empty?)
+  return [executable] if extensions.empty? || File.extname(executable) != ""
 
-  warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \\
+  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
+end
+
+def shakapacker_find_executable(executable)
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    shakapacker_executable_candidates(executable).each do |candidate|
+      executable_path = File.join(path, candidate)
+      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+    end
+  end
+
+  nil
+end
+
+def shakapacker_node_binary
+  node_bin = shakapacker_find_executable("node")
+  return node_bin if node_bin
+
+  warn '[Shakapacker] Could not find Node.js executable "node". ' \\
        "Install Node.js and try again."
   exit 1
 end
 
+def shakapacker_node_env
+  %w[development test].include?(ENV["RAILS_ENV"]) ? "development" : "production"
+end
+
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"] ||= "development"
+ENV["NODE_ENV"] ||= shakapacker_node_env
 
 app_root = shakapacker_app_root
 node_bin = shakapacker_node_binary

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Keep in sync with lib/install/bin/shakapacker-config and the template in
-# package/configExporter/cli.ts (createBinStub).
+require "rbconfig"
+
+# Keep helper logic in sync across:
+# - lib/install/bin/shakapacker-config
+# - lib/install/bin/diff-bundler-config
+# - spec/dummy/bin/shakapacker-config
+# - package/configExporter/cli.ts (createBinStub).
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))
@@ -12,17 +17,42 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_node_binary
-  node_bin = "node"
-  return node_bin if system(node_bin, "--version", out: File::NULL, err: File::NULL)
+def shakapacker_executable_candidates(executable)
+  extensions = [
+    RbConfig::CONFIG["EXEEXT"],
+    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
+  ].compact.reject(&:empty?)
+  return [executable] if extensions.empty? || File.extname(executable) != ""
 
-  warn "[Shakapacker] Could not find Node.js executable #{node_bin.inspect}. " \
+  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
+end
+
+def shakapacker_find_executable(executable)
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |path|
+    shakapacker_executable_candidates(executable).each do |candidate|
+      executable_path = File.join(path, candidate)
+      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+    end
+  end
+
+  nil
+end
+
+def shakapacker_node_binary
+  node_bin = shakapacker_find_executable("node")
+  return node_bin if node_bin
+
+  warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
 end
 
+def shakapacker_node_env
+  %w[development test].include?(ENV["RAILS_ENV"]) ? "development" : "production"
+end
+
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"] ||= "development"
+ENV["NODE_ENV"] ||= shakapacker_node_env
 
 app_root = shakapacker_app_root
 node_bin = shakapacker_node_binary

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -37,7 +37,7 @@ describe "binstub synchronization" do
     end
   end
 
-  it "documents every divergent binstub and only divergent binstubs" do
+  it "all documented divergent binstubs still exist in both directories" do
     install_basenames = Dir.glob(File.join(gem_root, "lib/install/bin/*")).map { |p| File.basename(p) }
     bin_basenames = Dir.glob(File.join(gem_root, "bin/*")).map { |p| File.basename(p) }
     actually_shared = install_basenames & bin_basenames
@@ -47,5 +47,14 @@ describe "binstub synchronization" do
       "INTENTIONALLY_DIVERGENT_BINSTUBS lists #{documented_but_missing.inspect} " \
       "but those files are no longer present in both bin/ and lib/install/bin/. " \
       "Remove them from the list."
+  end
+
+  it "spec/dummy/bin/shakapacker-config matches lib/install/bin/shakapacker-config" do
+    install_content = File.read(File.join(gem_root, "lib", "install", "bin", "shakapacker-config"))
+    dummy_content = File.read(File.join(gem_root, "spec", "dummy", "bin", "shakapacker-config"))
+
+    expect(dummy_content).to eq(install_content),
+      "spec/dummy/bin/shakapacker-config and lib/install/bin/shakapacker-config have diverged. " \
+      "Update both files to keep them in sync."
   end
 end

--- a/spec/shakapacker/binstub_sync_spec.rb
+++ b/spec/shakapacker/binstub_sync_spec.rb
@@ -57,4 +57,18 @@ describe "binstub synchronization" do
       "spec/dummy/bin/shakapacker-config and lib/install/bin/shakapacker-config have diverged. " \
       "Update both files to keep them in sync."
   end
+
+  # lib/install/bin/diff-bundler-config and lib/install/bin/shakapacker-config share
+  # the same helper functions and only legitimately diverge on the .cjs script name
+  # they dispatch to. Normalizing that one line catches any other drift between them.
+  it "lib/install/bin/diff-bundler-config stays in sync with lib/install/bin/shakapacker-config" do
+    shakapacker_config = File.read(File.join(gem_root, "lib", "install", "bin", "shakapacker-config"))
+    diff_bundler_config = File.read(File.join(gem_root, "lib", "install", "bin", "diff-bundler-config"))
+
+    normalized = diff_bundler_config.sub('"diff-bundler-config.cjs"', '"shakapacker-config.cjs"')
+
+    expect(normalized).to eq(shakapacker_config),
+      "lib/install/bin/diff-bundler-config and lib/install/bin/shakapacker-config have diverged " \
+      "beyond the intentional .cjs script name difference. Update both files to keep them in sync."
+  end
 end

--- a/spec/shakapacker/export_bundler_config_task_spec.rb
+++ b/spec/shakapacker/export_bundler_config_task_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "shakapacker:export_bundler_config" do
   def invoke_task(app_path, *args)
     captured_exec = nil
     stub_const("Rails", double(root: Pathname.new(app_path)))
-    allow_any_instance_of(Object).to receive(:exec) do |_receiver, *exec_args|
+    allow(Kernel).to receive(:exec) do |*exec_args|
       captured_exec = exec_args
     end
 

--- a/spec/shakapacker/export_bundler_config_task_spec.rb
+++ b/spec/shakapacker/export_bundler_config_task_spec.rb
@@ -1,0 +1,66 @@
+require "fileutils"
+require "pathname"
+require "rake"
+require "rbconfig"
+require "tmpdir"
+
+RSpec.describe "shakapacker:export_bundler_config" do
+  let(:task_name) { "shakapacker:export_bundler_config" }
+  let(:task_path) { File.expand_path("../../lib/tasks/shakapacker/export_bundler_config.rake", __dir__) }
+
+  around do |example|
+    original_application = Rake.application
+    original_argv = ARGV.dup
+
+    Rake.application = Rake::Application.new
+    load task_path
+
+    example.run
+  ensure
+    ARGV.replace(original_argv)
+    Rake.application = original_application
+  end
+
+  def write_app_binstub(app_path, content)
+    binstub_path = File.join(app_path, "bin", "shakapacker-config")
+    FileUtils.mkdir_p(File.dirname(binstub_path))
+    File.write(binstub_path, content)
+    FileUtils.chmod(0o755, binstub_path)
+    binstub_path
+  end
+
+  def invoke_task(app_path, *args)
+    captured_exec = nil
+    stub_const("Rails", double(root: Pathname.new(app_path)))
+    allow_any_instance_of(Object).to receive(:exec) do |_receiver, *exec_args|
+      captured_exec = exec_args
+    end
+
+    ARGV.replace([task_name, *args])
+    Rake::Task[task_name].invoke
+
+    captured_exec
+  end
+
+  it "runs upgraded apps' legacy JavaScript binstub with node" do
+    Dir.mktmpdir("shakapacker-export-bundler-config-") do |app_path|
+      binstub_path = write_app_binstub(app_path, <<~JS)
+        #!/usr/bin/env node
+        console.log("legacy binstub")
+      JS
+
+      expect(invoke_task(app_path, "--doctor")).to eq(["node", binstub_path, "--doctor"])
+    end
+  end
+
+  it "runs Ruby binstubs with the current Ruby interpreter" do
+    Dir.mktmpdir("shakapacker-export-bundler-config-") do |app_path|
+      binstub_path = write_app_binstub(app_path, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "ruby binstub"
+      RUBY
+
+      expect(invoke_task(app_path, "--save")).to eq([RbConfig.ruby, binstub_path, "--save"])
+    end
+  end
+end

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -2,6 +2,7 @@ require "fileutils"
 require "json"
 require "open3"
 require "rbconfig"
+require "shellwords"
 require "tmpdir"
 
 RSpec.describe "helper binstubs" do
@@ -26,7 +27,11 @@ RSpec.describe "helper binstubs" do
         process.env.SHAKAPACKER_BINSTUB_OUTPUT,
         JSON.stringify({
           cwd: process.cwd(),
-          argv: process.argv.slice(2)
+          argv: process.argv.slice(2),
+          env: {
+            RAILS_ENV: process.env.RAILS_ENV,
+            NODE_ENV: process.env.NODE_ENV
+          }
         })
       )
     JS
@@ -55,7 +60,7 @@ RSpec.describe "helper binstubs" do
         )
 
         expect(status).to be_success, stderr
-        expect(JSON.parse(File.read(output_path))).to eq(
+        expect(JSON.parse(File.read(output_path))).to include(
           "cwd" => File.realpath(app_path),
           "argv" => ["--flag", "value"]
         )
@@ -79,10 +84,86 @@ RSpec.describe "helper binstubs" do
         )
 
         expect(status).to be_success, stderr
-        expect(JSON.parse(File.read(output_path))).to eq(
+        expect(JSON.parse(File.read(output_path))).to include(
           "cwd" => File.realpath(app_path),
           "argv" => []
         )
+        expect(stderr).to include("[Shakapacker] No Gemfile found at")
+      end
+    end
+
+    it "sets NODE_ENV from RAILS_ENV when NODE_ENV is unset for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        output_path = File.join(app_path, "binstub-output.json")
+        _stdout, stderr, status = Open3.capture3(
+          {
+            "NODE_ENV" => nil,
+            "RAILS_ENV" => "production",
+            "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
+          },
+          binstub_path,
+          chdir: app_path
+        )
+
+        expect(status).to be_success, stderr
+        expect(JSON.parse(File.read(output_path))).to include(
+          "env" => include(
+            "RAILS_ENV" => "production",
+            "NODE_ENV" => "production"
+          )
+        )
+      end
+    end
+
+    it "does not execute node just to locate it for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        real_node_path = ENV.fetch("PATH").split(File::PATH_SEPARATOR).map { |path| File.join(path, "node") }.find do |path|
+          File.file?(path) && File.executable?(path)
+        end
+
+        fake_bin_path = File.join(app_path, "fake-bin")
+        FileUtils.mkdir_p(fake_bin_path)
+        probe_output_path = File.join(app_path, "node-probe-output.txt")
+        fake_node_path = File.join(fake_bin_path, "node")
+        File.write(fake_node_path, <<~SH)
+          #!/bin/sh
+          if [ "$1" = "--version" ]; then
+            echo probed >> "$SHAKAPACKER_NODE_PROBE_OUTPUT"
+            exit 0
+          fi
+          exec #{real_node_path.shellescape} "$@"
+        SH
+        FileUtils.chmod(0o755, fake_node_path)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        output_path = File.join(app_path, "binstub-output.json")
+        _stdout, stderr, status = Open3.capture3(
+          {
+            "PATH" => "#{fake_bin_path}#{File::PATH_SEPARATOR}#{ENV.fetch("PATH")}",
+            "SHAKAPACKER_BINSTUB_OUTPUT" => output_path,
+            "SHAKAPACKER_NODE_PROBE_OUTPUT" => probe_output_path
+          },
+          binstub_path,
+          chdir: app_path
+        )
+
+        expect(status).to be_success, stderr
+        expect(File).not_to exist(probe_output_path)
       end
     end
 

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -123,6 +123,37 @@ RSpec.describe "helper binstubs" do
       end
     end
 
+    it "maps RAILS_ENV=test to NODE_ENV=development for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        output_path = File.join(app_path, "binstub-output.json")
+        _stdout, stderr, status = Open3.capture3(
+          {
+            "NODE_ENV" => nil,
+            "RAILS_ENV" => "test",
+            "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
+          },
+          binstub_path,
+          chdir: app_path
+        )
+
+        expect(status).to be_success, stderr
+        expect(JSON.parse(File.read(output_path))).to include(
+          "env" => include(
+            "RAILS_ENV" => "test",
+            "NODE_ENV" => "development"
+          )
+        )
+      end
+    end
+
     it "does not execute node just to locate it for #{command}" do
       Dir.mktmpdir("shakapacker-binstub-") do |app_path|
         File.write(File.join(app_path, "Gemfile"), "")

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -164,6 +164,8 @@ RSpec.describe "helper binstubs" do
           File.file?(path) && File.executable?(path)
         end
 
+        skip "node not found in PATH" unless real_node_path
+
         fake_bin_path = File.join(app_path, "fake-bin")
         FileUtils.mkdir_p(fake_bin_path)
         probe_output_path = File.join(app_path, "node-probe-output.txt")

--- a/test/package/bin/shakapacker-config.test.js
+++ b/test/package/bin/shakapacker-config.test.js
@@ -1,0 +1,35 @@
+describe("package/bin/shakapacker-config", () => {
+  let originalArgv
+  let mockExit
+  let mockError
+
+  beforeEach(() => {
+    jest.resetModules()
+    originalArgv = process.argv
+    process.argv = ["node", "shakapacker-config"]
+    mockExit = jest.spyOn(process, "exit").mockImplementation(() => {})
+    mockError = jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    mockExit.mockRestore()
+    mockError.mockRestore()
+  })
+
+  test("prints non-Error rejections as strings", async () => {
+    const plainFailure = { toString: () => "plain failure" }
+
+    jest.doMock(require.resolve("../../../package/configExporter"), () => ({
+      run: jest.fn(() => Promise.reject(plainFailure))
+    }))
+
+    require("../../../package/bin/shakapacker-config.cjs")
+    await new Promise((resolve) => {
+      setImmediate(resolve)
+    })
+
+    expect(mockError).toHaveBeenCalledWith("plain failure")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+})

--- a/test/package/configExporter/cli.test.js
+++ b/test/package/configExporter/cli.test.js
@@ -1,3 +1,6 @@
+const { mkdirSync, mkdtempSync, readFileSync, rmSync } = require("fs")
+const { tmpdir } = require("os")
+const { join, resolve } = require("path")
 const { resetEnv } = require("../../helpers")
 
 describe("configExporter/cli", () => {
@@ -435,6 +438,43 @@ describe("configExporter/cli", () => {
           parseArguments([`--output=${path}`])
         }).not.toThrow()
       })
+    })
+  })
+
+  describe("run --init", () => {
+    let originalCwd
+    let testDir
+    let mockLog
+
+    beforeEach(() => {
+      originalCwd = process.cwd()
+      testDir = mkdtempSync(join(tmpdir(), "shakapacker-config-init-"))
+      mkdirSync(join(testDir, "config"), { recursive: true })
+      process.chdir(testDir)
+      mockLog = jest.spyOn(console, "log").mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      process.chdir(originalCwd)
+      rmSync(testDir, { recursive: true, force: true })
+      mockLog.mockRestore()
+    })
+
+    test("creates a shakapacker-config binstub matching the installed helper", async () => {
+      const { run } = require("../../../package/configExporter/cli")
+
+      const exitCode = await run(["--init"])
+
+      const generatedContent = readFileSync(
+        join(testDir, "bin", "shakapacker-config"),
+        "utf8"
+      )
+      const installedContent = readFileSync(
+        resolve(__dirname, "../../../lib/install/bin/shakapacker-config"),
+        "utf8"
+      )
+      expect(exitCode).toBe(0)
+      expect(generatedContent).toBe(installedContent)
     })
   })
 })


### PR DESCRIPTION
### Summary

Fixes #1123.
This updates `shakapacker:export_bundler_config` to dispatch existing app binstubs by shebang, so upgraded apps with legacy JavaScript binstubs still run through Node while Ruby binstubs continue through Ruby.
It also keeps installed, dummy, and generated helper binstubs in sync so `NODE_ENV` follows `RAILS_ENV`, Node is found without executing it during lookup, and non-`Error` CLI rejections print useful messages.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Validated with focused RSpec helper/rake specs, Jest config exporter tests, TypeScript type-checking, ESLint, and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `shakapacker:export_bundler_config` selects and executes binstubs and updates Node discovery / env defaults, which can affect command execution across platforms (notably Windows). Covered by new RSpec/Jest tests, but still impacts developer tooling entrypoints.
> 
> **Overview**
> Fixes Shakapacker helper/binstub behavior to better support upgraded apps and Windows/ESM environments.
> 
> The `shakapacker:export_bundler_config` rake task now inspects the `bin/shakapacker-config` shebang and dispatches *legacy JS binstubs via `node`* while continuing to run *Ruby binstubs via the current `RbConfig.ruby`*.
> 
> The installed/generatable Ruby helper binstubs (`shakapacker-config` and `diff-bundler-config`) are updated to (1) locate `node` via explicit PATH/PATHEXT scanning without executing it, (2) default `NODE_ENV` from `RAILS_ENV` (`test`/`development` -> `development`, otherwise `production`), and (3) improve CLI error printing for non-`Error` rejections. New specs ensure binstub sync, correct dispatching, env mapping, and init-generated stub parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a536a418d937d602f1667ee36de25f08a4ab19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->