### PR TITLE
Fix instance-scoped compiler strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance-specific config and watch both webpack and rspack config directories.
+- **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #1147](https://github.com/shakacode/shakapacker/pull/1147) by [justin808](https://github.com/justin808). Ports [#976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance-specific config and watch both webpack and rspack config directories.
 
 ## [v10.1.0] - May 27, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance-specific config and watch both webpack and rspack config directories.
+
 ## [v10.1.0] - May 27, 2026
 
 ### Added

--- a/lib/shakapacker/base_strategy.rb
+++ b/lib/shakapacker/base_strategy.rb
@@ -1,7 +1,7 @@
 module Shakapacker
   class BaseStrategy
-    def initialize
-      @config = Shakapacker.config
+    def initialize(instance = Shakapacker.instance)
+      @instance = instance
     end
 
     def after_compile_hook
@@ -10,7 +10,13 @@ module Shakapacker
 
     private
 
-      attr_reader :config
+      def config
+        @instance.config
+      end
+
+      def env
+        @instance.env
+      end
 
       def default_watched_paths
         [
@@ -18,7 +24,7 @@ module Shakapacker
           "#{config.source_path}{,/**/*}",
           "package.json", "package-lock.json", "yarn.lock",
           "pnpm-lock.yaml", "bun.lockb",
-          "config/webpack{,/**/*}"
+          "config/{webpack,rspack}{,/**/*}"
         ].freeze
       end
   end

--- a/lib/shakapacker/compiler_strategy.rb
+++ b/lib/shakapacker/compiler_strategy.rb
@@ -3,14 +3,14 @@ require_relative "digest_strategy"
 
 module Shakapacker
   class CompilerStrategy
-    def self.from_config
-      strategy_from_config = Shakapacker.config.compiler_strategy
+    def self.from_config(instance = Shakapacker.instance)
+      strategy_from_config = instance.config.compiler_strategy
 
       case strategy_from_config
       when "mtime"
-        Shakapacker::MtimeStrategy.new
+        Shakapacker::MtimeStrategy.new(instance)
       when "digest"
-        Shakapacker::DigestStrategy.new
+        Shakapacker::DigestStrategy.new(instance)
       else
         raise "Unknown strategy '#{strategy_from_config}'. " \
               "Available options are 'mtime' and 'digest'."

--- a/lib/shakapacker/digest_strategy.rb
+++ b/lib/shakapacker/digest_strategy.rb
@@ -46,7 +46,7 @@ module Shakapacker
         files = Dir[*expanded_paths].reject { |f| File.directory?(f) }
         file_ids = files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
 
-        asset_host = Shakapacker.config.asset_host.to_s
+        asset_host = config.asset_host.to_s
         Digest::SHA1.hexdigest(file_ids.join("/").concat(asset_host))
       end
 
@@ -56,7 +56,7 @@ module Shakapacker
       end
 
       def compilation_digest_path
-        config.cache_path.join("last-compilation-digest-#{Shakapacker.env}")
+        config.cache_path.join("last-compilation-digest-#{env}")
       end
   end
 end

--- a/lib/shakapacker/digest_strategy.rb
+++ b/lib/shakapacker/digest_strategy.rb
@@ -30,7 +30,7 @@ module Shakapacker
       end
 
       def watched_files_digest
-        if Rails.env.development?
+        if env.development?
           warn <<~MSG.strip
           Shakapacker::Compiler - Slow setup for development
           Prepare JS assets with either:

--- a/lib/shakapacker/instance.rb
+++ b/lib/shakapacker/instance.rb
@@ -81,7 +81,7 @@ class Shakapacker::Instance
   # @return [Shakapacker::CompilerStrategy] the compiler strategy
   # @api private
   def strategy
-    @strategy ||= Shakapacker::CompilerStrategy.from_config
+    @strategy ||= Shakapacker::CompilerStrategy.from_config(self)
   end
 
   # Returns the compiler for this instance

--- a/lib/shakapacker/mtime_strategy.rb
+++ b/lib/shakapacker/mtime_strategy.rb
@@ -19,7 +19,7 @@ module Shakapacker
       end
 
       def latest_modified_timestamp
-        if Rails.env.development?
+        if env.development?
           warn <<~MSG.strip
           Shakapacker::Compiler - Slow setup for development
 

--- a/spec/shakapacker/compiler_strategy_spec.rb
+++ b/spec/shakapacker/compiler_strategy_spec.rb
@@ -22,8 +22,8 @@ describe "Shakapacker::CompilerStrategy" do
     end
 
     it "uses the given instance's config instead of the global config" do
