### PR TITLE
Make Rspack the default bundler for new installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Changed
 
-- **New installs now default to Rspack instead of webpack**. [PR #1150](https://github.com/shakacode/shakapacker/pull/1150) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer never rewrites a pre-existing config in `SKIP` mode. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
+- **New installs now default to Rspack instead of webpack**. [PR #1150](https://github.com/shakacode/shakapacker/pull/1150) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer only rewrites that value when it actually writes the bundled template, so a config it preserves (`SKIP` mode or a declined overwrite prompt) keeps its existing bundler. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - **Added support for `sass-loader` v17**. [PR #1141](https://github.com/shakacode/shakapacker/pull/1141) by [fukayatsu](https://github.com/fukayatsu). Widened the optional `sass-loader` peer range to `^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` in core `shakapacker`, `shakapacker-webpack`, and `shakapacker-rspack`. The Sass rule already selects `loadPaths` for v16+ and keeps `api: "modern"`, both of which remain valid in v17. Note that sass-loader v17 requires Node.js 22.11.0+ and drops `node-sass` and the legacy Sass JS API, so apps that opt into v17 must already be on Node 22.12+ (the upper branch of Shakapacker's `engines.node` range).
 
+### Changed
+
+- **New installs now default to Rspack instead of webpack**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer never rewrites a pre-existing config in `SKIP` mode. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
+
 ### Fixed
 
 - **Fixed compiler strategies ignoring the instance config of custom `Shakapacker::Instance` objects.** [PR #1147](https://github.com/shakacode/shakapacker/pull/1147) by [justin808](https://github.com/justin808). Ports [#976](https://github.com/shakacode/shakapacker/pull/976) by [brunodccarvalho](https://github.com/brunodccarvalho). Strategies now read the instance-specific config and watch both webpack and rspack config directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Changed
 
-- **New installs now default to Rspack instead of webpack**. [PR #XXXX](https://github.com/shakacode/shakapacker/pull/XXXX) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer never rewrites a pre-existing config in `SKIP` mode. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
+- **New installs now default to Rspack instead of webpack**. [PR #1150](https://github.com/shakacode/shakapacker/pull/1150) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer never rewrites a pre-existing config in `SKIP` mode. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Changed
 
-- **New installs now default to Rspack instead of webpack**. [PR #1150](https://github.com/shakacode/shakapacker/pull/1150) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is an install-time default only: existing applications are unaffected on upgrade — the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"`, and the installer only rewrites that value when it actually writes the bundled template, so a config it preserves (`SKIP` mode or a declined overwrite prompt) keeps its existing bundler. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`.
+- **New installs now default to Rspack instead of webpack**. [PR #1150](https://github.com/shakacode/shakapacker/pull/1150) by [justin808](https://github.com/justin808). `bundle exec rake shakapacker:install` now scaffolds an Rspack project (config, dependencies, and `config/shakapacker.yml`) by default. This is a new-install default only: existing applications are unaffected. The Rspack default applies only to brand-new installs — re-running the installer on an app that already has a `config/shakapacker.yml` keeps that app's current bundler (and installs that bundler's dependencies), so the installer never silently switches an existing project's bundler. To install with webpack, run `bundle exec rake shakapacker:install[webpack]` or set `SHAKAPACKER_ASSETS_BUNDLER=webpack`; to change an existing app's bundler, use `bundle exec rake shakapacker:switch_bundler`.
 
 ### Fixed
 

--- a/docs/dependency-strategy.md
+++ b/docs/dependency-strategy.md
@@ -218,7 +218,7 @@ The core `shakapacker` package keeps its broad optional peer ranges during v10.x
 
 `shakapacker-webpack` and `shakapacker-rspack` declare the singleton bundler stack as **required peer dependencies**. npm 7+ can auto-install those peers with the supplemental. pnpm and Yarn PnP users should keep packages imported by app config files (`shakapacker`, and often the bundler packages) as explicit app dependencies unless their configs import the wrapper packages directly.
 
-**Webpack + SWC (default happy path):**
+**Webpack + SWC:**
 
 ```json
 {
@@ -235,7 +235,7 @@ The core `shakapacker` package keeps its broad optional peer ranges during v10.x
 
 `shakapacker` and `terser-webpack-plugin` come along as direct dependencies of `shakapacker-webpack`. npm 7+ auto-installs `webpack`, `webpack-cli`, and `webpack-assets-manifest` via the required peer declarations. pnpm and Yarn PnP users should list them directly if app config files import them.
 
-**Rspack (SWC is built-in):**
+**Rspack — new-install default (SWC is built-in):**
 
 ```json
 {
@@ -385,7 +385,7 @@ Core `shakapacker` was tightened to `^20.19.0 || >=22.12.0` in v10.1 (PR #1099, 
 
 The `shakapacker:install` rake task should be updated to:
 
-1. Ask which bundler (webpack or rspack) — **default: rspack**. Rspack ships SWC transpilation built in, so the recommended path is the lowest-friction install.
+1. Ask which bundler (webpack or rspack) — **default: rspack** (the non-interactive installer already defaults to rspack; the interactive prompt remains v11 work). Rspack ships SWC transpilation built in, so the recommended path is the lowest-friction install.
 2. **If the user picked webpack**, ask which transpiler (swc, babel, esbuild, none) — default: swc. **Skip this question entirely for rspack** — rspack uses its built-in SWC and we don't want to expand the support burden by exposing transpiler swap-out for rspack users who don't need it.
 3. Install the appropriate `shakapacker-*` package + its required bundler peers (npm 7+ could auto-install the peers, but the installer writes them explicitly for cross-PM consistency and for pnpm/Yarn PnP app-level imports)
 4. Install **only** the optional peer dependencies for the features the app actually uses

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,10 +106,12 @@ config inside `package.json`. See
 
 ## Choosing a Bundler or Transpiler
 
-New installs use webpack and SWC by default. To install with Rspack:
+New installs use Rspack by default. To install with Webpack:
 
 ```bash
-SHAKAPACKER_ASSETS_BUNDLER=rspack bundle exec rake shakapacker:install
+SHAKAPACKER_ASSETS_BUNDLER=webpack bundle exec rake shakapacker:install
+# or
+bundle exec rake shakapacker:install[webpack]
 ```
 
 To install with Babel instead of SWC:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,14 +110,15 @@ New installs use Rspack by default. To install with Webpack:
 
 ```bash
 SHAKAPACKER_ASSETS_BUNDLER=webpack bundle exec rake shakapacker:install
-# or
-bundle exec rake shakapacker:install[webpack]
+# or (quote the task name so zsh does not treat the brackets as a glob)
+bundle exec rake 'shakapacker:install[webpack]'
 ```
 
-To install with Babel instead of SWC:
+To install with Babel instead of SWC (applies to webpack installs — Rspack always
+uses its built-in SWC and ignores `javascript_transpiler`):
 
 ```bash
-JAVASCRIPT_TRANSPILER=babel bundle exec rake shakapacker:install
+SHAKAPACKER_ASSETS_BUNDLER=webpack JAVASCRIPT_TRANSPILER=babel bundle exec rake shakapacker:install
 ```
 
 Most JavaScript packages are optional peer dependencies. The installer adds the

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -60,8 +60,6 @@ default: &default
 
   # Select assets bundler to use
   # Available options: 'webpack' or 'rspack'
-  # New installs default to 'rspack'; this value stays 'webpack' so existing apps
-  # keep their current bundler on upgrade.
   assets_bundler: "webpack"
 
   # Path to the directory containing webpack/rspack config files

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -59,7 +59,9 @@ default: &default
   javascript_transpiler: "swc"
 
   # Select assets bundler to use
-  # Available options: 'webpack' (default) or 'rspack'
+  # Available options: 'webpack' or 'rspack'
+  # New installs default to 'rspack'; this value stays 'webpack' so existing apps
+  # keep their current bundler on upgrade.
   assets_bundler: "webpack"
 
   # Path to the directory containing webpack/rspack config files

--- a/lib/install/package.json
+++ b/lib/install/package.json
@@ -2,6 +2,7 @@
   "rspack": {
     "@rspack/cli": "^1.0.0 || ^2.0.0-0",
     "@rspack/core": "^1.0.0 || ^2.0.0-0",
+    "@rspack/dev-server": "^1.0.0 || ^2.0.0-0",
     "rspack-manifest-plugin": "^5.0.0"
   },
   "webpack": {

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -41,6 +41,13 @@ end
 shakapacker_config_preexisting = Rails.root.join("config/shakapacker.yml").exist?
 copy_file "#{install_dir}/config/shakapacker.yml", "config/shakapacker.yml", @conflict_option
 
+# True only when copy_file actually wrote the bundled template (fresh install,
+# FORCE, or an accepted interactive overwrite). It stays false when a pre-existing
+# config is preserved (SKIP mode or a declined overwrite prompt), so we never
+# rewrite a config the user chose to keep.
+shakapacker_config_written =
+  File.read(Rails.root.join("config/shakapacker.yml")) == File.read("#{install_dir}/config/shakapacker.yml")
+
 # Update config to match the selected transpiler
 # Skip modification only when SKIP mode preserved a pre-existing user file
 if Shakapacker::Install::Env.update_transpiler_config?(
@@ -52,12 +59,14 @@ if Shakapacker::Install::Env.update_transpiler_config?(
   say "   📝 Updated config/shakapacker.yml to use #{@transpiler_to_install} transpiler", :green
 end
 
-# Update config to match the selected bundler. Mirrors the transpiler rewrite
-# above: skip it only when SKIP mode preserved a pre-existing user file.
+# Update config to match the selected bundler. The bundled shakapacker.yml ships
+# assets_bundler: "webpack" for backward compatibility, so new installs rewrite it
+# to the chosen bundler. Only rewrite when copy_file actually wrote that template;
+# a preserved user config (SKIP mode or a declined overwrite) is left untouched so
+# the installer never silently switches an existing app's bundler.
 if Shakapacker::Install::Env.update_assets_bundler_config?(
   assets_bundler_to_install: assets_bundler,
-  conflict_option: @conflict_option,
-  config_preexisting: shakapacker_config_preexisting
+  config_written: shakapacker_config_written
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
   say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -63,6 +63,12 @@ if Shakapacker::Install::Env.update_assets_bundler_config?(
   config_preexisting: shakapacker_config_preexisting
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
+  # gsub_file matches the literal shipped value, so a future reformat of the
+  # template would turn this into a silent no-op. Surface that instead of leaving
+  # the user on the wrong bundler without any warning.
+  unless File.read(Rails.root.join("config/shakapacker.yml")).include?("assets_bundler: \"#{assets_bundler}\"")
+    say "   ⚠️  Could not update assets_bundler in config/shakapacker.yml — please set it to \"#{assets_bundler}\" manually.", :yellow
+  end
   say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
 end
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -332,6 +332,8 @@ Dir.chdir(Rails.root) do
   end
 
   if dev_dependencies_to_add.any?
+    # Strip the trailing @version, keeping the package name; the regex drops only
+    # the last @-segment so scoped names (e.g. @rspack/dev-server) survive.
     dev_dependency_names = dev_dependencies_to_add.map { |entry| entry.sub(/@[^@]+\z/, "") }
     say "Installing development dependencies: #{dev_dependency_names.join(", ")}"
     begin

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -74,10 +74,13 @@ if Shakapacker::Install::Env.update_assets_bundler_config?(
 else
   # The bundler was deliberately left as-is: an explicit webpack request, a
   # preserved pre-existing config, or an interactive overwrite that restored the
-  # shipped webpack default. Report the retained value so the choice isn't silent.
-  config_contents = File.read(Rails.root.join("config/shakapacker.yml"))
-  retained_bundler = config_contents[/assets_bundler:\s*"([^"]+)"/, 1] || assets_bundler
-  say "   📝 Keeping assets_bundler: \"#{retained_bundler}\" in config/shakapacker.yml", :green
+  # shipped webpack default. Report the value actually present so the choice isn't
+  # silent, but only when we can read it back — never guess, or the message could
+  # contradict the file.
+  retained_bundler = File.read(Rails.root.join("config/shakapacker.yml"))[/assets_bundler:\s*"([^"]+)"/, 1]
+  if retained_bundler
+    say "   📝 Keeping assets_bundler: \"#{retained_bundler}\" in config/shakapacker.yml", :green
+  end
 end
 
 # Detect TypeScript usage

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -70,9 +70,8 @@ if Shakapacker::Install::Env.update_assets_bundler_config?(
   config_preexisting: shakapacker_config_preexisting
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
-  # gsub_file matches the literal shipped value, so a future reformat of the
-  # template would turn this into a silent no-op. Report success and failure as
-  # mutually exclusive outcomes so the user never sees both messages at once.
+  # gsub_file silently no-ops if the shipped literal is ever reformatted, so verify
+  # the value landed and report success/failure as mutually exclusive outcomes.
   if File.read(Rails.root.join("config/shakapacker.yml")).include?("assets_bundler: \"#{assets_bundler}\"")
     say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
   else
@@ -333,7 +332,8 @@ Dir.chdir(Rails.root) do
   end
 
   if dev_dependencies_to_add.any?
-    say "Installing bundler development dependencies"
+    dev_dependency_names = dev_dependencies_to_add.map { |entry| entry.sub(/@[^@]+\z/, "") }
+    say "Installing development dependencies: #{dev_dependency_names.join(", ")}"
     begin
       @package_json.manager.add!(dev_dependencies_to_add, type: :dev)
     rescue PackageJson::Error

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -52,11 +52,8 @@ if Shakapacker::Install::Env.update_transpiler_config?(
   say "   📝 Updated config/shakapacker.yml to use #{@transpiler_to_install} transpiler", :green
 end
 
-# Update config to match the selected bundler.
-# The bundled shakapacker.yml ships assets_bundler: "webpack" so existing apps
-# keep webpack on upgrade; new installs default to rspack and rewrite the value
-# here. As with the transpiler, skip the rewrite only when SKIP mode preserved a
-# pre-existing user file.
+# Update config to match the selected bundler. Mirrors the transpiler rewrite
+# above: skip it only when SKIP mode preserved a pre-existing user file.
 if Shakapacker::Install::Env.update_assets_bundler_config?(
   assets_bundler_to_install: assets_bundler,
   conflict_option: @conflict_option,

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -64,12 +64,20 @@ if Shakapacker::Install::Env.update_assets_bundler_config?(
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
   # gsub_file matches the literal shipped value, so a future reformat of the
-  # template would turn this into a silent no-op. Surface that instead of leaving
-  # the user on the wrong bundler without any warning.
-  unless File.read(Rails.root.join("config/shakapacker.yml")).include?("assets_bundler: \"#{assets_bundler}\"")
+  # template would turn this into a silent no-op. Report success and failure as
+  # mutually exclusive outcomes so the user never sees both messages at once.
+  if File.read(Rails.root.join("config/shakapacker.yml")).include?("assets_bundler: \"#{assets_bundler}\"")
+    say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
+  else
     say "   ⚠️  Could not update assets_bundler in config/shakapacker.yml — please set it to \"#{assets_bundler}\" manually.", :yellow
   end
-  say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
+else
+  # The bundler was deliberately left as-is: an explicit webpack request, a
+  # preserved pre-existing config, or an interactive overwrite that restored the
+  # shipped webpack default. Report the retained value so the choice isn't silent.
+  config_contents = File.read(Rails.root.join("config/shakapacker.yml"))
+  retained_bundler = config_contents[/assets_bundler:\s*"([^"]+)"/, 1] || assets_bundler
+  say "   📝 Keeping assets_bundler: \"#{retained_bundler}\" in config/shakapacker.yml", :green
 end
 
 # Detect TypeScript usage

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -14,9 +14,24 @@ require "json"
 # Using instance variable to avoid method definition issues in Rails templates
 @package_json ||= PackageJson.new
 install_dir = File.expand_path(File.dirname(__FILE__))
-# New installs default to rspack. The bundled shakapacker.yml keeps "webpack" for
-# backward compatibility, so the installer rewrites the value below when needed.
-assets_bundler = ENV["SHAKAPACKER_ASSETS_BUNDLER"] || "rspack"
+
+# Read the existing app's bundler (if any) before copy_file can overwrite it, so a
+# re-install can default to that bundler instead of silently switching it.
+config_path = Rails.root.join("config/shakapacker.yml")
+shakapacker_config_preexisting = config_path.exist?
+existing_assets_bundler =
+  File.read(config_path)[/assets_bundler:\s*"([^"]+)"/, 1] if shakapacker_config_preexisting
+
+# New installs default to rspack; an existing app keeps its current bundler on a
+# re-install unless overridden by the env var/argument or a FORCE overwrite (see
+# Env.resolve_assets_bundler for the precedence rules). The bundled shakapacker.yml
+# ships "webpack" for backward compatibility and is rewritten below when the chosen
+# bundler differs.
+assets_bundler = Shakapacker::Install::Env.resolve_assets_bundler(
+  env_value: ENV["SHAKAPACKER_ASSETS_BUNDLER"],
+  existing_bundler: existing_assets_bundler,
+  force: @conflict_option[:force]
+)
 
 # Fail fast on a misspelled SHAKAPACKER_ASSETS_BUNDLER instead of failing later
 # with a confusing missing-config-directory or peer-lookup error.
@@ -45,7 +60,6 @@ else
 end
 
 # Copy config file
-shakapacker_config_preexisting = Rails.root.join("config/shakapacker.yml").exist?
 copy_file "#{install_dir}/config/shakapacker.yml", "config/shakapacker.yml", @conflict_option
 
 # Update config to match the selected transpiler
@@ -56,14 +70,18 @@ if Shakapacker::Install::Env.update_transpiler_config?(
   config_preexisting: shakapacker_config_preexisting
 )
   gsub_file "config/shakapacker.yml", 'javascript_transpiler: "swc"', "javascript_transpiler: \"#{@transpiler_to_install}\""
-  say "   📝 Updated config/shakapacker.yml to use #{@transpiler_to_install} transpiler", :green
+  # Unlike the bundler rewrite below (which only runs on installer-owned files and
+  # aborts on a miss), this can also run against a pre-existing user config whose
+  # transpiler line may legitimately differ from the shipped "swc" literal. A no-op
+  # there is not an error, so only claim success when the value actually landed.
+  if File.read(config_path).include?("javascript_transpiler: \"#{@transpiler_to_install}\"")
+    say "   📝 Updated config/shakapacker.yml to use #{@transpiler_to_install} transpiler", :green
+  end
 end
 
-# Update config to match the selected bundler. The bundled shakapacker.yml ships
-# assets_bundler: "webpack" for backward compatibility, so new installs rewrite it
-# to the chosen bundler. We only rewrite a config the installer owns (a fresh
-# install or FORCE); a pre-existing config (SKIP mode, a declined overwrite, or any
-# existing app) is left untouched so the installer never silently switches its bundler.
+# Update config to match the selected bundler (see update_assets_bundler_config?
+# for when the installer rewrites the shipped "webpack" default vs. preserves an
+# existing config).
 if Shakapacker::Install::Env.update_assets_bundler_config?(
   assets_bundler_to_install: assets_bundler,
   conflict_option: @conflict_option,
@@ -71,20 +89,32 @@ if Shakapacker::Install::Env.update_assets_bundler_config?(
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
   # gsub_file silently no-ops if the shipped literal is ever reformatted, so verify
-  # the value landed and report success/failure as mutually exclusive outcomes.
-  if File.read(Rails.root.join("config/shakapacker.yml")).include?("assets_bundler: \"#{assets_bundler}\"")
+  # the value landed. Abort rather than continue, since the installer is about to set
+  # up the chosen bundler's dependencies and config, and a mismatched bundler value
+  # would produce a broken install. This runs before any dependencies are installed.
+  if File.read(config_path).include?("assets_bundler: \"#{assets_bundler}\"")
     say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
   else
-    say "   ⚠️  Could not update assets_bundler in config/shakapacker.yml — please set it to \"#{assets_bundler}\" manually.", :yellow
+    say "❌ Could not set assets_bundler to \"#{assets_bundler}\" in config/shakapacker.yml " \
+        "— the expected 'assets_bundler: \"webpack\"' line was not found. Aborting so the " \
+        "install doesn't proceed with a mismatched bundler config.", :red
+    exit 1
   end
 else
-  # The bundler was deliberately left as-is: an explicit webpack request, a
-  # preserved pre-existing config, or an interactive overwrite that restored the
-  # shipped webpack default. Report the value actually present so the choice isn't
-  # silent, but only when we can read it back — never guess, or the message could
-  # contradict the file.
-  retained_bundler = File.read(Rails.root.join("config/shakapacker.yml"))[/assets_bundler:\s*"([^"]+)"/, 1]
-  if retained_bundler
+  # The bundler config was left as-is (an existing app's config is preserved unless
+  # FORCE overwrites it). Report the value present, and warn if it differs from the
+  # bundler whose dependencies/config are being installed — usually when a bundler is
+  # requested explicitly (env var or task argument) against a preserved config, but
+  # also when a preserved config holds an unrecognized bundler and resolve_assets_bundler
+  # falls back to rspack. Either case would otherwise be a silent mismatch. Only act
+  # when we can read the value back — never guess, or the message could contradict the file.
+  retained_bundler = File.read(config_path)[/assets_bundler:\s*"([^"]+)"/, 1]
+  if retained_bundler && retained_bundler != assets_bundler
+    say "⚠️  Installing #{assets_bundler} dependencies, but config/shakapacker.yml keeps " \
+        "assets_bundler: \"#{retained_bundler}\". To switch an existing app's bundler, run " \
+        "`bin/rake shakapacker:switch_bundler #{assets_bundler} -- --install-deps`, " \
+        "or re-run the installer with FORCE=true to overwrite the config.", :yellow
+  elsif retained_bundler
     say "   📝 Keeping assets_bundler: \"#{retained_bundler}\" in config/shakapacker.yml", :green
   end
 end

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -14,6 +14,9 @@ require "json"
 # Using instance variable to avoid method definition issues in Rails templates
 @package_json ||= PackageJson.new
 install_dir = File.expand_path(File.dirname(__FILE__))
+# New installs default to rspack. The bundled shakapacker.yml keeps "webpack" for
+# backward compatibility, so the installer rewrites the value below when needed.
+assets_bundler = ENV["SHAKAPACKER_ASSETS_BUNDLER"] || "rspack"
 
 # Installation strategy:
 # - USE_BABEL_PACKAGES installs both babel AND swc for compatibility
@@ -49,11 +52,24 @@ if Shakapacker::Install::Env.update_transpiler_config?(
   say "   📝 Updated config/shakapacker.yml to use #{@transpiler_to_install} transpiler", :green
 end
 
+# Update config to match the selected bundler.
+# The bundled shakapacker.yml ships assets_bundler: "webpack" so existing apps
+# keep webpack on upgrade; new installs default to rspack and rewrite the value
+# here. As with the transpiler, skip the rewrite only when SKIP mode preserved a
+# pre-existing user file.
+if Shakapacker::Install::Env.update_assets_bundler_config?(
+  assets_bundler_to_install: assets_bundler,
+  conflict_option: @conflict_option,
+  config_preexisting: shakapacker_config_preexisting
+)
+  gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
+  say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
+end
+
 # Detect TypeScript usage
 # Auto-detect from tsconfig.json or explicit via SHAKAPACKER_USE_TYPESCRIPT env var
 @use_typescript = File.exist?(Rails.root.join("tsconfig.json")) ||
   Shakapacker::Install::Env.truthy_env?("SHAKAPACKER_USE_TYPESCRIPT")
-assets_bundler = ENV["SHAKAPACKER_ASSETS_BUNDLER"] || "webpack"
 config_extension = @use_typescript ? "ts" : "js"
 
 say "Copying #{assets_bundler} core config (#{config_extension.upcase})"
@@ -224,7 +240,7 @@ Dir.chdir(Rails.root) do
   end
 
   # Inline fetch_peer_dependencies and fetch_common_dependencies
-  peers = PackageJson.read(install_dir).fetch(ENV["SHAKAPACKER_ASSETS_BUNDLER"] || "webpack")
+  peers = PackageJson.read(install_dir).fetch(assets_bundler)
   common_deps = Shakapacker::Install::Env.truthy_env?("SKIP_COMMON_LOADERS") ? {} : PackageJson.read(install_dir).fetch("common")
   peers = peers.merge(common_deps)
 
@@ -255,7 +271,7 @@ Dir.chdir(Rails.root) do
     peers = peers.merge(esbuild_deps)
   end
 
-  dev_dependency_packages = ["webpack-dev-server"]
+  dev_dependency_packages = ["webpack-dev-server", "@rspack/dev-server"]
 
   dependencies_to_add = []
   dev_dependencies_to_add = []
@@ -290,12 +306,14 @@ Dir.chdir(Rails.root) do
     exit 1
   end
 
-  say "Installing webpack-dev-server for live reloading as a development dependency"
-  begin
-    @package_json.manager.add!(dev_dependencies_to_add, type: :dev)
-  rescue PackageJson::Error
-    say "Shakapacker installation failed 😭 See above for details.", :red
-    exit 1
+  if dev_dependencies_to_add.any?
+    say "Installing bundler development dependencies"
+    begin
+      @package_json.manager.add!(dev_dependencies_to_add, type: :dev)
+    rescue PackageJson::Error
+      say "Shakapacker installation failed 😭 See above for details.", :red
+      exit 1
+    end
   end
 
   # Configure babel preset in package.json if babel is being used

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -18,6 +18,13 @@ install_dir = File.expand_path(File.dirname(__FILE__))
 # backward compatibility, so the installer rewrites the value below when needed.
 assets_bundler = ENV["SHAKAPACKER_ASSETS_BUNDLER"] || "rspack"
 
+# Fail fast on a misspelled SHAKAPACKER_ASSETS_BUNDLER instead of failing later
+# with a confusing missing-config-directory or peer-lookup error.
+unless Shakapacker::Install::Env::VALID_BUNDLERS.include?(assets_bundler)
+  say "❌ Unknown bundler '#{assets_bundler}'. Set SHAKAPACKER_ASSETS_BUNDLER to one of: #{Shakapacker::Install::Env::VALID_BUNDLERS.join(", ")}.", :red
+  exit 1
+end
+
 # Installation strategy:
 # - USE_BABEL_PACKAGES installs both babel AND swc for compatibility
 # - Otherwise install only the specified transpiler

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -41,13 +41,6 @@ end
 shakapacker_config_preexisting = Rails.root.join("config/shakapacker.yml").exist?
 copy_file "#{install_dir}/config/shakapacker.yml", "config/shakapacker.yml", @conflict_option
 
-# True only when copy_file actually wrote the bundled template (fresh install,
-# FORCE, or an accepted interactive overwrite). It stays false when a pre-existing
-# config is preserved (SKIP mode or a declined overwrite prompt), so we never
-# rewrite a config the user chose to keep.
-shakapacker_config_written =
-  File.read(Rails.root.join("config/shakapacker.yml")) == File.read("#{install_dir}/config/shakapacker.yml")
-
 # Update config to match the selected transpiler
 # Skip modification only when SKIP mode preserved a pre-existing user file
 if Shakapacker::Install::Env.update_transpiler_config?(
@@ -61,12 +54,13 @@ end
 
 # Update config to match the selected bundler. The bundled shakapacker.yml ships
 # assets_bundler: "webpack" for backward compatibility, so new installs rewrite it
-# to the chosen bundler. Only rewrite when copy_file actually wrote that template;
-# a preserved user config (SKIP mode or a declined overwrite) is left untouched so
-# the installer never silently switches an existing app's bundler.
+# to the chosen bundler. We only rewrite a config the installer owns (a fresh
+# install or FORCE); a pre-existing config (SKIP mode, a declined overwrite, or any
+# existing app) is left untouched so the installer never silently switches its bundler.
 if Shakapacker::Install::Env.update_assets_bundler_config?(
   assets_bundler_to_install: assets_bundler,
-  config_written: shakapacker_config_written
+  conflict_option: @conflict_option,
+  config_preexisting: shakapacker_config_preexisting
 )
   gsub_file "config/shakapacker.yml", 'assets_bundler: "webpack"', "assets_bundler: \"#{assets_bundler}\""
   say "   📝 Updated config/shakapacker.yml to use #{assets_bundler} bundler", :green
@@ -277,6 +271,8 @@ Dir.chdir(Rails.root) do
     peers = peers.merge(esbuild_deps)
   end
 
+  # Lists both dev servers for classification only; just the one matching the chosen
+  # bundler appears in `peers`, so only that package is actually installed.
   dev_dependency_packages = ["webpack-dev-server", "@rspack/dev-server"]
 
   dependencies_to_add = []

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -30,15 +30,18 @@ module Shakapacker
       end
 
       # Keep bundled runtime defaults backward compatible while allowing the
-      # installer to write an explicit new-project bundler choice. Only rewrite
-      # when copy_file actually wrote the bundled template (config_written); a
-      # preserved user config (SKIP mode or a declined overwrite) is left as-is.
-      def update_assets_bundler_config?(assets_bundler_to_install:, config_written:)
+      # installer to write an explicit new-project bundler choice. Takes the same
+      # inputs as update_transpiler_config? for consistency, but is deliberately
+      # more conservative: switching an existing app's bundler is impactful, so we
+      # only rewrite a config the installer owns (a fresh install, or an explicit
+      # FORCE overwrite) and never a pre-existing one (interactive or SKIP mode).
+      def update_assets_bundler_config?(assets_bundler_to_install:, conflict_option:, config_preexisting:)
         # The bundled shakapacker.yml already ships assets_bundler: "webpack", so
         # rewriting it to "webpack" would be a no-op. This relies on that shipped default.
         return false if assets_bundler_to_install == "webpack"
+        return true if conflict_option[:force]
 
-        config_written
+        !config_preexisting
       end
     end
   end

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -2,6 +2,7 @@ module Shakapacker
   module Install
     module Env
       TRUTHY_VALUES = %w[true 1 yes].freeze
+      VALID_BUNDLERS = %w[webpack rspack].freeze
 
       module_function
 
@@ -42,6 +43,24 @@ module Shakapacker
         return true if conflict_option[:force]
 
         !config_preexisting
+      end
+
+      # Apply an optional `shakapacker:install[bundler]` task argument. A
+      # recognized bundler (webpack or rspack) is written to
+      # SHAKAPACKER_ASSETS_BUNDLER so the install template picks it up; an
+      # unrecognized value is ignored — the bundler then falls back to the env
+      # var or the rspack default — and described in the returned warning so the
+      # caller can surface it. Returns nil when no argument was given or there is
+      # nothing to warn about.
+      def apply_bundler_arg(bundler_arg)
+        return nil if bundler_arg.nil? || bundler_arg.empty?
+
+        if VALID_BUNDLERS.include?(bundler_arg)
+          ENV["SHAKAPACKER_ASSETS_BUNDLER"] = bundler_arg
+          nil
+        else
+          "Unknown bundler '#{bundler_arg}'; ignoring it. Valid values: #{VALID_BUNDLERS.join(", ")}."
+        end
       end
     end
   end

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -32,6 +32,8 @@ module Shakapacker
       # Keep bundled runtime defaults backward compatible while allowing the
       # installer to write an explicit new-project bundler choice.
       def update_assets_bundler_config?(assets_bundler_to_install:, conflict_option:, config_preexisting:)
+        # The bundled shakapacker.yml already ships assets_bundler: "webpack", so
+        # rewriting it to "webpack" would be a no-op. This relies on that shipped default.
         return false if assets_bundler_to_install == "webpack"
         return true if conflict_option[:force]
         return true unless conflict_option[:skip]

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -45,11 +45,27 @@ module Shakapacker
         !config_preexisting
       end
 
+      # Resolve which bundler the installer should set up. Precedence: an explicit
+      # SHAKAPACKER_ASSETS_BUNDLER env var (or task argument, which sets that env var)
+      # always wins; otherwise a FORCE overwrite installs the new-project default;
+      # otherwise an existing app keeps its current bundler (when it is a recognized
+      # value) so a re-install never silently switches it; brand-new installs fall
+      # back to rspack. Returning the env var verbatim lets the caller's strict
+      # VALID_BUNDLERS check still reject a misspelled value.
+      def resolve_assets_bundler(env_value:, existing_bundler:, force:)
+        return env_value if env_value
+        return "rspack" if force
+        return existing_bundler if VALID_BUNDLERS.include?(existing_bundler)
+
+        "rspack"
+      end
+
       # Apply an optional `shakapacker:install[bundler]` task argument. A
       # recognized bundler (webpack or rspack) is written to
-      # SHAKAPACKER_ASSETS_BUNDLER so the install template picks it up. An
-      # unrecognized value returns an error message (and leaves the env var
-      # unset) so the caller can abort, mirroring the template's strict
+      # SHAKAPACKER_ASSETS_BUNDLER so the install template picks it up,
+      # overriding any value already set in that env var (the explicit argument
+      # wins). An unrecognized value returns an error message (and leaves the
+      # env var unset) so the caller can abort, mirroring the template's strict
       # validation of SHAKAPACKER_ASSETS_BUNDLER. Returns nil when the argument
       # is valid or absent.
       def apply_bundler_arg(bundler_arg)

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -28,6 +28,16 @@ module Shakapacker
 
         !config_preexisting
       end
+
+      # Keep bundled runtime defaults backward compatible while allowing the
+      # installer to write an explicit new-project bundler choice.
+      def update_assets_bundler_config?(assets_bundler_to_install:, conflict_option:, config_preexisting:)
+        return false if assets_bundler_to_install == "webpack"
+        return true if conflict_option[:force]
+        return true unless conflict_option[:skip]
+
+        !config_preexisting
+      end
     end
   end
 end

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -30,15 +30,15 @@ module Shakapacker
       end
 
       # Keep bundled runtime defaults backward compatible while allowing the
-      # installer to write an explicit new-project bundler choice.
-      def update_assets_bundler_config?(assets_bundler_to_install:, conflict_option:, config_preexisting:)
+      # installer to write an explicit new-project bundler choice. Only rewrite
+      # when copy_file actually wrote the bundled template (config_written); a
+      # preserved user config (SKIP mode or a declined overwrite) is left as-is.
+      def update_assets_bundler_config?(assets_bundler_to_install:, config_written:)
         # The bundled shakapacker.yml already ships assets_bundler: "webpack", so
         # rewriting it to "webpack" would be a no-op. This relies on that shipped default.
         return false if assets_bundler_to_install == "webpack"
-        return true if conflict_option[:force]
-        return true unless conflict_option[:skip]
 
-        !config_preexisting
+        config_written
       end
     end
   end

--- a/lib/shakapacker/install/env.rb
+++ b/lib/shakapacker/install/env.rb
@@ -47,11 +47,11 @@ module Shakapacker
 
       # Apply an optional `shakapacker:install[bundler]` task argument. A
       # recognized bundler (webpack or rspack) is written to
-      # SHAKAPACKER_ASSETS_BUNDLER so the install template picks it up; an
-      # unrecognized value is ignored — the bundler then falls back to the env
-      # var or the rspack default — and described in the returned warning so the
-      # caller can surface it. Returns nil when no argument was given or there is
-      # nothing to warn about.
+      # SHAKAPACKER_ASSETS_BUNDLER so the install template picks it up. An
+      # unrecognized value returns an error message (and leaves the env var
+      # unset) so the caller can abort, mirroring the template's strict
+      # validation of SHAKAPACKER_ASSETS_BUNDLER. Returns nil when the argument
+      # is valid or absent.
       def apply_bundler_arg(bundler_arg)
         return nil if bundler_arg.nil? || bundler_arg.empty?
 
@@ -59,7 +59,7 @@ module Shakapacker
           ENV["SHAKAPACKER_ASSETS_BUNDLER"] = bundler_arg
           nil
         else
-          "Unknown bundler '#{bundler_arg}'; ignoring it. Valid values: #{VALID_BUNDLERS.join(", ")}."
+          "Unknown bundler '#{bundler_arg}'. Valid values: #{VALID_BUNDLERS.join(", ")}."
         end
       end
     end

--- a/lib/tasks/shakapacker.rake
+++ b/lib/tasks/shakapacker.rake
@@ -1,6 +1,6 @@
 tasks = {
   "shakapacker:info"                    => "Provides information on Shakapacker's environment",
-  "shakapacker:install"                 => "Installs and setup webpack",
+  "shakapacker:install"                 => "Installs and sets up Shakapacker",
   "shakapacker:compile"                 => "Compiles webpack bundles based on environment",
   "shakapacker:clean"                   => "Remove old compiled bundles",
   "shakapacker:clobber"                 => "Removes the webpack compiled output directory",

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -10,7 +10,7 @@ namespace :shakapacker do
       if %w[webpack rspack].include?(args[:bundler])
         ENV["SHAKAPACKER_ASSETS_BUNDLER"] = args[:bundler]
       else
-        warn "Unknown bundler '#{args[:bundler]}'; defaulting to rspack. Valid values: webpack, rspack."
+        warn "Unknown bundler '#{args[:bundler]}'; ignoring it. Valid values: webpack, rspack."
       end
     end
 

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -8,8 +8,8 @@ namespace :shakapacker do
   task :install, [:bundler, :typescript] => [:check_node] do |task, args|
     Shakapacker::Configuration.installing = true
 
-    if (bundler_warning = Shakapacker::Install::Env.apply_bundler_arg(args[:bundler]))
-      warn bundler_warning
+    if (bundler_error = Shakapacker::Install::Env.apply_bundler_arg(args[:bundler]))
+      abort bundler_error
     end
 
     # Set typescript flag if passed as argument

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -2,12 +2,12 @@ install_template_path = File.expand_path("../../install/template.rb", __dir__).f
 bin_path = ENV["BUNDLE_BIN"] || Rails.root.join("bin")
 
 namespace :shakapacker do
-  desc "Install Shakapacker in this application (use SHAKAPACKER_ASSETS_BUNDLER=rspack for Rspack, --typescript for TypeScript)"
+  desc "Install Shakapacker in this application (defaults to Rspack; pass webpack or SHAKAPACKER_ASSETS_BUNDLER=webpack for Webpack)"
   task :install, [:bundler, :typescript] => [:check_node] do |task, args|
     Shakapacker::Configuration.installing = true
 
-    if args[:bundler] == "rspack" || ENV["SHAKAPACKER_ASSETS_BUNDLER"] == "rspack"
-      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = "rspack"
+    if %w[webpack rspack].include?(args[:bundler])
+      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = args[:bundler]
     end
 
     # Set typescript flag if passed as argument

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -6,8 +6,12 @@ namespace :shakapacker do
   task :install, [:bundler, :typescript] => [:check_node] do |task, args|
     Shakapacker::Configuration.installing = true
 
-    if %w[webpack rspack].include?(args[:bundler])
-      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = args[:bundler]
+    if args[:bundler]
+      if %w[webpack rspack].include?(args[:bundler])
+        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = args[:bundler]
+      else
+        warn "Unknown bundler '#{args[:bundler]}'; defaulting to rspack. Valid values: webpack, rspack."
+      end
     end
 
     # Set typescript flag if passed as argument

--- a/lib/tasks/shakapacker/install.rake
+++ b/lib/tasks/shakapacker/install.rake
@@ -1,3 +1,5 @@
+require "shakapacker/install/env"
+
 install_template_path = File.expand_path("../../install/template.rb", __dir__).freeze
 bin_path = ENV["BUNDLE_BIN"] || Rails.root.join("bin")
 
@@ -6,12 +8,8 @@ namespace :shakapacker do
   task :install, [:bundler, :typescript] => [:check_node] do |task, args|
     Shakapacker::Configuration.installing = true
 
-    if args[:bundler]
-      if %w[webpack rspack].include?(args[:bundler])
-        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = args[:bundler]
-      else
-        warn "Unknown bundler '#{args[:bundler]}'; ignoring it. Valid values: webpack, rspack."
-      end
+    if (bundler_warning = Shakapacker::Install::Env.apply_bundler_arg(args[:bundler]))
+      warn bundler_warning
     end
 
     # Set typescript flag if passed as argument

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -219,9 +219,13 @@ describe "Generator" do
         it "adds the rspack dev-server (and not webpack-dev-server) as a dev dependency" do
           package_json = PackageJson.read(path_in_the_app)
           actual_dev_dependencies = package_json.fetch("devDependencies", {}).keys
+          actual_dependencies = package_json.fetch("dependencies", {}).keys
 
           expect(actual_dev_dependencies).to include("@rspack/dev-server")
           expect(actual_dev_dependencies).not_to include("webpack-dev-server")
+          # Guard the dev/runtime classification: the dev-server must land in
+          # devDependencies, not leak into runtime dependencies.
+          expect(actual_dependencies).not_to include("@rspack/dev-server")
         end
 
         context "with a basic react app setup" do
@@ -288,6 +292,14 @@ describe "Generator" do
           content = File.read(config_path)
 
           expect(content).to end_with("\n")
+        end
+
+        it "keeps assets_bundler set to webpack when requested via the positional argument" do
+          config_path = Pathname.new(File.join(TEMP_RAILS_APP_PATH.to_s + "-ts", "config/shakapacker.yml"))
+          content = File.read(config_path)
+
+          expect(content).to include('assets_bundler: "webpack"')
+          expect(content).not_to include('assets_bundler: "rspack"')
         end
       end
 

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -421,6 +421,19 @@ describe "Generator" do
         expect(config_content).to include('javascript_transpiler: "babel"')
         expect(config_content).not_to include('javascript_transpiler: "swc"')
       end
+
+      it "creates the webpack config directory and files (JS by default)" do
+        Dir.chdir(File.join(@babel_only_app_path, "config/webpack")) do
+          expect(Dir.glob("*")).to eq(["webpack.config.js"])
+        end
+      end
+
+      it "keeps assets_bundler set to webpack when requested explicitly" do
+        config_content = File.read(File.join(@babel_only_app_path, "config/shakapacker.yml"))
+
+        expect(config_content).to include('assets_bundler: "webpack"')
+        expect(config_content).not_to include('assets_bundler: "rspack"')
+      end
     end
   end
 

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -64,8 +64,8 @@ describe "Generator" do
             else
               ""
             end
-            install_cmd = "#{npm_package_env}SHAKAPACKER_ASSETS_BUNDLER=webpack " \
-                          "USE_BABEL_PACKAGES=true FORCE=true bundle exec rake shakapacker:install"
+            install_cmd = "#{npm_package_env}USE_BABEL_PACKAGES=true FORCE=true " \
+                          "bundle exec rake shakapacker:install"
             sh_in_dir(sh_opts, TEMP_RAILS_APP_PATH, install_cmd)
 
             # Update package.json to use local shakapacker package
@@ -107,15 +107,16 @@ describe "Generator" do
           FileUtils.rm_rf(TEMP_RAILS_APP_PATH)
         end
 
-        it "creates `config/shakapacker.yml` with babel transpiler when USE_BABEL_PACKAGES is set" do
+        it "creates `config/shakapacker.yml` with rspack bundler and babel transpiler when USE_BABEL_PACKAGES is set" do
           config_file_relative_path = "config/shakapacker.yml"
           actual_content = read(path_in_the_app(config_file_relative_path))
           expected_content = read(path_in_the_gem(config_file_relative_path))
 
           # When USE_BABEL_PACKAGES=true, the config should be updated to use babel
           expected_content_with_babel = expected_content.gsub('javascript_transpiler: "swc"', 'javascript_transpiler: "babel"')
+          expected_content_with_babel_and_rspack = expected_content_with_babel.gsub('assets_bundler: "webpack"', 'assets_bundler: "rspack"')
 
-          expect(actual_content).to eq expected_content_with_babel
+          expect(actual_content).to eq expected_content_with_babel_and_rspack
         end
 
         it "ensures the 'packageManager' field is set" do
@@ -126,14 +127,14 @@ describe "Generator" do
           expect(package_json.fetch("packageManager", "")).to match(/#{manager_name}@\d+\.\d+\.\d+/)
         end
 
-        it "creates webpack config directory and files (defaults to JS)" do
+        it "creates rspack config directory and files by default (defaults to JS)" do
           expected_files = [
-            "webpack.config.js"
+            "rspack.config.js"
           ]
 
-          Dir.chdir(path_in_the_app("config/webpack")) do
-            existing_files_in_config_webpack_dir = Dir.glob("*")
-            expect(existing_files_in_config_webpack_dir).to eq expected_files
+          Dir.chdir(path_in_the_app("config/rspack")) do
+            existing_files_in_config_rspack_dir = Dir.glob("*")
+            expect(existing_files_in_config_rspack_dir).to eq expected_files
           end
         end
 
@@ -207,25 +208,20 @@ describe "Generator" do
             @swc/core
             swc-loader
             compression-webpack-plugin
-            terser-webpack-plugin
-            webpack
-            webpack-assets-manifest
-            webpack-cli
-            webpack-merge
+            @rspack/cli
+            @rspack/core
+            rspack-manifest-plugin
           )
 
           expect(actual_dependencies).to include(*expected_dependencies)
         end
 
-        it "adds Shakapacker peer dev dependencies to package.json" do
+        it "adds the rspack dev-server (and not webpack-dev-server) as a dev dependency" do
           package_json = PackageJson.read(path_in_the_app)
           actual_dev_dependencies = package_json.fetch("devDependencies", {}).keys
 
-          expected_dev_dependencies = %w(
-            webpack-dev-server
-          )
-
-          expect(actual_dev_dependencies).to include(*expected_dev_dependencies)
+          expect(actual_dev_dependencies).to include("@rspack/dev-server")
+          expect(actual_dev_dependencies).not_to include("webpack-dev-server")
         end
 
         context "with a basic react app setup" do

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -370,10 +370,10 @@ describe "Generator" do
 
         it "auto-detects TypeScript and creates .ts config" do
           expected_files = [
-            "webpack.config.ts"
+            "rspack.config.ts"
           ]
 
-          Dir.chdir(Pathname.new(File.join(TEMP_RAILS_APP_PATH.to_s + "-tsconfig", "config/webpack"))) do
+          Dir.chdir(Pathname.new(File.join(TEMP_RAILS_APP_PATH.to_s + "-tsconfig", "config/rspack"))) do
             existing_files = Dir.glob("*")
             expect(existing_files).to eq expected_files
           end

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -280,6 +280,50 @@ describe Shakapacker::Install::Env do
     end
   end
 
+  describe "resolve_assets_bundler" do
+    it "returns the env var value when set (it wins over force and existing config)" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: "webpack", existing_bundler: "rspack", force: true)
+      ).to eq "webpack"
+    end
+
+    it "returns the env var value verbatim so the caller can still reject a bad value" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: "wbpack", existing_bundler: nil, force: false)
+      ).to eq "wbpack"
+    end
+
+    it "treats an empty env var as set and returns it verbatim (the caller's VALID_BUNDLERS check then rejects it)" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: "", existing_bundler: "webpack", force: false)
+      ).to eq ""
+    end
+
+    it "installs the rspack default on FORCE, ignoring an existing bundler" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: nil, existing_bundler: "webpack", force: true)
+      ).to eq "rspack"
+    end
+
+    it "keeps an existing app's bundler when not overridden" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: nil, existing_bundler: "webpack", force: false)
+      ).to eq "webpack"
+    end
+
+    it "ignores an unrecognized existing value and falls back to rspack" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: nil, existing_bundler: "wbpack", force: false)
+      ).to eq "rspack"
+    end
+
+    it "defaults a brand-new install (no env, no existing config) to rspack" do
+      expect(
+        described_class.resolve_assets_bundler(env_value: nil, existing_bundler: nil, force: false)
+      ).to eq "rspack"
+    end
+  end
+
   describe "apply_bundler_arg" do
     before { ENV.delete("SHAKAPACKER_ASSETS_BUNDLER") }
 
@@ -293,11 +337,23 @@ describe Shakapacker::Install::Env do
       expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "rspack"
     end
 
+    it "lets an explicit argument override an existing SHAKAPACKER_ASSETS_BUNDLER" do
+      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = "rspack"
+      expect(described_class.apply_bundler_arg("webpack")).to be_nil
+      expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "webpack"
+    end
+
     it "returns an error and leaves SHAKAPACKER_ASSETS_BUNDLER unset for an unknown bundler" do
       error = described_class.apply_bundler_arg("wbpack")
 
       expect(error).to include "Unknown bundler 'wbpack'"
       expect(error).to include "webpack, rspack"
+      expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
+    end
+
+    it "matches strictly, rejecting values that differ only by case or surrounding whitespace" do
+      expect(described_class.apply_bundler_arg("Rspack")).to include "Unknown bundler 'Rspack'"
+      expect(described_class.apply_bundler_arg(" rspack")).to include "Unknown bundler ' rspack'"
       expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
     end
 

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -283,21 +283,21 @@ describe Shakapacker::Install::Env do
   describe "apply_bundler_arg" do
     before { ENV.delete("SHAKAPACKER_ASSETS_BUNDLER") }
 
-    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no warning for webpack" do
+    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no error for webpack" do
       expect(described_class.apply_bundler_arg("webpack")).to be_nil
       expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "webpack"
     end
 
-    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no warning for rspack" do
+    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no error for rspack" do
       expect(described_class.apply_bundler_arg("rspack")).to be_nil
       expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "rspack"
     end
 
-    it "returns a warning and leaves SHAKAPACKER_ASSETS_BUNDLER unset for an unknown bundler" do
-      warning = described_class.apply_bundler_arg("wbpack")
+    it "returns an error and leaves SHAKAPACKER_ASSETS_BUNDLER unset for an unknown bundler" do
+      error = described_class.apply_bundler_arg("wbpack")
 
-      expect(warning).to include "Unknown bundler 'wbpack'"
-      expect(warning).to include "webpack, rspack"
+      expect(error).to include "Unknown bundler 'wbpack'"
+      expect(error).to include "webpack, rspack"
       expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
     end
 

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -218,7 +218,7 @@ describe Shakapacker::Install::Env do
       ).to be false
     end
 
-    it "skips updates for the default webpack bundler even when FORCE=true" do
+    it "skips updates for webpack regardless of FORCE (it is the template's shipped default)" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "webpack",

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -208,62 +208,38 @@ describe Shakapacker::Install::Env do
   end
 
   describe "update_assets_bundler_config?" do
-    it "skips updates for default webpack bundler" do
+    it "skips updates for the default webpack bundler" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "webpack",
-          conflict_option: {},
-          config_preexisting: false
+          config_written: false
         )
       ).to be false
     end
 
-    it "skips updates for default webpack bundler even when FORCE=true" do
+    it "skips updates for the default webpack bundler even when the template was written" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "webpack",
-          conflict_option: { force: true },
-          config_preexisting: true
+          config_written: true
         )
       ).to be false
     end
 
-    it "updates config when bundler is non-default and skip mode is off" do
+    it "updates config when the bundled template was written (fresh install, FORCE, or accepted overwrite)" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "rspack",
-          conflict_option: {},
-          config_preexisting: true
+          config_written: true
         )
       ).to be true
     end
 
