### PR TITLE
Fix README CI badges and add prominent docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,19 @@ _Shakapacker 10 supports [Rspack](https://rspack.rs/) — up to 17x faster than
 webpack per
 [upstream benchmarks](https://shakapacker.com/docs/transpiler-performance/#published-benchmarks)._
 
-Full documentation lives at [shakapacker.com/docs](https://shakapacker.com/docs/).
 The canonical markdown source stays in this repository's [`docs/`](./docs/)
 directory and is published to the docs site.
 
-[![Ruby based checks](https://github.com/shakacode/shakapacker/workflows/Ruby%20based%20checks/badge.svg)](https://github.com/shakacode/shakapacker/actions)
-[![Jest specs](https://github.com/shakacode/shakapacker/workflows/Jest%20specs/badge.svg)](https://github.com/shakacode/shakapacker/actions)
-[![Rubocop](https://github.com/shakacode/shakapacker/workflows/Rubocop/badge.svg)](https://github.com/shakacode/shakapacker/actions)
-[![JS lint](https://github.com/shakacode/shakapacker/workflows/JS%20lint/badge.svg)](https://github.com/shakacode/shakapacker/actions)
+<p align="center">
+  <a href="https://shakapacker.com/docs/">
+    <img src="https://img.shields.io/badge/%F0%9F%93%96%20Read%20the%20Docs-shakapacker.com-cc0000?style=for-the-badge" alt="Read the Shakapacker documentation at shakapacker.com">
+  </a>
+</p>
+
+[![Ruby based checks](https://github.com/shakacode/shakapacker/actions/workflows/ruby.yml/badge.svg)](https://github.com/shakacode/shakapacker/actions/workflows/ruby.yml)
+[![Node based checks](https://github.com/shakacode/shakapacker/actions/workflows/node.yml/badge.svg)](https://github.com/shakacode/shakapacker/actions/workflows/node.yml)
+[![Generator specs](https://github.com/shakacode/shakapacker/actions/workflows/generator.yml/badge.svg)](https://github.com/shakacode/shakapacker/actions/workflows/generator.yml)
+[![Test Both Bundlers](https://github.com/shakacode/shakapacker/actions/workflows/test-bundlers.yml/badge.svg)](https://github.com/shakacode/shakapacker/actions/workflows/test-bundlers.yml)
 
 [![node.js](https://img.shields.io/badge/node-%5E20.19.0%20%7C%7C%20%3E%3D22.12.0-brightgreen.svg)](https://www.npmjs.com/package/shakapacker)
 [![shakapacker gem version](https://img.shields.io/gem/v/shakapacker.svg?label=shakapacker%20gem)](https://rubygems.org/gems/shakapacker)


### PR DESCRIPTION
## Problem

The four CI status badges at the top of the README were rendering blank ("no status"):

> Ruby based checks · Jest specs · Rubocop · JS lint

They used the legacy *workflow-name* badge URLs (`/workflows/<Name>/badge.svg`). Only **Ruby based checks** still matched a real workflow. There are no longer standalone workflows named **Jest specs**, **Rubocop**, or **JS lint** — Jest and ESLint are jobs inside **Node based checks** (`node.yml`), and RuboCop is a job inside **Ruby based checks** (`ruby.yml`). GitHub badges are per-workflow (not per-job), so those three showed "no status".

## Fix

Repoint all four badges to real workflows that run on `main`, using the current file-path badge URL format so each reports live pass/fail status and links to its workflow runs:

| Badge | Workflow | Covers |
| --- | --- | --- |
| Ruby based checks | `ruby.yml` | Ruby specs, RuboCop, RBS |
| Node based checks | `node.yml` | Jest, ESLint (JS lint), Prettier, TypeScript |
| Generator specs | `generator.yml` | Installer/generator specs |
| Test Both Bundlers | `test-bundlers.yml` | webpack + Rspack dummy-app specs |

RuboCop / JS lint / Jest are surfaced through the umbrella workflows that actually own those jobs.

Verified the new badge endpoints return real status (`passing`/`failing`) instead of `no status`.

## Docs link

Added a large, bold **📖 Read the Docs** button near the top linking to [shakapacker.com/docs](https://shakapacker.com/docs/), and removed the now-redundant inline "Full documentation lives at…" sentence in the intro (the dedicated Documentation section below still has it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and badge URL changes only; no runtime, CI workflow, or application code is modified.
> 
> **Overview**
> Updates the README so CI status badges reflect real GitHub Actions workflows and the docs site is easier to find from the top of the page.
> 
> **CI badges** are switched from legacy workflow-name URLs (which left Jest specs, Rubocop, and JS lint showing “no status”) to the current `actions/workflows/<file>.yml/badge.svg` links for **Ruby based checks**, **Node based checks**, **Generator specs**, and **Test Both Bundlers**, each pointing at the matching workflow run page.
> 
> A centered **Read the Docs** shield button links to `shakapacker.com/docs`. The redundant intro sentence that duplicated that link is removed; the **Documentation** section below is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099b961a7a01ac89d3017a1f00fef3593f674851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->