### PR TITLE
Expand prerelease-to-stable changelog coalesce guidance in /update-changelog

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -349,7 +349,7 @@ When releasing from prerelease to a stable version (e.g., v9.6.0-rc.2 → v9.6.0
 
 For each entry from the prerelease section, ask:
 
-- Was this bug present in the last stable release? If no, drop (or apply the merge-into-original-entry rule from Step 2, item 1).
+- Was this change (bug fix, feature, or other) introduced during the RC cycle and absent from the previous stable? If yes, apply the REMOVE rules in Step 2 to decide whether to drop, merge, or keep it.
 - Was this feature introduced in an earlier prerelease and then superseded? If yes, keep only the final state.
 
 #### Step 5: Final read-through

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -356,7 +356,7 @@ For each entry from the prerelease section, ask:
 
 Read the resulting stable section as if you're a user upgrading from the previous stable. Every entry should be something you'd want to know about. If an entry only makes sense to someone who tracked the RC cycle, drop it.
 
-#### Step 6: Verify the compare links from Step 1
+#### Step 6: Verify the compare links from Step 1 (before committing)
 
 Before committing, confirm the compare-link updates from Step 1 are in place: orphaned RC compare links removed, the new `[v9.6.0]` link anchored at the previous stable tag (not the latest RC), and `[Unreleased]` pointing from `v9.6.0` to `main`.
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -313,19 +313,53 @@ When the user passes `rc` or `beta` as an argument (or when creating a prereleas
 
 ### For Prerelease to Stable Version Release
 
-When releasing from prerelease to a stable version (e.g., v9.6.0-rc.1 → v9.6.0):
+When releasing from prerelease to a stable version (e.g., v9.6.0-rc.2 → v9.6.0), the accumulated prerelease section becomes the stable section. **Curate carefully** — users landing on the stable version don't care about intermediate prerelease state, and noise here makes the upgrade story harder to read.
 
-1. **Remove all prerelease version labels** from the changelog:
-   - Change `## [v9.6.0-rc.0]`, `## [v9.6.0-rc.1]`, etc. to a single `## [v9.6.0]` section
-   - Also handle beta versions: `## [v9.6.0-beta.1]` etc.
-   - Combine all prerelease entries into the stable release section
+#### Step 1: Convert the prerelease section into the stable section
 
-2. **Consolidate duplicate entries**:
-   - If bug fixes or changes were made to features introduced in earlier prereleases, keep only the final state
-   - Remove redundant changelog entries for fixes to prerelease features
-   - Keep the most recent/accurate description of each change
+- Change `## [v9.6.0-rc.0]`, `## [v9.6.0-rc.1]`, etc. (and any `## [v9.6.0-beta.N]` sections) into a single `## [v9.6.0] - Month Day, Year` section
+- **Move any remaining entries from `## [Unreleased]` into the new stable section** — anything still under `[Unreleased]` at stable-release time is shipping in this stable version. Leave `## [Unreleased]` with only its header (no entries).
+- Consolidate duplicate category headings — merge multiple `### Fixed` sections into one, etc., under the preferred order from "Category Organization"
+- Remove orphaned compare links at the bottom of the file for the prerelease versions
+- Add the `[v9.6.0]` compare link pointing from the **previous stable tag** (e.g., `v9.5.0...v9.6.0`) — **not** from the latest RC tag
+- Update the `[Unreleased]` compare link to point from `v9.6.0` to `main`
 
-3. **Update version diff links** at the bottom to point to the stable version
+#### Step 2: Curate the entries — REMOVE these
+
+1. **Prerelease-only fixes** — bugs introduced during the prerelease cycle and fixed in a later RC. If the bug never shipped in stable, the fix is noise to stable users.
+   - Investigate when the bug was introduced: `git log --oneline v<last_stable>..v<rc_that_fixed_the_bug>` — if the introducing commit predates the RC cycle, the bug was already in the last stable release and the fix belongs in the stable section. If the introduction _is_ in this range, the bug never shipped in stable.
+   - For RC-only regression fixes where the fix changed user-visible behavior of the original feature (e.g., extended a config allowlist), apply the **merge** rule from "Filtering RC-only fixes when collapsing prereleases" above: fold the fix into the original PR's entry, credit both PRs, and update any details the fix changed so the entry reflects the final shipped state. Don't drop these — stable consumers will see the merged behavior, not the intermediate regression.
+   - Pure-restore fixes (the fix only restores prior behavior without changing the original entry's description) can be dropped.
+
+2. **Refinements to prerelease-only features** — if a new feature was introduced in `rc.0` and then iterated in `rc.1`/`rc.2`, keep only the final description and drop the iteration history.
+
+3. **Internal/contributor-only tooling** — CI tweaks, build script changes, generator handling of prerelease version formats, local-dev tooling fixes. These don't belong in a user-facing changelog.
+
+#### Step 3: Curate the entries — KEEP these
+
+1. **User-facing fixes for bugs that existed in the previous stable** — if `rc.2` fixes a bug that was in `v9.5.0`, that fix matters to stable users upgrading.
+
+2. **Compatibility fixes** — Ruby/Node/Rails version support, dependency relaxations, etc.
+
+3. **All breaking changes** — API/CLI changes, removed methods, configuration changes, generator output changes. Even if a breaking change was introduced and refined across multiple prereleases, the final breaking change description belongs in stable.
+
+4. **Performance/security improvements affecting all users.**
+
+#### Step 4: Investigation process for each entry
+
+For each entry from the prerelease section, ask:
+
+- Was this bug present in the last stable release? If no, drop (or merge per Step 2).
+- Was this feature introduced in an earlier prerelease and then superseded? If yes, keep only the final state.
+- Does this matter to someone upgrading from the last stable to this stable? If no, drop.
+
+#### Step 5: Final read-through
+
+Read the resulting stable section as if you're a user upgrading from the previous stable. Every entry should be something you'd want to know about. If an entry only makes sense to someone who tracked the RC cycle, drop it.
+
+#### Step 6: Update version diff links
+
+Update the version diff links at the bottom of the file: the new `[v9.6.0]` link compares from the previous stable tag, and orphaned compare links for the coalesced prerelease versions are removed.
 
 ## Examples
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -327,7 +327,7 @@ When releasing from prerelease to a stable version (e.g., v9.6.0-rc.2 → v9.6.0
 #### Step 2: Curate the entries — REMOVE these
 
 1. **Prerelease-only fixes** — bugs introduced during the prerelease cycle and fixed in a later RC. If the bug never shipped in stable, the fix is noise to stable users.
-   - Investigate when the bug was introduced: `git log --oneline v<last_stable>..v<rc_that_fixed_the_bug>` — if the introducing commit predates the RC cycle, the bug was already in the last stable release and the fix belongs in the stable section. If the introduction _is_ in this range, the bug never shipped in stable.
+   - Investigate when the bug was introduced: `git log --oneline v<last_stable>..v<rc_that_fixed_the_bug>` lists every commit added since the last stable release. If the introducing commit appears in this range, the bug was introduced during the prerelease cycle and never shipped to stable users — apply the RC-only churn rules below. If it does not appear (i.e., it is reachable from `v<last_stable>`), the bug was already in the last stable release and the fix belongs in the stable section.
    - For RC-only regression fixes where the fix changed user-visible behavior of the original feature (e.g., extended a config allowlist), apply the **merge** rule from "Filtering RC-only fixes when collapsing prereleases" above: fold the fix into the original PR's entry, credit both PRs, and update any details the fix changed so the entry reflects the final shipped state. Don't drop these — stable consumers will see the merged behavior, not the intermediate regression.
    - Pure-restore fixes (the fix only restores prior behavior without changing the original entry's description) can be dropped.
 
@@ -349,17 +349,16 @@ When releasing from prerelease to a stable version (e.g., v9.6.0-rc.2 → v9.6.0
 
 For each entry from the prerelease section, ask:
 
-- Was this bug present in the last stable release? If no, drop (or merge per Step 2).
+- Was this bug present in the last stable release? If no, drop (or apply the merge-into-original-entry rule from Step 2, item 1).
 - Was this feature introduced in an earlier prerelease and then superseded? If yes, keep only the final state.
-- Does this matter to someone upgrading from the last stable to this stable? If no, drop.
 
 #### Step 5: Final read-through
 
 Read the resulting stable section as if you're a user upgrading from the previous stable. Every entry should be something you'd want to know about. If an entry only makes sense to someone who tracked the RC cycle, drop it.
 
-#### Step 6: Update version diff links
+#### Step 6: Verify the compare links from Step 1
 
-Update the version diff links at the bottom of the file: the new `[v9.6.0]` link compares from the previous stable tag, and orphaned compare links for the coalesced prerelease versions are removed.
+Before committing, confirm the compare-link updates from Step 1 are in place: orphaned RC compare links removed, the new `[v9.6.0]` link anchored at the previous stable tag (not the latest RC), and `[Unreleased]` pointing from `v9.6.0` to `main`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Ports the curation playbook structure from [shakacode/control-plane-flow#320](https://github.com/shakacode/control-plane-flow/pull/320) into shakapacker's existing **"For Prerelease to Stable Version Release"** section of `.claude/commands/update-changelog.md`.

The prior 3-bullet section was thin on what to drop, what to keep, and how to decide — especially relevant for the upcoming `v10.1.0-rc.N` → `v10.1.0` coalesce, where the right call requires reasoning about whether a bug ever shipped in the last stable.

## What changed

Replaces the 14-line section with 48 lines structured as 6 explicit sub-steps:

1. **Convert the prerelease section into the stable section** — now spells out the Unreleased migration, duplicate-heading consolidation, and the previous-stable compare-link rule (not the latest RC tag).
2. **REMOVE rules** — prerelease-only fixes, prerelease feature iteration noise, internal/contributor-only tooling, with `git log --oneline v<last_stable>..v<rc>` for investigating whether a bug ever shipped.
3. **KEEP rules** — fixes for bugs already in last stable, compatibility fixes, all breaking changes, performance/security improvements.
4. **Per-entry investigation questions.**
5. **Final read-through** as a user upgrading from the previous stable.
6. **Compare-link cleanup.**

## What's preserved

Shakapacker's [PR #1125](https://github.com/shakacode/shakapacker/pull/1125) **"merge RC-only fix into original entry"** rule (lines 302–310) is cross-referenced from Step 2 — that approach is arguably better than control-plane-flow PR #320's drop-and-curate because it keeps the original entry accurate for stable consumers, who see the merged behavior rather than the intermediate regression. So we get PR #320's curation rigor at the stable-release boundary without losing PR #1125's nuance during the rc-collapse step.

## What is NOT changing

This PR **does not** change the rc/beta collapse policy. Shakapacker keeps the always-collapse-during-rc approach refined by PR #1125; we only add curation rigor at the prerelease→stable boundary. Adopting PR #320's "don't collapse until stable" approach wholesale would be a larger design call and is left for a separate discussion.

The `rakelib/release.rake` infrastructure (`extract_changelog_section`) is unchanged — it already reads one `## [vX.Y.Z]` section per invocation, so no rake changes are required either way.

## Test plan

- [ ] Docs-only change; no automated tests required.
- [ ] Next time `/update-changelog release` is run with prior RC sections present (e.g., for `v10.1.0` after `v10.1.0-rc.2`), verify the new 6-step playbook produces a cleaner, well-curated stable section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-facing command documentation only; no runtime, release rake, or changelog policy changes beyond clearer guidance.
> 
> **Overview**
> Expands the **"For Prerelease to Stable Version Release"** playbook in `.claude/commands/update-changelog.md` from a short bullet list into a **six-step curation workflow** for turning accumulated RC/beta sections into a single stable release section.
> 
> **Step 1** now explicitly covers folding RC headers into one dated stable header, pulling any leftover `## [Unreleased]` entries into that release, merging duplicate category headings, and fixing compare links (stable link from the **previous stable tag**, not the latest RC).
> 
> **Steps 2–3** add clear **REMOVE** vs **KEEP** rules: drop prerelease-only churn, iteration noise, and contributor-only tooling; keep fixes for bugs that existed in the last stable, compatibility work, breaking changes, and broad performance/security items. **Step 2** ties RC-only regression fixes to the existing **merge-into-original-entry** rule from the RC-collapse section (with `git log` guidance to tell whether a bug ever shipped in stable).
> 
> **Steps 4–6** add per-entry investigation questions, a final read-through from an upgrader’s perspective, and a compare-link verification checklist before commit.
> 
> Docs-only; RC collapse during prerelease releases is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08ed1fdd1872ef894748fefd340a504cea55798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->