-    it "updates config when FORCE=true even if config already exists" do
+    it "preserves a kept user config when the template was not written (SKIP or declined overwrite)" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "rspack",
-          conflict_option: { force: true },
-          config_preexisting: true
-        )
-      ).to be true
-    end
-
-    it "updates config on fresh install even when SKIP=true" do
-      expect(
-        described_class.update_assets_bundler_config?(
-          assets_bundler_to_install: "rspack",
-          conflict_option: { skip: true },
-          config_preexisting: false
-        )
-      ).to be true
-    end
-
-    it "preserves existing user config when SKIP=true" do
-      expect(
-        described_class.update_assets_bundler_config?(
-          assets_bundler_to_install: "rspack",
-          conflict_option: { skip: true },
-          config_preexisting: true
+          config_written: false
         )
       ).to be false
     end

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -8,6 +8,7 @@ describe Shakapacker::Install::Env do
     USE_BABEL_PACKAGES
     SHAKAPACKER_USE_TYPESCRIPT
     SKIP_COMMON_LOADERS
+    SHAKAPACKER_ASSETS_BUNDLER
   ].freeze
   installer_flag_truthy_values = %w[true TRUE 1 yes YES].freeze
   installer_flag_falsey_values = ["false", "0", ""].freeze
@@ -276,6 +277,34 @@ describe Shakapacker::Install::Env do
           config_preexisting: true
         )
       ).to be false
