### PR TITLE
Fix Ruby 3.1 CI: exclude broken i18n 1.15.0/1.15.1 (Fiber[])

### DIFF
--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -10,3 +10,6 @@ gem "rack-proxy", require: false
 gem "rspec-rails", "~> 6.0.0"
 gem "byebug"
 gem "concurrent-ruby", "1.3.4"
+# i18n 1.15.0/1.15.1 call Fiber[] (Ruby 3.2+) unconditionally, crashing on Ruby 3.1.
+# Fixed in 1.15.2; exclude the broken releases to keep Ruby 3.1 CI green.
+gem "i18n", "!= 1.15.0", "!= 1.15.1"

--- a/gemfiles/Gemfile-rails.7.0.x
+++ b/gemfiles/Gemfile-rails.7.0.x
@@ -10,3 +10,6 @@ gem "rack-proxy", require: false
 gem "rspec-rails", "~> 7.0"
 gem "byebug"
 gem "concurrent-ruby", "1.3.4"
+# i18n 1.15.0/1.15.1 call Fiber[] (Ruby 3.2+) unconditionally, crashing on Ruby 3.1.
+# Fixed in 1.15.2; exclude the broken releases to keep Ruby 3.1 CI green.
+gem "i18n", "!= 1.15.0", "!= 1.15.1"

--- a/gemfiles/Gemfile-rails.7.1.x
+++ b/gemfiles/Gemfile-rails.7.1.x
@@ -9,3 +9,6 @@ gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
 gem "rspec-rails", "~> 7.0"
 gem "byebug"
+# i18n 1.15.0/1.15.1 call Fiber[] (Ruby 3.2+) unconditionally, crashing on Ruby 3.1.
+# Fixed in 1.15.2; exclude the broken releases to keep Ruby 3.1 CI green.
+gem "i18n", "!= 1.15.0", "!= 1.15.1"

--- a/gemfiles/Gemfile-rails.7.2.x
+++ b/gemfiles/Gemfile-rails.7.2.x
@@ -9,3 +9,6 @@ gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
 gem "rspec-rails", "~> 7.0"
 gem "byebug"
+# i18n 1.15.0/1.15.1 call Fiber[] (Ruby 3.2+) unconditionally, crashing on Ruby 3.1.
+# Fixed in 1.15.2; exclude the broken releases to keep Ruby 3.1 CI green.
+gem "i18n", "!= 1.15.0", "!= 1.15.1"


### PR DESCRIPTION
## Problem

CI on `main` is red. The first failing job ([run 27797642864 / Testing 3.1, rails 7.2](https://github.com/shakacode/shakapacker/actions/runs/27797642864/job/82260880281)) aborts before any examples run:

```
An error occurred while loading ./spec/shakapacker/version_checker_spec.rb.
Failure/Error: require "action_controller/railtie"

NoMethodError:
  undefined method `[]' for Fiber:Class
        current = Fiber[:i18n_config] || self.config = I18n::Config.new
# i18n-1.15.0/lib/i18n.rb:58:in `config'
0 examples, 0 failures, 23 errors occurred outside of examples
```

## Root cause

This is **not** a shakapacker code change — it's an upstream gem release.

- `i18n` **1.15.0** and **1.15.1** call `Fiber[:i18n_config]` unconditionally in `I18n.config`.
- `Fiber.[]` (fiber storage) was introduced in **Ruby 3.2**, so the call raises `NoMethodError` on Ruby 3.1.
- `i18n` 1.15.0+ requires `Ruby >= 3.1`, so Ruby 2.7/3.0 fall back to `i18n` 1.14.x (unaffected) and Ruby 3.2+ has `Fiber[]` (unaffected). **Only Ruby 3.1 breaks**, taking down the `Testing` matrix legs for rails 6.1 / 7.0 / 7.1 / 7.2.

Upstream fixed this in **i18n 1.15.2** (guarding with `Fiber.respond_to?(:[])` and falling back to thread variables), but the broken 1.15.0/1.15.1 releases remain on RubyGems and can still be resolved.

## Fix

Exclude the two broken releases in the gemfiles that run on Ruby 3.1:

```ruby
gem "i18n", "!= 1.15.0", "!= 1.15.1"
```

This keeps resolution deterministic — bundler lands on 1.15.2 (verified locally) on Ruby 3.1+ and 1.14.x on older Rubies — instead of depending on whichever i18n happens to be newest at CI time.

## Verification

- `BUNDLE_GEMFILE=gemfiles/Gemfile-rails.7.2.x bundle lock --print` now resolves `i18n (1.15.2)`.
- The real proof is the Ruby 3.1 CI legs on this PR going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency constraints in gemfiles; no production code or security-sensitive logic touched.
> 
> **Overview**
> Restores **Ruby 3.1 CI** by pinning Bundler away from upstream **i18n 1.15.0/1.15.1**, which call `Fiber[]` and blow up before specs run on Ruby 3.1.
> 
> The same `gem "i18n", "!= 1.15.0", "!= 1.15.1"` line (with a short comment) is added to `gemfiles/Gemfile-rails.6.1.x`, `7.0.x`, `7.1.x`, and `7.2.x` so resolution prefers **1.15.2** instead of the broken releases. No shakapacker runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511124afd9ee04b62dabf6932e1c87dde577da73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded problematic i18n gem versions that caused crashes on Ruby 3.1 and 3.2+. Updated dependency constraints across all Rails version configurations to ensure stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->