### PR TITLE
Fix Rspack devServer in static watch mode

### DIFF
--- a/package/environments/development.ts
+++ b/package/environments/development.ts
@@ -58,13 +58,15 @@ const rspackDevConfig = (): RspackConfigWithDevServer => {
   const devServerConfig = webpackDevServerConfig()
   const rspackConfig: RspackConfigWithDevServer = {
     ...baseDevConfig,
-    devServer: {
-      ...devServerConfig,
-      devMiddleware: {
-        ...(devServerConfig.devMiddleware || {}),
-        writeToDisk: (filePath: string) => !filePath.includes(".hot-update.")
+    ...(runningWebpackDevServer && {
+      devServer: {
+        ...devServerConfig,
+        devMiddleware: {
+          ...(devServerConfig.devMiddleware || {}),
+          writeToDisk: (filePath: string) => !filePath.includes(".hot-update.")
+        }
       }
-    }
+    })
   }
 
   if (

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (10.1.0.rc.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/test/package/environments/development-rspack-react-refresh.test.js
+++ b/test/package/environments/development-rspack-react-refresh.test.js
@@ -3,13 +3,16 @@ const { chdirTestApp, resetEnv } = require("../../helpers")
 const rootPath = process.cwd()
 chdirTestApp()
 
-const loadRspackDevelopmentConfig = (reactRefreshModule) => {
+const loadRspackDevelopmentConfig = (
+  reactRefreshModule = function ReactRefreshRspackPlugin() {},
+  webpackServe = "true"
+) => {
   jest.resetModules()
   resetEnv()
   process.env.RAILS_ENV = "development"
   process.env.NODE_ENV = "development"
-  process.env.WEBPACK_SERVE = "true"
   process.env.SHAKAPACKER_ASSETS_BUNDLER = "rspack"
+  if (webpackServe !== null) process.env.WEBPACK_SERVE = webpackServe
 
   jest.doMock("../../../package/utils/helpers", () => {
     const original = jest.requireActual("../../../package/utils/helpers")
@@ -107,5 +110,23 @@ describe("Rspack React refresh development config", () => {
     )
     expect(environmentConfig).toBeDefined()
     expect(hasReactRefreshPluginInstance(environmentConfig)).toBe(false)
+  })
+
+  test("omits devServer when webpack dev server is not running", () => {
+    const environmentConfig = loadRspackDevelopmentConfig(undefined, null)
+
+    expect(environmentConfig.devServer).toBeUndefined()
+  })
+
+  test("sets devServer when webpack dev server is running", () => {
+    const environmentConfig = loadRspackDevelopmentConfig()
+
+    expect(environmentConfig.devServer).toBeDefined()
+    expect(environmentConfig.devServer.devMiddleware.writeToDisk).toStrictEqual(
+      expect.any(Function)
+    )
+    const { writeToDisk } = environmentConfig.devServer.devMiddleware
+    expect(writeToDisk("/packs/app.hot-update.js")).toBe(false)
+    expect(writeToDisk("/packs/app.js")).toBe(true)
   })
 })

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -8,16 +8,28 @@ const mapping = {
 
 const repoRoot = resolve(__dirname, "..")
 // Keep this map explicit to avoid accidentally rewriting third-party imports.
-// If a new local rspack TS module is required via its compiled .js path in tests,
+// If a new local bundler TS module is required via its compiled .js path in tests,
 // add the corresponding mapping here.
-const rspackModuleAliasMap = {
+const bundlerModuleAliasMap = {
+  [resolve(repoRoot, "package/plugins/webpack.js")]: resolve(
+    repoRoot,
+    "package/plugins/webpack.ts"
+  ),
   [resolve(repoRoot, "package/plugins/rspack.js")]: resolve(
     repoRoot,
     "package/plugins/rspack.ts"
   ),
+  [resolve(repoRoot, "package/rules/webpack.js")]: resolve(
+    repoRoot,
+    "package/rules/webpack.ts"
+  ),
   [resolve(repoRoot, "package/rules/rspack.js")]: resolve(
     repoRoot,
     "package/rules/rspack.ts"
+  ),
+  [resolve(repoRoot, "package/optimization/webpack.js")]: resolve(
+    repoRoot,
+    "package/optimization/webpack.ts"
   ),
   [resolve(repoRoot, "package/optimization/rspack.js")]: resolve(
     repoRoot,
@@ -30,11 +42,11 @@ function resolver(module, options) {
     return mapping[module]
   }
 
-  // Remap only this repository's known rspack JS targets to TS sources.
+  // Remap only this repository's known bundler JS targets to TS sources.
   if (options.basedir) {
     const requestedPath = resolve(options.basedir, module)
-    if (rspackModuleAliasMap[requestedPath]) {
-      return rspackModuleAliasMap[requestedPath]
+    if (bundlerModuleAliasMap[requestedPath]) {
+      return bundlerModuleAliasMap[requestedPath]
     }
   }
 


### PR DESCRIPTION
### Summary

Fixes #1137.

- Gate Rspack `devServer` config behind `WEBPACK_SERVE=true`, matching the existing Webpack development config behavior so static watch builds do not load the dev-server client.
- Preserve the Rspack `devMiddleware.writeToDisk` filter that skips hot-update files, and assert that predicate behavior in the focused Jest test.
- Update the dummy app lockfile path gem entry to `shakapacker (10.1.0)` after rebasing on `origin/main`, fixing the frozen Bundler CI failure.
- Keep the Jest resolver mapped to local Webpack and Rspack TypeScript source modules for environment tests.

### Review Notes

- Addressed the optional CodeRabbit nitpick by asserting `writeToDisk` returns `false` for hot-update files and `true` for normal assets.
- There are no unresolved inline review threads on the PR.
- CodeRabbit's docstring coverage warning is not actionable for this scoped JavaScript config/test change.

### Validation

- `bundle install --jobs 4` from `spec/dummy`
- `yarn jest test/package/environments/development-rspack-react-refresh.test.js --runInBand`
- `yarn type-check`

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update lockfile needed by CI
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development server no longer writes hot-update files to disk, reducing disk noise during development.

* **Tests**
  * Added and refactored tests to validate behavior with and without the development server running.
  * Improved test resolution/mapping so bundler-related modules resolve to their source counterparts for more accurate testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/shakapacker/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->