+    end
+  end
+
+  describe "apply_bundler_arg" do
+    before { ENV.delete("SHAKAPACKER_ASSETS_BUNDLER") }
+
+    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no warning for webpack" do
+      expect(described_class.apply_bundler_arg("webpack")).to be_nil
+      expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "webpack"
+    end
+
+    it "sets SHAKAPACKER_ASSETS_BUNDLER and returns no warning for rspack" do
+      expect(described_class.apply_bundler_arg("rspack")).to be_nil
+      expect(ENV["SHAKAPACKER_ASSETS_BUNDLER"]).to eq "rspack"
+    end
+
+    it "returns a warning and leaves SHAKAPACKER_ASSETS_BUNDLER unset for an unknown bundler" do
+      warning = described_class.apply_bundler_arg("wbpack")
+
+      expect(warning).to include "Unknown bundler 'wbpack'"
+      expect(warning).to include "webpack, rspack"
+      expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
+    end
+
+    it "does nothing when no bundler argument is given" do
+      expect(described_class.apply_bundler_arg(nil)).to be_nil
+      expect(described_class.apply_bundler_arg("")).to be_nil
+      expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
     end
   end
 end

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -212,34 +212,68 @@ describe Shakapacker::Install::Env do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "webpack",
-          config_written: false
+          conflict_option: {},
+          config_preexisting: false
         )
       ).to be false
     end
 
