### PR TITLE
Replace helper binstub sync note

### DIFF
--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -3,11 +3,7 @@
 
 require "rbconfig"
 
-# Keep helper logic in sync across:
-# - lib/install/bin/shakapacker-config
-# - lib/install/bin/diff-bundler-config
-# - spec/dummy/bin/shakapacker-config
-# - package/configExporter/cli.ts (createBinStub).
+# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -3,7 +3,7 @@
 
 require "rbconfig"
 
-# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
+# This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -3,11 +3,7 @@
 
 require "rbconfig"
 
-# Keep helper logic in sync across:
-# - lib/install/bin/shakapacker-config
-# - lib/install/bin/diff-bundler-config
-# - spec/dummy/bin/shakapacker-config
-# - package/configExporter/cli.ts (createBinStub).
+# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -3,7 +3,7 @@
 
 require "rbconfig"
 
-# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
+# This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -537,7 +537,7 @@ export function createBinStub(binStubPath: string): void {
 
 require "rbconfig"
 
-# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
+# This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -537,11 +537,7 @@ export function createBinStub(binStubPath: string): void {
 
 require "rbconfig"
 
-# Keep helper logic in sync across:
-# - lib/install/bin/shakapacker-config
-# - lib/install/bin/diff-bundler-config
-# - spec/dummy/bin/shakapacker-config
-# - package/configExporter/cli.ts (createBinStub).
+# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -3,11 +3,7 @@
 
 require "rbconfig"
 
-# Keep helper logic in sync across:
-# - lib/install/bin/shakapacker-config
-# - lib/install/bin/diff-bundler-config
-# - spec/dummy/bin/shakapacker-config
-# - package/configExporter/cli.ts (createBinStub).
+# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -3,7 +3,7 @@
 
 require "rbconfig"
 
-# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command.
+# This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
 def shakapacker_app_root
   candidate = File.expand_path("..", __dir__)
   return candidate if File.exist?(File.join(candidate, "Gemfile"))

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -46,7 +46,7 @@ describe("createBinStub template parity", () => {
 
       expect(generated).toBe(installed)
       expect(generated).toContain(
-        "# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command."
+        "# This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it."
       )
       expect(generated).not.toContain("# Keep helper logic in sync across:")
       expect(generated).not.toContain("package/configExporter/cli.ts")

--- a/test/configExporter/createBinStub.test.js
+++ b/test/configExporter/createBinStub.test.js
@@ -45,6 +45,11 @@ describe("createBinStub template parity", () => {
       )
 
       expect(generated).toBe(installed)
+      expect(generated).toContain(
+        "# This binstub is managed by Shakapacker. Regenerate it by rerunning the install or init command."
+      )
+      expect(generated).not.toContain("# Keep helper logic in sync across:")
+      expect(generated).not.toContain("package/configExporter/cli.ts")
       expect(() => accessSync(generatedPath, constants.X_OK)).not.toThrow()
     }
   )


### PR DESCRIPTION
## Summary
- Replace the maintainer-only sync reminder in distributed/generated helper binstubs with a user-facing regeneration note.
- Keep the generated template and checked-in helper binstubs in parity.
- Add test coverage so generated binstubs do not expose the internal package sync path.

Closes #1149

## Validation
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH yarn test test/configExporter/createBinStub.test.js --runInBand`
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH bundle exec rspec spec/shakapacker/binstub_sync_spec.rb`
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH yarn lint`
- `codex review --base origin/main` clean

## Notes
- `.agents/bin/validate` was attempted; RuboCop completed with no offenses, then the wrapper entered a local `mise node@22.20.0 install`/`npm -v` hang. Targeted Ruby and JS checks above were run with the direct Node/Yarn path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binstub header text to clearly state the files are managed by Shakapacker and should be regenerated through the install/init command.
  * Applied the same wording across generated and checked-in binstub files for consistency.

* **Tests**
  * Expanded coverage to verify the updated notice appears in generated binstubs and the old helper-sync message is no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->