### PR TITLE
Adopt agent-workflow binstubs (.agents/bin/ + AGENTS.md pointer)

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,0 +1,13 @@
+# Non-command agent-workflow configuration for portable shared skills.
+# Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
+base_branch: main
+changelog: "CHANGELOG.md — user-visible changes only"
+follow_up_prefix: "Follow-up:"
+review_gate: "AI reviewers are advisory unless they confirm a blocker; merge gate is the full `gh pr checks` list green (not --required) + all threads resolved + mergeable clean"
+approval_exempt: "at batch closeout, auto-merge ready low-risk PRs that pass the merge gate; keep high-risk (CI/workflow, build-config, dependency or runtime bumps, broad refactors, release) maintainer-gated"
+coordination_backend: "private shakacode/agent-coordination (claims/heartbeats namespaced by full repo name)"
+benchmark_labels: n/a
+merge_ledger: n/a
+ci_parity_environment: "n/a — reproduce CI-only failures from the matching job in .github/workflows/**"
+hosted_ci_trigger: "n/a — CI runs on every PR"
+ci_change_detector: n/a

--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -9,7 +9,7 @@ means that capability is n/a here.
 | --- | --- | --- |
 | `setup` | Install dependencies | `bundle install` + `yarn install` |
 | `validate` | Pre-push gate (run before pushing) | `lint` + `test` |
-| `test` | Run tests | `bundle exec rake test` (rspec) + `yarn test` (jest) |
+| `test` | Run tests | `bundle exec rake test` (rspec) + `yarn test --runInBand` (jest) |
 | `lint` | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint) |
 | `build` | Build / type-check | `yarn build` + `yarn type-check` |
 

--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -1,0 +1,16 @@
+# Agent Workflow Scripts
+
+Standard entry points that portable agent-workflow skills call, so a skill can
+run `.agents/bin/<name>` in any repo without knowing this repo's specific
+commands. Each script is a thin, repo-owned wrapper. A script that is **absent**
+means that capability is n/a here.
+
+| Script | Purpose | This repo runs |
+| --- | --- | --- |
+| `setup` | Install dependencies | `bundle install` + `yarn install` |
+| `validate` | Pre-push gate (run before pushing) | `lint` + `test` |
+| `test` | Run tests | `bundle exec rake test` (rspec) + `yarn test` (jest) |
+| `lint` | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint) |
+| `build` | Build / type-check | `yarn build` + `yarn type-check` |
+
+Non-command policy lives in [`../agent-workflow.yml`](../agent-workflow.yml).

--- a/.agents/bin/build
+++ b/.agents/bin/build
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build the JS package and type-check.
+set -euo pipefail
+yarn build
+yarn type-check

--- a/.agents/bin/build
+++ b/.agents/bin/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Build the JS package and type-check.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 yarn build
 yarn type-check

--- a/.agents/bin/lint
+++ b/.agents/bin/lint
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Lint / format (Ruby + JS). Pass -A to autocorrect RuboCop.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 bundle exec rubocop "$@"
 yarn lint

--- a/.agents/bin/lint
+++ b/.agents/bin/lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Lint / format (Ruby + JS). Pass -A to autocorrect RuboCop.
+set -euo pipefail
+bundle exec rubocop "$@"
+yarn lint

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Install dependencies (Ruby + JS).
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 bundle install
 yarn install

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install dependencies (Ruby + JS).
+set -euo pipefail
+bundle install
+yarn install

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Run the test suite (Ruby specs + JS jest).
+set -euo pipefail
+bundle exec rake test
+yarn test

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Run the test suite (Ruby specs + JS jest).
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 bundle exec rake test
-yarn test
+yarn test --runInBand

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Pre-push gate: lint + test (run before pushing).
 set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-"$here/lint"
-"$here/test"
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+"$root/.agents/bin/lint"
+"$root/.agents/bin/test"

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Pre-push gate: lint + test (run before pushing).
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+"$here/lint"
+"$here/test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Canonical agent instructions for Shakapacker.
+
+> Project guidelines currently also live in `CLAUDE.md`; consolidating them here
+> (and slimming `CLAUDE.md` to `@AGENTS.md`) is a planned follow-up.
+
+## Agent Workflow Configuration
+
+Portable shared skills (from
+[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows))
+resolve this repo's commands and policy through:
+
+- **Commands** — run `.agents/bin/<name>` (`setup`, `validate`, `test`, `lint`,
+  `build`); see [`.agents/bin/README.md`](.agents/bin/README.md). A missing script
+  means that capability is n/a here.
+- **Policy / config** — [`.agents/agent-workflow.yml`](.agents/agent-workflow.yml).


### PR DESCRIPTION
## Summary

Adopts the portable agent-workflow contract from
[shakacode/agent-workflows](https://github.com/shakacode/agent-workflows) using the
"Scripts to Rule Them All" pattern, so portable skills resolve this repo's commands
through a stable, durable interface:

- **`.agents/bin/<name>`** — executable wrappers spanning the Ruby + JS halves
  (`setup`, `validate`, `test`, `lint`, `build`); see `.agents/bin/README.md`.
- **`.agents/agent-workflow.yml`** — non-command policy (base branch, changelog, review
  gate, coordination backend, …).
- **`AGENTS.md`** — new canonical file; the `## Agent Workflow Configuration` section is
  a thin pointer to the above.

The scripts wrap existing commands (`bundle exec rubocop`/`rake test`, `yarn lint`/`test`);
nothing executable changes. `CLAUDE.md` is left untouched — consolidating it into
`AGENTS.md` (and slimming it to `@AGENTS.md`) is a planned follow-up.

## Validation

- `bash -n` on each script; all `chmod +x`; `agent-workflow.yml` parses as YAML.
- `.agents/bin/validate` composes `lint` + `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for the repo’s standard workflow scripts and where to find agent-related instructions.
  * Documented the available setup, validation, testing, linting, and build commands in one place.

* **Chores**
  * Added standardized workflow configuration and executable helper scripts for setup, validation, tests, linting, and builds.
  * Improved consistency in local and CI-related command handling, with stricter failure behavior for these scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->