### PR TITLE
[codex] Fix Claude workflow permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
       checks: read
@@ -52,4 +52,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary

- Grant the interactive Claude Code workflow the standard write scopes it needs to comment on issues/PRs and operate on PR branches.
- Keep the CI inspection permissions read-only.

## Root Cause

The failed Claude workflow run attempted to create a comment on issue/PR #1107, but the job token only had `issues: read`, so GitHub rejected the request with `403 Resource not accessible by integration`.

## Validation

- `actionlint .github/workflows/claude.yml`
- `SHELLCHECK_OPTS='-S warning' actionlint`
- `git diff origin/main --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission changes for the Claude bot; no application runtime or production code is affected.
> 
> **Overview**
> Fixes **403 Resource not accessible by integration** when the `@claude` workflow tried to post on issues/PRs with only read scopes.
> 
> The **`claude`** job in `.github/workflows/claude.yml` now grants **`contents: write`**, **`pull-requests: write`**, and **`issues: write`** at the job level (replacing read). **`actions`**, **`checks`**, and **`statuses`** remain **read-only**, including via `additional_permissions` on the Claude Code action step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0dc35d50cfa42e7c49655f96f0d106e36b55568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance CI/CD pipeline permissions and improve automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->