-    it "skips updates for the default webpack bundler even when the template was written" do
+    it "skips updates for the default webpack bundler even when FORCE=true" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "webpack",
-          config_written: true
+          conflict_option: { force: true },
+          config_preexisting: true
         )
       ).to be false
     end
 
-    it "updates config when the bundled template was written (fresh install, FORCE, or accepted overwrite)" do
+    it "updates config for a non-default bundler on a fresh install" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "rspack",
-          config_written: true
+          conflict_option: {},
+          config_preexisting: false
         )
       ).to be true
     end
 
-    it "preserves a kept user config when the template was not written (SKIP or declined overwrite)" do
+    it "updates config for a non-default bundler when FORCE=true even if config already exists" do
       expect(
         described_class.update_assets_bundler_config?(
           assets_bundler_to_install: "rspack",
-          config_written: false
+          conflict_option: { force: true },
+          config_preexisting: true
+        )
+      ).to be true
+    end
+
+    it "updates config on fresh install even when SKIP=true" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: { skip: true },
+          config_preexisting: false
+        )
+      ).to be true
+    end
+
+    it "preserves an existing user config when SKIP=true" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: { skip: true },
+          config_preexisting: true
+        )
+      ).to be false
+    end
+
+    it "preserves an existing user config in interactive mode (no FORCE/SKIP)" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: {},
+          config_preexisting: true
         )
       ).to be false
     end

