### PR TITLE
Optimize CI: minimal version matrix on PRs, full matrix on main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    # Skip docs-only PRs (matches the path filters used by the test workflows)
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
 
 jobs:
   claude-review:

--- a/.github/workflows/eslint-validation.yml
+++ b/.github/workflows/eslint-validation.yml
@@ -9,6 +9,11 @@ on:
       - "test/**/*.js"
       - ".github/workflows/eslint-validation.yml"
 
+concurrency:
+  # Pushing new changes to a branch will cancel any in-progress CI runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -25,34 +25,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup-matrix:
+    name: Set up generator matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Select matrix (minimal on PRs, full on main / workflow_dispatch)
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Fast PR feedback: only the newest and oldest supported combos.
+            # The full matrix below still runs on `main` pushes and via workflow_dispatch.
+            echo 'matrix={"include":[{"os":"ubuntu-latest","ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"os":"ubuntu-latest","ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.7.0.x"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"os":["ubuntu-latest"],"ruby":["2.7","3.0","3.1","3.2","3.3","3.4"],"gemfile":["gemfiles/Gemfile-rails.7.0.x","gemfiles/Gemfile-rails.7.1.x","gemfiles/Gemfile-rails.7.2.x","gemfiles/Gemfile-rails.8.0.x"],"exclude":[{"ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.7.2.x"},{"ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.0","gemfile":"gemfiles/Gemfile-rails.7.2.x"},{"ruby":"3.0","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.1","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.7.0.x"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Generator specs
+    needs: setup-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        gemfile:
-          - gemfiles/Gemfile-rails.7.0.x
-          - gemfiles/Gemfile-rails.7.1.x
-          - gemfiles/Gemfile-rails.7.2.x
-          - gemfiles/Gemfile-rails.8.0.x
-          # Uncomment the following line only to ensure compatibility with the
-          # upcomming Rails versions, maybe before a release.
-          #- gemfiles/Gemfile-rails-edge
-        exclude:
-          - ruby: "2.7"
-            gemfile: gemfiles/Gemfile-rails.7.2.x
-          - ruby: "2.7"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.0"
-            gemfile: gemfiles/Gemfile-rails.7.2.x
-          - ruby: "3.0"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.1"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.4"
-            gemfile: gemfiles/Gemfile-rails.7.0.x
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -61,48 +61,29 @@ jobs:
       - name: Validate RBS signatures
         run: bundle exec rbs validate
 
+  setup-matrix:
+    name: Set up test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Select matrix (minimal on PRs, full on main / workflow_dispatch)
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Fast PR feedback: only the newest and oldest supported combos.
+            # The full matrix below still runs on `main` pushes and via workflow_dispatch.
+            echo 'matrix={"include":[{"os":"ubuntu-latest","ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"os":"ubuntu-latest","ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.6.0.x"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"os":["ubuntu-latest"],"ruby":["2.7","3.0","3.1","3.2","3.3","3.4"],"gemfile":["gemfiles/Gemfile-rails.6.0.x","gemfiles/Gemfile-rails.6.1.x","gemfiles/Gemfile-rails.7.0.x","gemfiles/Gemfile-rails.7.1.x","gemfiles/Gemfile-rails.7.2.x","gemfiles/Gemfile-rails.8.0.x"],"exclude":[{"ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.7.2.x"},{"ruby":"2.7","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.0","gemfile":"gemfiles/Gemfile-rails.7.2.x"},{"ruby":"3.0","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.1","gemfile":"gemfiles/Gemfile-rails.6.0.x"},{"ruby":"3.1","gemfile":"gemfiles/Gemfile-rails.8.0.x"},{"ruby":"3.2","gemfile":"gemfiles/Gemfile-rails.6.0.x"},{"ruby":"3.3","gemfile":"gemfiles/Gemfile-rails.6.0.x"},{"ruby":"3.3","gemfile":"gemfiles/Gemfile-rails.6.1.x"},{"ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.6.0.x"},{"ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.6.1.x"},{"ruby":"3.4","gemfile":"gemfiles/Gemfile-rails.7.0.x"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Testing
+    needs: setup-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        gemfile:
-          - gemfiles/Gemfile-rails.6.0.x
-          - gemfiles/Gemfile-rails.6.1.x
-          - gemfiles/Gemfile-rails.7.0.x
-          - gemfiles/Gemfile-rails.7.1.x
-          - gemfiles/Gemfile-rails.7.2.x
-          - gemfiles/Gemfile-rails.8.0.x
-          # Uncomment the following line only to ensure compatibility with the
-          # upcomming Rails versions, maybe before a release.
-          #- gemfiles/Gemfile-rails-edge
-        exclude:
-          - ruby: "2.7"
-            gemfile: gemfiles/Gemfile-rails.7.2.x
-          - ruby: "2.7"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.0"
-            gemfile: gemfiles/Gemfile-rails.7.2.x
-          - ruby: "3.0"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.1"
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: "3.1"
-            gemfile: gemfiles/Gemfile-rails.8.0.x
-          - ruby: "3.2"
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: "3.3"
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: "3.3"
-            gemfile: gemfiles/Gemfile-rails.6.1.x
-          - ruby: "3.4"
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: "3.4"
-            gemfile: gemfiles/Gemfile-rails.6.1.x
-          - ruby: "3.4"
-            gemfile: gemfiles/Gemfile-rails.7.0.x
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -15,6 +15,11 @@ on:
     branches: [master, main]
   workflow_dispatch:
 
