### PR TITLE
[codex] Fix main CI generator dependency pin

### DIFF
--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -5,12 +5,12 @@ run `.agents/bin/<name>` in any repo without knowing this repo's specific
 commands. Each script is a thin, repo-owned wrapper. A script that is **absent**
 means that capability is n/a here.
 
-| Script | Purpose | This repo runs |
-| --- | --- | --- |
-| `setup` | Install dependencies | `bundle install` + `yarn install` |
-| `validate` | Pre-push gate (run before pushing) | `lint` + `test` |
-| `test` | Run tests | `bundle exec rake test` (rspec) + `yarn test --runInBand` (jest) |
-| `lint` | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint) |
-| `build` | Build / type-check | `yarn build` + `yarn type-check` |
+| Script     | Purpose                                  | This repo runs                                                   |
+| ---------- | ---------------------------------------- | ---------------------------------------------------------------- |
+| `setup`    | Install dependencies                     | `bundle install` + `yarn install`                                |
+| `validate` | Pre-push gate (run before pushing)       | `lint` + `test`                                                  |
+| `test`     | Run tests                                | `bundle exec rake test` (rspec) + `yarn test --runInBand` (jest) |
+| `lint`     | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint)                     |
+| `build`    | Build / type-check                       | `yarn build` + `yarn type-check`                                 |
 
 Non-command policy lives in [`../agent-workflow.yml`](../agent-workflow.yml).

--- a/spec/generator_specs/e2e_template/template.rb
+++ b/spec/generator_specs/e2e_template/template.rb
@@ -5,7 +5,7 @@ require "package_json"
 package_json = PackageJson.new
 
 # install react
-package_json.manager.add(["react", "react-dom", "@babel/preset-react"])
+package_json.manager.add(["react", "react-dom", "@babel/preset-react@^7.0.0"])
 
 # update webpack presets for react
 package_json.merge! do |pj|

--- a/spec/generator_specs/generator_spec.rb
+++ b/spec/generator_specs/generator_spec.rb
@@ -11,6 +11,14 @@ SPEC_PATH = Pathname.new(File.expand_path("../", __FILE__))
 BASE_RAILS_APP_PATH = SPEC_PATH.join("base-rails-app")
 TEMP_RAILS_APP_PATH = SPEC_PATH.join("temp-rails-app")
 
+describe "Generator e2e React template" do
+  it "pins @babel/preset-react to a Node 20-compatible major version" do
+    template = File.read(SPEC_PATH.join("e2e_template/template.rb"))
+
+    expect(template).to include("@babel/preset-react@^7.0.0")
+  end
+end
+
 describe "Generator" do
   before :all do
     # Don't use --skip-git because we want .gitignore file to exist in the project


### PR DESCRIPTION
## Summary
- format the agent workflow README so main's Prettier check passes
- pin the generator e2e React template to @babel/preset-react@^7.0.0
- add a guard spec so the template stays Node 20-compatible

## Root cause
Main CI started resolving unpinned @babel/preset-react to a package path that pulls Babel 8-era helpers requiring newer Node than the generator workflow's Node 20.19.x runtime. The React install then failed, and the generated app later failed to compile because react/react-dom were missing.

## Validation
- yarn prettier --check .
- .agents/bin/lint
- .agents/bin/build
- bundle exec rspec spec/generator_specs/generator_spec.rb:15
- Node 20 CI-style generator repro for the failing npm and yarn_classic examples with SHAKAPACKER_NPM_PACKAGE set
- git diff --check
- autoreview clean