--- a/spec/shakapacker/install_env_spec.rb
+++ b/spec/shakapacker/install_env_spec.rb
@@ -206,4 +206,66 @@ describe Shakapacker::Install::Env do
       ).to be false
     end
   end
+
+  describe "update_assets_bundler_config?" do
+    it "skips updates for default webpack bundler" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "webpack",
+          conflict_option: {},
+          config_preexisting: false
+        )
+      ).to be false
+    end
+
+    it "skips updates for default webpack bundler even when FORCE=true" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "webpack",
+          conflict_option: { force: true },
+          config_preexisting: true
+        )
+      ).to be false
+    end
+
+    it "updates config when bundler is non-default and skip mode is off" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: {},
+          config_preexisting: true
+        )
+      ).to be true
+    end
+
+    it "updates config when FORCE=true even if config already exists" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: { force: true },
+          config_preexisting: true
+        )
+      ).to be true
+    end
+
+    it "updates config on fresh install even when SKIP=true" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: { skip: true },
+          config_preexisting: false
+        )
+      ).to be true
+    end
+
+    it "preserves existing user config when SKIP=true" do
+      expect(
+        described_class.update_assets_bundler_config?(
+          assets_bundler_to_install: "rspack",
+          conflict_option: { skip: true },
+          config_preexisting: true
+        )
+      ).to be false
+    end
+  end
 end

