### PR TITLE
Support sass-loader v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Added support for `sass-loader` v17**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [fukayatsu](https://github.com/fukayatsu). Widened the optional `sass-loader` peer range to `^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` in core `shakapacker`, `shakapacker-webpack`, and `shakapacker-rspack`. The Sass rule already selects `loadPaths` for v16+ and keeps `api: "modern"`, both of which remain valid in v17. Note that sass-loader v17 requires Node.js 22.11.0+ and drops `node-sass` and the legacy Sass JS API, so apps that opt into v17 must already be on Node 22.12+ (the upper branch of Shakapacker's `engines.node` range).
+
 ### Fixed
 
 - **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #1147](https://github.com/shakacode/shakapacker/pull/1147) by [justin808](https://github.com/justin808). Ports [#976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance-specific config and watch both webpack and rspack config directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Added
 
-- **Added support for `sass-loader` v17**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [fukayatsu](https://github.com/fukayatsu). Widened the optional `sass-loader` peer range to `^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` in core `shakapacker`, `shakapacker-webpack`, and `shakapacker-rspack`. The Sass rule already selects `loadPaths` for v16+ and keeps `api: "modern"`, both of which remain valid in v17. Note that sass-loader v17 requires Node.js 22.11.0+ and drops `node-sass` and the legacy Sass JS API, so apps that opt into v17 must already be on Node 22.12+ (the upper branch of Shakapacker's `engines.node` range).
+- **Added support for `sass-loader` v17**. [PR #1141](https://github.com/shakacode/shakapacker/pull/1141) by [fukayatsu](https://github.com/fukayatsu). Widened the optional `sass-loader` peer range to `^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` in core `shakapacker`, `shakapacker-webpack`, and `shakapacker-rspack`. The Sass rule already selects `loadPaths` for v16+ and keeps `api: "modern"`, both of which remain valid in v17. Note that sass-loader v17 requires Node.js 22.11.0+ and drops `node-sass` and the legacy Sass JS API, so apps that opt into v17 must already be on Node 22.12+ (the upper branch of Shakapacker's `engines.node` range).
 
 ### Fixed
 

--- a/docs/dependency-strategy.md
+++ b/docs/dependency-strategy.md
@@ -29,7 +29,7 @@ Shakapacker v10 has **23 optional peer dependencies** with extremely broad versi
 
 - `esbuild`: 14 separate version ranges (`^0.14.0 || ^0.15.0 || ... || ^0.27.0`)
 - `webpack-cli`: 4 major versions (`^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0`)
-- `sass-loader`: 4 major versions (`^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`)
+- `sass-loader`: 5 major versions (`^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0`)
 - `babel-loader`: 3 major versions (`^8.2.4 || ^9.0.0 || ^10.0.0`)
 
 On the Ruby side, the gem supports Rails 5.2+ and Ruby 2.7+ — both well past end-of-life.
@@ -166,11 +166,11 @@ Supplemental package for the standard webpack managed build experience.
 
 **Peer dependencies (optional — CSS preprocessors):**
 
-| Package     | Range                                            | When needed      |
-| ----------- | ------------------------------------------------ | ---------------- |
-| css-loader  | `^6.8.1 \|\| ^7.0.0`                             | CSS processing   |
-| sass        | `^1.50.0`                                        | SCSS/Sass files  |
-| sass-loader | `^13.0.0 \|\| ^14.0.0 \|\| ^15.0.0 \|\| ^16.0.0` | Paired with sass |
+| Package     | Range                                                         | When needed      |
+| ----------- | ------------------------------------------------------------- | ---------------- |
+| css-loader  | `^6.8.1 \|\| ^7.0.0`                                          | CSS processing   |
+| sass        | `^1.50.0`                                                     | SCSS/Sass files  |
+| sass-loader | `^13.0.0 \|\| ^14.0.0 \|\| ^15.0.0 \|\| ^16.0.0 \|\| ^17.0.0` | Paired with sass |
 
 #### `shakapacker-rspack` (managed rspack build)
 
@@ -192,12 +192,12 @@ Supplemental package for the rspack managed build experience.
 
 **Peer dependencies (optional):**
 
-| Package                      | Range                                            | When needed      |
-| ---------------------------- | ------------------------------------------------ | ---------------- |
-| @rspack/plugin-react-refresh | `^1.0.0 \|\| ^2.0.0`                             | React HMR        |
-| css-loader                   | `^6.8.1 \|\| ^7.0.0`                             | CSS processing   |
-| sass                         | `^1.50.0`                                        | SCSS/Sass files  |
-| sass-loader                  | `^13.0.0 \|\| ^14.0.0 \|\| ^15.0.0 \|\| ^16.0.0` | Paired with sass |
+| Package                      | Range                                                         | When needed      |
+| ---------------------------- | ------------------------------------------------------------- | ---------------- |
+| @rspack/plugin-react-refresh | `^1.0.0 \|\| ^2.0.0`                                          | React HMR        |
+| css-loader                   | `^6.8.1 \|\| ^7.0.0`                                          | CSS processing   |
+| sass                         | `^1.50.0`                                                     | SCSS/Sass files  |
+| sass-loader                  | `^13.0.0 \|\| ^14.0.0 \|\| ^15.0.0 \|\| ^16.0.0 \|\| ^17.0.0` | Paired with sass |
 
 Note: rspack has built-in SWC transpilation, so no external transpiler deps are needed.
 

--- a/docs/peer-dependencies.md
+++ b/docs/peer-dependencies.md
@@ -26,7 +26,7 @@ releases support.
 "css-loader": "^6.8.1 || ^7.0.0"
 "mini-css-extract-plugin": "^2.0.0"
 "sass": "^1.50.0"
-"sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+"sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 "terser-webpack-plugin": "^5.3.1"
 "webpack-assets-manifest": "^5.0.6 || ^6.0.0"
 "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "mini-css-extract-plugin": "^2.0.0",
     "rspack-manifest-plugin": "^5.0.0",
     "sass": "^1.50.0",
-    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
     "swc-loader": "^0.1.15 || ^0.2.0",
     "terser-webpack-plugin": "^5.3.1",
     "webpack": "^5.101.0",

--- a/packages/shakapacker-rspack/package.json
+++ b/packages/shakapacker-rspack/package.json
@@ -35,7 +35,7 @@
     "@rspack/plugin-react-refresh": "^1.0.0 || ^2.0.0",
     "css-loader": "^6.8.1 || ^7.0.0",
     "sass": "^1.50.0",
-    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/plugin-react-refresh": {

--- a/packages/shakapacker-webpack/package.json
+++ b/packages/shakapacker-webpack/package.json
@@ -45,7 +45,7 @@
     "esbuild-loader": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "css-loader": "^6.8.1 || ^7.0.0",
     "sass": "^1.50.0",
-    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "webpack-dev-server": {


### PR DESCRIPTION
### Summary

Widens the optional `sass-loader` peer range to include `^17.0.0` so apps on Node 22.12+ can opt into sass-loader v17. No loader-rule changes are required.

Closes #1140.

**Changes**

- Add `^17.0.0` to the optional `sass-loader` peer range in core `shakapacker`, `shakapacker-webpack`, and `shakapacker-rspack`.
- Update `docs/peer-dependencies.md` and `docs/dependency-strategy.md` to match.
- Add a CHANGELOG entry.

**Why no rule changes:** the Sass rule already selects `loadPaths` for sass-loader v16+ and keeps `api: "modern"`. Both remain valid in v17 — v17 only removed the legacy Sass JS API and `node-sass`, neither of which Shakapacker uses.

**Why the installer is intentionally NOT widened:** `lib/install/package.json`'s `common` range is the dependency actually installed into newly generated apps (package managers install the highest match). Adding `^17.0.0` there would force every new app onto `sass-loader@17`, which requires Node ≥ 22.11.0 — combined with Shakapacker's `engines.node` (`^20.19.0 || >=22.12.0`) that effectively means Node 22.12+. Since Shakapacker still supports Node 20.19, defaulting new installs to v17 would break the install/build flow for Node 20 users. An OR range can't express "allow v17 but install v16", so v17 stays opt-in via the peer range and the installer default stays conservative.

### Pull Request checklist

- [x] Add/update test to cover these changes — existing `test/package/rules/sass-version-parsing.test.js` already asserts v17 → `loadPaths`; generator specs exercise the install across npm/yarn/pnpm/bun
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

- **Compatibility:** `sass-loader@17` requires Node.js 22.11.0+, drops `node-sass`, and removes the legacy Sass JS API. Apps using Shakapacker + v17 need Node 22.12+ (the upper branch of Shakapacker's supported range). Non-breaking: Node 20 users stay on v16 via the OR range.
- **devDependency intentionally not bumped:** CONTRIBUTING asks to keep devDependency/peerDependency ranges in sync, but the pinned `sass-loader` devDependency stays at `16.0.7` because CI runs on Node 20.19.x and `sass-loader@17` requires Node 22.11+. Bumping it would require raising the whole CI Node matrix, out of scope for a compatibility-range change.
- **Testing:** `yarn test` (full JS suite) ✓, `yarn lint` + Prettier ✓, `bundle exec rspec spec/generator_specs/generator_spec.rb` → 71 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wider sass-loader support: Shakapacker now accepts v13–v17 in peer-dependency ranges across packages.

* **Documentation**
  * Changelog and dependency docs updated to note v17 support, Node.js minimum (22.11.0+), and guidance about opting into v17; documents that v17 removes node-sass and the legacy Sass JS API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->