+concurrency:
+  # Pushing new changes to a branch will cancel any in-progress CI runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-webpack:
     name: Test with Webpack


### PR DESCRIPTION
## What & why

Optimize CI to cut per-PR runner minutes, inspired by [`shakacode/react_on_rails`](https://github.com/shakacode/react_on_rails)'s approach of running a minimal matrix on PRs and the full matrix on `main`. Sized down to fit shakapacker (a single gem): **no new scripts, labels, or slash-command workflows** — that machinery is appropriate for the ROR monorepo but cuts against this repo's "prefer removing complexity over configuration" guideline.

## Changes

**1. Dynamic version matrix (`ruby.yml`, `generator.yml`)**

A tiny `setup-matrix` job now emits the matrix based on the trigger:

| Trigger | Matrix |
|---|---|
| `pull_request` | newest + oldest supported combos only |
| `push` to `main` / `workflow_dispatch` | full matrix (unchanged) |

Per-PR matrix jobs drop from **24 → 2** (`ruby.yml`) and **18 → 2** (`generator.yml`):

- `ruby.yml` PR: `3.4 × Rails 8.0` and `2.7 × Rails 6.0`
- `generator.yml` PR: `3.4 × Rails 8.0` and `2.7 × Rails 7.0`

The full matrix (every Ruby × Rails combo, with the existing exclusions) still runs on every `main` push after merge and on demand via the existing `workflow_dispatch`, so **coverage at merge time is unchanged** — only redundant pre-merge combos are deferred.

**2. Concurrency groups added to `test-bundlers.yml` and `eslint-validation.yml`**

These two were the only workflows missing a `concurrency` block, so superseded PR runs weren't being cancelled. Now matches the other workflows.

**3. `claude-code-review.yml` skips docs-only PRs**

It was the only PR workflow with no path filter; added `paths-ignore` for `**.md` / `docs/**` so the review bot doesn't run on docs-only PRs (the headline "don't run full CI for docs" case).

## Deliberately out of scope

- No port of ROR's `ci-changes-detector` script, `full-ci` label, or `/run-skipped-ci` slash commands.
- Existing `paths:` filters left as-is (they already skip docs for the test workflows).
- Both bundlers (webpack + rspack) still run on every PR — dual-bundler support is core.
- `node.yml` left as-is (only 2 Node versions; not worth the conditional).

## Verification

- `actionlint` passes on all changed workflows with CI's exact `SHELLCHECK_OPTS="-S warning"` (exit 0).
- Matrix JSON validated as parseable; combo counts confirmed (PR 2 / full 24 & 18).
- No Ruby/JS source touched → no CHANGELOG entry (CI infra, not user-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pre-merge CI no longer exercises every Ruby/Rails combination; regressions in skipped combos only surface after merge to main unless workflow_dispatch is used.
> 
> **Overview**
> Speeds up pull-request CI by shrinking Ruby/Rails matrix jobs while keeping full compatibility coverage on `main` and manual runs.
> 
> **`ruby.yml` and `generator.yml`** now use a `setup-matrix` job that writes JSON to `GITHUB_OUTPUT`. On `pull_request`, only two corner-case combos run (newest and oldest Ruby/Rails); on `push` to `main` and `workflow_dispatch`, the previous full matrix and exclusions are unchanged. The `test` job consumes `matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}` instead of an inline strategy matrix—roughly **24→2** and **18→2** jobs per PR respectively.
> 
> **`eslint-validation.yml` and `test-bundlers.yml`** gain the same `concurrency` group + `cancel-in-progress` pattern other workflows already use, so stale runs on the same branch are cancelled when new commits land.
> 
> **`claude-code-review.yml`** adds `paths-ignore` for `**.md` and `docs/**` so the review workflow does not run on documentation-only PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323b708abbe1419ca2990fff1b852af0e981cc2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->