--- a/spec/shakapacker/install_task_spec.rb
+++ b/spec/shakapacker/install_task_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "rake"
+require "shakapacker/configuration"
+
+RSpec.describe "shakapacker:install task" do
+  let(:task_name) { "shakapacker:install" }
+  let(:task_path) { File.expand_path("../../lib/tasks/shakapacker/install.rake", __dir__) }
+
+  around do |example|
+    original_application = Rake.application
+    original_bundle_bin = ENV["BUNDLE_BIN"]
+    original_assets_bundler = ENV["SHAKAPACKER_ASSETS_BUNDLER"]
+
+    Rake.application = Rake::Application.new
+    # install.rake reads Rails.root only when BUNDLE_BIN is unset; set it so the
+    # task file loads without a Rails app present.
+    ENV["BUNDLE_BIN"] = "/nonexistent/bin"
+    # Stub the :check_node prerequisite so the task graph resolves without Node.
+    Rake::Task.define_task("shakapacker:check_node")
+    load task_path
+
+    example.run
+  ensure
+    Rake.application = original_application
+    Shakapacker::Configuration.installing = false
+    ENV["BUNDLE_BIN"] = original_bundle_bin
+    if original_assets_bundler.nil?
+      ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+    else
+      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = original_assets_bundler
+    end
+  end
+
+  def invoke_ignoring_exit(*args)
+    Rake::Task[task_name].invoke(*args)
+  rescue SystemExit
+    nil
+  end
+
+  context "when given an unknown bundler argument" do
+    it "aborts (exits non-zero) before running the install template" do
+      # Capture stderr so abort's message doesn't leak into the suite output;
+      # the message content itself is asserted in the next example.
+      expect do
+        expect { Rake::Task[task_name].invoke("wbpack") }.to raise_error(SystemExit)
+      end.to output.to_stderr
+    end
+
+    it "prints the unknown-bundler error to stderr" do
+      expect { invoke_ignoring_exit("wbpack") }.to output(/Unknown bundler 'wbpack'/).to_stderr
+    end
+
+    it "does not leave SHAKAPACKER_ASSETS_BUNDLER set to the bad value" do
+      ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+      # Capture stderr so abort's message doesn't leak into the suite output.
+      expect { invoke_ignoring_exit("wbpack") }.to output.to_stderr
+      expect(ENV).not_to have_key("SHAKAPACKER_ASSETS_BUNDLER")
+    end
+  end
+end