-      custom_instance = Shakapacker::Instance.new
-      allow(custom_instance.config).to receive(:compiler_strategy).and_return("mtime")
+      custom_config = double("config", compiler_strategy: "mtime")
+      custom_instance = double("instance", config: custom_config)
       allow(Shakapacker.config).to receive(:compiler_strategy).and_return("digest")
 
       expect(Shakapacker::CompilerStrategy.from_config(custom_instance)).to be_an_instance_of(Shakapacker::MtimeStrategy)

--- a/spec/shakapacker/compiler_strategy_spec.rb
+++ b/spec/shakapacker/compiler_strategy_spec.rb
@@ -20,5 +20,13 @@ describe "Shakapacker::CompilerStrategy" do
 
       expect { Shakapacker::CompilerStrategy.from_config }.to raise_error(expected_error_message)
     end
+
+    it "uses the given instance's config instead of the global config" do
+      custom_instance = Shakapacker::Instance.new
+      allow(custom_instance.config).to receive(:compiler_strategy).and_return("mtime")
+      allow(Shakapacker.config).to receive(:compiler_strategy).and_return("digest")
+
+      expect(Shakapacker::CompilerStrategy.from_config(custom_instance)).to be_an_instance_of(Shakapacker::MtimeStrategy)
+    end
   end
 end

--- a/spec/shakapacker/digest_strategy_spec.rb
+++ b/spec/shakapacker/digest_strategy_spec.rb
@@ -56,4 +56,30 @@ describe "DigestStrategy" do
 
     expect(actual_path).to eq expected_path
   end
+
+  it "uses the provided instance cache path and env for compilation_digest_path" do
+    cache_path = Pathname.new("/tmp/custom-shakapacker-cache")
+    custom_config = double("config", cache_path: cache_path)
+    custom_instance = double("instance", config: custom_config, env: "custom-env")
+    digest_strategy = Shakapacker::DigestStrategy.new(custom_instance)
+
+    expect(digest_strategy.send(:compilation_digest_path)).to eq cache_path.join("last-compilation-digest-custom-env")
+  end
+
+  it "uses the provided instance asset_host in watched_files_digest" do
+    custom_config = double(
+      "config",
+      root_path: Shakapacker.config.root_path,
+      source_path: "missing-source-path",
+      additional_paths: [],
+      asset_host: "instance-host"
+    )
+    custom_instance = double("instance", config: custom_config, env: Shakapacker.env)
+    digest_strategy = Shakapacker::DigestStrategy.new(custom_instance)
+
+    allow(Dir).to receive(:[]).and_return([])
+    allow(Shakapacker.config).to receive(:asset_host).and_return("global-host")
+
+    expect(digest_strategy.send(:watched_files_digest)).to eq Digest::SHA1.hexdigest("instance-host")
+  end
 end

--- a/spec/shakapacker/mtime_strategy_spec.rb
+++ b/spec/shakapacker/mtime_strategy_spec.rb
@@ -4,6 +4,12 @@ describe "Shakapacker::MtimeStrategy" do
   let(:mtime_strategy) { Shakapacker::MtimeStrategy.new }
   let(:manifest_timestamp) { Time.parse("2021-01-01 12:34:56 UTC") }
 
+  describe "#default_watched_paths" do
+    it "watches both webpack and rspack config directories" do
+      expect(mtime_strategy.send(:default_watched_paths)).to include("config/{webpack,rspack}{,/**/*}")
+    end
+  end
+
   describe "#fresh?" do
     it "returns false when the manifest is missing" do
       latest_timestamp = manifest_timestamp + 3600


### PR DESCRIPTION
### Summary

Ports the #976 fix onto current `main` so compiler strategies can be built from a specific `Shakapacker::Instance` while preserving the existing zero-argument defaults. Strategies now read config, env, and asset host from that instance, and watched paths include both webpack and rspack config directories. The "slow setup for development" warning in both `DigestStrategy` and `MtimeStrategy` now checks the instance's `env.development?` instead of the global `Rails.env.development?`, completing the instance-scoping consistently across both strategies.

### Pull Request checklist

- [x] Add/update test to cover these changes
- ~[x] Update documentation~
- [x] Update CHANGELOG file

### Other Information

Verified with `bundle exec rspec spec/shakapacker/compiler_strategy_spec.rb spec/shakapacker/digest_strategy_spec.rb spec/shakapacker/mtime_strategy_spec.rb spec/shakapacker/compiler_spec.rb`, `bundle exec rubocop lib/shakapacker/base_strategy.rb lib/shakapacker/compiler_strategy.rb lib/shakapacker/digest_strategy.rb lib/shakapacker/mtime_strategy.rb lib/shakapacker/instance.rb spec/shakapacker/compiler_strategy_spec.rb spec/shakapacker/digest_strategy_spec.rb spec/shakapacker/mtime_strategy_spec.rb`, and `git diff --check`; the broader `bundle exec rspec spec/shakapacker` still has an unrelated local packaging failure in `optional_dependencies_spec` because `package/index.js` is missing for a file-based npm install.
