### PR TITLE
Add homepage links for supplemental npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ _Official, actively maintained successor to [rails/webpacker](https://github.com
 
 [![node.js](https://img.shields.io/badge/node-%5E20.19.0%20%7C%7C%20%3E%3D22.12.0-brightgreen.svg)](https://www.npmjs.com/package/shakapacker)
 [![Gem](https://img.shields.io/gem/v/shakapacker.svg)](https://rubygems.org/gems/shakapacker)
-[![npm version](https://badge.fury.io/js/shakapacker.svg)](https://badge.fury.io/js/shakapacker)
-[![shakapacker-webpack npm version](https://badge.fury.io/js/shakapacker-webpack.svg)](https://www.npmjs.com/package/shakapacker-webpack)
-[![shakapacker-rspack npm version](https://badge.fury.io/js/shakapacker-rspack.svg)](https://www.npmjs.com/package/shakapacker-rspack)
+[![shakapacker npm version](https://img.shields.io/npm/v/shakapacker.svg?label=shakapacker)](https://www.npmjs.com/package/shakapacker)
+[![shakapacker-webpack npm version](https://img.shields.io/npm/v/shakapacker-webpack.svg?label=shakapacker-webpack)](https://www.npmjs.com/package/shakapacker-webpack)
+[![shakapacker-rspack npm version](https://img.shields.io/npm/v/shakapacker-rspack.svg?label=shakapacker-rspack)](https://www.npmjs.com/package/shakapacker-rspack)
 
 Shakapacker makes it easy to use the JavaScript pre-processor and bundler [Webpack v5+](https://webpack.js.org/)
 to manage frontend JavaScript in Rails. It can coexist with the asset pipeline,

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ _Official, actively maintained successor to [rails/webpacker](https://github.com
 [![JS lint](https://github.com/shakacode/shakapacker/workflows/JS%20lint/badge.svg)](https://github.com/shakacode/shakapacker/actions)
 
 [![node.js](https://img.shields.io/badge/node-%5E20.19.0%20%7C%7C%20%3E%3D22.12.0-brightgreen.svg)](https://www.npmjs.com/package/shakapacker)
-[![Gem](https://img.shields.io/gem/v/shakapacker.svg)](https://rubygems.org/gems/shakapacker)
-[![shakapacker npm version](https://img.shields.io/npm/v/shakapacker.svg?label=shakapacker)](https://www.npmjs.com/package/shakapacker)
-[![shakapacker-webpack npm version](https://img.shields.io/npm/v/shakapacker-webpack.svg?label=shakapacker-webpack)](https://www.npmjs.com/package/shakapacker-webpack)
-[![shakapacker-rspack npm version](https://img.shields.io/npm/v/shakapacker-rspack.svg?label=shakapacker-rspack)](https://www.npmjs.com/package/shakapacker-rspack)
+[![shakapacker gem version](https://img.shields.io/gem/v/shakapacker.svg?label=shakapacker%20gem)](https://rubygems.org/gems/shakapacker)
+[![shakapacker npm package version](https://img.shields.io/npm/v/shakapacker.svg?label=shakapacker%20package)](https://www.npmjs.com/package/shakapacker)
+[![shakapacker-webpack npm package version](https://img.shields.io/npm/v/shakapacker-webpack.svg?label=shakapacker-webpack%20package)](https://www.npmjs.com/package/shakapacker-webpack)
+[![shakapacker-rspack npm package version](https://img.shields.io/npm/v/shakapacker-rspack.svg?label=shakapacker-rspack%20package)](https://www.npmjs.com/package/shakapacker-rspack)
 
 Shakapacker makes it easy to use the JavaScript pre-processor and bundler [Webpack v5+](https://webpack.js.org/)
 to manage frontend JavaScript in Rails. It can coexist with the asset pipeline,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _📖 **Full documentation at [shakapacker.com](https://shakapacker.com)**_
 _Official, actively maintained successor to [rails/webpacker](https://github.com/rails/webpacker). ShakaCode stands behind the long-term maintenance and development of this project for the Rails community._
 
 - ⚠️ See the [6-stable](https://github.com/shakacode/shakapacker/tree/6-stable) branch for Shakapacker v6.x code and documentation. :warning:
-- **New in 10.1: optional `shakapacker-webpack` and `shakapacker-rspack` packages let you replace four `devDependencies` with one. See the [v10.1 supplemental packages migration guide](./docs/migration/v10.1-supplemental-packages.md).**
+- **New in 10.1: optional `shakapacker-webpack` and `shakapacker-rspack` packages let you replace four `devDependencies` with one. See the package references for [`shakapacker-webpack`](./packages/shakapacker-webpack/README.md) and [`shakapacker-rspack`](./packages/shakapacker-rspack/README.md), plus the [v10.1 supplemental packages migration guide](./docs/migration/v10.1-supplemental-packages.md).**
 - **See the [v10.0.0 release notes](https://github.com/shakacode/shakapacker/releases/tag/v10.0.0) for upgrading from v9 to v10.**
 - **See [V9 Upgrade](./docs/v9_upgrade.md) for upgrading from v8 to v9.**
 - See [V8 Upgrade](./docs/v8_upgrade.md) for upgrading from the v7 release.
@@ -32,6 +32,8 @@ _Official, actively maintained successor to [rails/webpacker](https://github.com
 [![node.js](https://img.shields.io/badge/node-%5E20.19.0%20%7C%7C%20%3E%3D22.12.0-brightgreen.svg)](https://www.npmjs.com/package/shakapacker)
 [![Gem](https://img.shields.io/gem/v/shakapacker.svg)](https://rubygems.org/gems/shakapacker)
 [![npm version](https://badge.fury.io/js/shakapacker.svg)](https://badge.fury.io/js/shakapacker)
+[![shakapacker-webpack npm version](https://badge.fury.io/js/shakapacker-webpack.svg)](https://www.npmjs.com/package/shakapacker-webpack)
+[![shakapacker-rspack npm version](https://badge.fury.io/js/shakapacker-rspack.svg)](https://www.npmjs.com/package/shakapacker-rspack)
 
 Shakapacker makes it easy to use the JavaScript pre-processor and bundler [Webpack v5+](https://webpack.js.org/)
 to manage frontend JavaScript in Rails. It can coexist with the asset pipeline,


### PR DESCRIPTION
### Summary

Adds homepage links to the `shakapacker-webpack` and `shakapacker-rspack` package references.
Adds npm version badges for both supplemental packages beside the existing package badges.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Other Information

Validated the referenced local docs exist and that the new badge URLs and npm registry package endpoints return 200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, build, or dependency changes.
> 
> **Overview**
> Updates the root **README** so the v10.1 supplemental-packages callout links directly to [`shakapacker-webpack`](./packages/shakapacker-webpack/README.md) and [`shakapacker-rspack`](./packages/shakapacker-rspack/README.md), in addition to the existing migration guide.
> 
> The version badge row is expanded: the gem and core npm badges are relabeled for clarity, and new shields.io badges are added for **`shakapacker-webpack`** and **`shakapacker-rspack`** on npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cd1340cc5a1075d1d23e57028cc21254fc7592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->