--- a/spec/shakapacker/install_template_config_spec.rb
+++ b/spec/shakapacker/install_template_config_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+# The installer rewrites these literal values in the bundled config template via
+# gsub_file (see lib/install/template.rb). gsub_file silently no-ops when the
+# literal is absent, so if the shipped template is ever reformatted (quote style,
+# spacing, or default value) the installer would quietly stop honoring the chosen
+# bundler/transpiler. These guards fail fast at CI time if that contract breaks.
+describe "bundled install config template" do
+  let(:config_path) { File.expand_path("../../lib/install/config/shakapacker.yml", __dir__) }
+  let(:contents) { File.read(config_path) }
+
+  it 'ships assets_bundler: "webpack" so the bundler gsub_file matches' do
+    expect(contents).to include('assets_bundler: "webpack"')
+  end
+
+  it 'ships javascript_transpiler: "swc" so the transpiler gsub_file matches' do
+    expect(contents).to include('javascript_transpiler: "swc"')
+  end
+end


### PR DESCRIPTION
### Summary

Makes Rspack the default bundler for new installs (`bundle exec rake shakapacker:install`); webpack stays available via `shakapacker:install[webpack]` or `SHAKAPACKER_ASSETS_BUNDLER=webpack`. This is an install-time default only — existing apps are unaffected on upgrade, because the bundled `shakapacker.yml` still ships `assets_bundler: "webpack"` and the installer never rewrites a pre-existing config in `SKIP` mode. It also bundles `@rspack/dev-server` with the rspack install group (routed to `devDependencies`, mirroring `webpack-dev-server`); without it a fresh rspack install shipped a broken `bin/shakapacker-dev-server`, now verified booting and compiling. Adds unit coverage for `Shakapacker::Install::Env.update_assets_bundler_config?`, updates the generator spec, and documents the new default consistently across README, installation docs, and `shakapacker.yml`. Reconciles `docs/dependency-strategy.md`, which previously called Webpack+SWC the "default happy path" while elsewhere stating the installer defaults to rspack.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

