### PR TITLE
Fix order-dependent flake in dev_server custom-env-prefix test

### DIFF
--- a/test/package/dev_server.test.js
+++ b/test/package/dev_server.test.js
@@ -3,8 +3,36 @@ const { chdirTestApp } = require("../helpers")
 const rootPath = process.cwd()
 chdirTestApp()
 
+const envKeys = [
+  "NODE_ENV",
+  "RAILS_ENV",
+  "SHAKAPACKER_DEV_SERVER_HOST",
+  "SHAKAPACKER_DEV_SERVER_PORT",
+  "SHAKAPACKER_DEV_SERVER_DISABLE_HOST_CHECK",
+  "TEST_SHAKAPACKER_DEV_SERVER_HOST",
+  "TEST_SHAKAPACKER_DEV_SERVER_PORT"
+]
+
 describe("DevServer", () => {
-  beforeEach(() => jest.resetModules())
+  let originalEnv
+
+  beforeEach(() => {
+    originalEnv = Object.fromEntries(
+      envKeys.map((key) => [key, process.env[key]])
+    )
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    envKeys.forEach((key) => {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    })
+  })
+
   afterAll(() => process.chdir(rootPath))
 
   test("with NODE_ENV and RAILS_ENV set to development", () => {

--- a/test/package/dev_server.test.js
+++ b/test/package/dev_server.test.js
@@ -1,36 +1,12 @@
-const { chdirTestApp } = require("../helpers")
+const { chdirTestApp, resetEnv } = require("../helpers")
 
 const rootPath = process.cwd()
 chdirTestApp()
 
-const envKeys = [
-  "NODE_ENV",
-  "RAILS_ENV",
-  "SHAKAPACKER_DEV_SERVER_HOST",
-  "SHAKAPACKER_DEV_SERVER_PORT",
-  "SHAKAPACKER_DEV_SERVER_DISABLE_HOST_CHECK",
-  "TEST_SHAKAPACKER_DEV_SERVER_HOST",
-  "TEST_SHAKAPACKER_DEV_SERVER_PORT"
-]
-
 describe("DevServer", () => {
-  let originalEnv
-
   beforeEach(() => {
-    originalEnv = Object.fromEntries(
-      envKeys.map((key) => [key, process.env[key]])
-    )
     jest.resetModules()
-  })
-
-  afterEach(() => {
-    envKeys.forEach((key) => {
-      if (originalEnv[key] === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = originalEnv[key]
-      }
-    })
+    resetEnv()
   })
 
   afterAll(() => process.chdir(rootPath))
@@ -39,8 +15,8 @@ describe("DevServer", () => {
     process.env.NODE_ENV = "development"
     process.env.RAILS_ENV = "development"
     process.env.SHAKAPACKER_DEV_SERVER_HOST = "0.0.0.0"
-    process.env.SHAKAPACKER_DEV_SERVER_PORT = 5000
-    process.env.SHAKAPACKER_DEV_SERVER_DISABLE_HOST_CHECK = false
+    process.env.SHAKAPACKER_DEV_SERVER_PORT = "5000"
+    process.env.SHAKAPACKER_DEV_SERVER_DISABLE_HOST_CHECK = "false"
 
     const devServer = require("../../package/dev_server")
     expect(devServer).toBeDefined()
@@ -50,15 +26,11 @@ describe("DevServer", () => {
   })
 
   test("with custom env prefix", () => {
-    // Set NODE_ENV/RAILS_ENV before requiring config: config resolves
-    // dev_server from shakapacker.yml at load time, and production has no
-    // dev_server section. Without this, a reordered run (e.g. --randomize)
-    // where the production test ran first leaks NODE_ENV=production here and
-    // config.dev_server is undefined.
+    // NODE_ENV must precede require: config reads shakapacker.yml at load time; production has no dev_server.
     process.env.NODE_ENV = "development"
     process.env.RAILS_ENV = "development"
     process.env.TEST_SHAKAPACKER_DEV_SERVER_HOST = "0.0.0.0"
-    process.env.TEST_SHAKAPACKER_DEV_SERVER_PORT = 5000
+    process.env.TEST_SHAKAPACKER_DEV_SERVER_PORT = "5000"
 
     const config = require("../../package/config")
     config.dev_server.env_prefix = "TEST_SHAKAPACKER_DEV_SERVER"

--- a/test/package/dev_server.test.js
+++ b/test/package/dev_server.test.js
@@ -22,13 +22,18 @@ describe("DevServer", () => {
   })
 
   test("with custom env prefix", () => {
-    const config = require("../../package/config")
-    config.dev_server.env_prefix = "TEST_SHAKAPACKER_DEV_SERVER"
-
+    // Set NODE_ENV/RAILS_ENV before requiring config: config resolves
+    // dev_server from shakapacker.yml at load time, and production has no
+    // dev_server section. Without this, a reordered run (e.g. --randomize)
+    // where the production test ran first leaks NODE_ENV=production here and
+    // config.dev_server is undefined.
     process.env.NODE_ENV = "development"
     process.env.RAILS_ENV = "development"
     process.env.TEST_SHAKAPACKER_DEV_SERVER_HOST = "0.0.0.0"
     process.env.TEST_SHAKAPACKER_DEV_SERVER_PORT = 5000
+
+    const config = require("../../package/config")
+    config.dev_server.env_prefix = "TEST_SHAKAPACKER_DEV_SERVER"
 
     const devServer = require("../../package/dev_server")
     expect(devServer).toBeDefined()

--- a/test/package/dev_server.test.js
+++ b/test/package/dev_server.test.js
@@ -9,6 +9,8 @@ describe("DevServer", () => {
     resetEnv()
   })
 
+  afterEach(() => resetEnv())
+
   afterAll(() => process.chdir(rootPath))
 
   test("with NODE_ENV and RAILS_ENV set to development", () => {


### PR DESCRIPTION
## Summary

Fixes an order-dependent (flaky) test in `test/package/dev_server.test.js` that fails intermittently under `jest --randomize`.

## Root cause

The `"with custom env prefix"` test required `package/config` **before** setting `NODE_ENV`/`RAILS_ENV`:

```js
const config = require("../../package/config")   // loads dev_server from shakapacker.yml under whatever env is current
config.dev_server.env_prefix = "TEST_SHAKAPACKER_DEV_SERVER"

process.env.NODE_ENV = "development"              // too late
```

`config` resolves `dev_server` from `shakapacker.yml` at load time, and the `production` section has no `dev_server`. When `jest --randomize` runs the later `"production"` test first, `NODE_ENV=production` leaks into this test, so `config.dev_server` is `undefined` and line 26 throws:

```
TypeError: Cannot set properties of undefined (setting 'env_prefix')
```

This reproduces ~1 in 8 randomized runs of the file in isolation.

## Fix

Set the development env vars **before** requiring `config`, making the test independent of execution order. No production code changes.

## Verification

- `yarn jest test/package/dev_server.test.js --randomize` — 20/20 runs green (previously ~1/8 failed).
- `yarn eslint test/package/dev_server.test.js` — clean.

Surfaced while running the suite under `--randomize` during review of #1107; kept separate to stay focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only reordering and comments; no runtime or config behavior changes.
> 
> **Overview**
> Fixes an order-dependent flake in `test/package/dev_server.test.js` for the **"with custom env prefix"** case.
> 
> The test now sets `NODE_ENV` and `RAILS_ENV` to `development` (and the prefixed dev-server env vars) **before** `require("../../package/config")`, because `config` reads `dev_server` from `shakapacker.yml` at load time and production has no `dev_server` block. Under `jest --randomize`, a prior production test could leave `NODE_ENV=production`, leaving `config.dev_server` undefined and causing `config.dev_server.env_prefix = ...` to throw.
> 
> Comments in the test document that behavior. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4045332c6c0b637e1652ba93ba58504e2a46c2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for development server environment handling.
  * Strengthened test setup and cleanup to prevent environment settings from leaking between runs.
  * Updated the custom environment prefix test to align with how configuration is loaded during module startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->