VERSION is intentionally untouched and the CHANGELOG entry sits under `[Unreleased]`, per the project's release flow. The supplemental `shakapacker-rspack` package also omits the dev-server peer dependency — that's the separate v11 package surface and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only install-time scaffolding and docs, not runtime for upgraded apps, but wrong bundler resolution could mis-scaffold new or re-installed projects; coverage is strong via new Env specs and generator tests.
> 
> **Overview**
> **New installs default to Rspack** for `bundle exec rake shakapacker:install`: fresh apps get `assets_bundler: "rspack"`, `config/rspack/`, and rspack npm deps. Webpack remains available via `SHAKAPACKER_ASSETS_BUNDLER=webpack` or `shakapacker:install[webpack]`. The shipped template still contains `assets_bundler: "webpack"` for compatibility; the installer rewrites it on new installs only.
> 
> **Bundler selection is centralized** in `Shakapacker::Install::Env` (`resolve_assets_bundler`, `update_assets_bundler_config?`, `apply_bundler_arg`). Re-installs on apps that already have `config/shakapacker.yml` keep the current bundler unless env/argument or `FORCE` overrides; mismatches between installed deps and preserved YAML now warn or abort instead of failing silently.
> 
> **Rspack installs include `@rspack/dev-server`** in `lib/install/package.json`, installed as a dev dependency (same pattern as `webpack-dev-server` for webpack).
> 
> Docs (`CHANGELOG`, installation, dependency strategy) and specs (generator, `install_env`, install task, template literal guards) are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc82a83ee5537e351b894a139c80cc71ed983d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * New Shakapacker installations now default to Rspack instead of webpack
  * Installer (non-interactive) defaults to Rspack; webpack can be selected via env var or install option
  * Generated scaffolding and package output now target Rspack (config directories and package dependencies/dev-deps)
  * Install task messaging/selection updated to allow explicit bundler choices and warn on invalid values
  * Existing applications remain unaffected on upgrade

* **Documentation**
  * Installation and dependency docs updated to reflect Rspack as the new-install default and how to choose Webpack instead
<!-- end of auto-generated comment: release notes by coderabbit.ai -->