### PR TITLE
Gate React on Rails AI prompt context

### DIFF
--- a/package/configExporter/aiPromptGenerator.ts
+++ b/package/configExporter/aiPromptGenerator.ts
@@ -25,10 +25,15 @@ export class AiPromptGenerator {
   static generatePrompt(
     exportedFiles: string[],
     targetDir: string,
-    bundler: string
+    bundler: string,
+    options: { includeReactOnRailsContext?: boolean } = {}
   ): string {
     const timestamp = new Date().toISOString()
     const configFiles = AiPromptGenerator.buildConfigFilesSection(exportedFiles)
+    const reactOnRailsContext =
+      options.includeReactOnRailsContext === false
+        ? ""
+        : AiPromptGenerator.REACT_ON_RAILS_CONTEXT
 
     // Only the directory name is included in Context: users are encouraged to
     // paste this prompt into external AI assistants, so the absolute path
@@ -48,7 +53,7 @@ Please analyze these configurations and provide recommendations.
 
 ${configFiles}
 
-${AiPromptGenerator.REACT_ON_RAILS_CONTEXT}## Analysis Objectives
+${reactOnRailsContext}## Analysis Objectives
 
 Please analyze the exported configuration files and provide:
 

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1117,7 +1117,7 @@ function reactOnRailsDetectionRoots(appRoot: string): string[] {
 
   while (true) {
     roots.push(current)
-    if (railsRootMarkerExists(current)) {
+    if (railsRootMarkerExists(current) || projectBoundaryExists(current)) {
       break
     }
 
@@ -1130,6 +1130,10 @@ function reactOnRailsDetectionRoots(appRoot: string): string[] {
   }
 
   return roots
+}
+
+function projectBoundaryExists(path: string): boolean {
+  return existsSync(resolve(path, ".git"))
 }
 
 function railsRootMarkerExists(path: string): boolean {

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -935,7 +935,8 @@ async function runDoctorMode(
         const aiPromptFilename = writeAiAnalysisPrompt(
           createdFiles,
           targetDir,
-          detectedBundlers
+          detectedBundlers,
+          appRoot
         )
 
         // Print summary and exit early
@@ -1043,7 +1044,8 @@ async function runDoctorMode(
     const aiPromptFilename = writeAiAnalysisPrompt(
       createdFiles,
       targetDir,
-      detectedBundlers
+      detectedBundlers,
+      appRoot
     )
 
     printDoctorSummary(createdFiles, targetDir, aiPromptFilename)
@@ -1067,7 +1069,8 @@ async function runDoctorMode(
 export function writeAiAnalysisPrompt(
   createdFiles: string[],
   targetDir: string,
-  bundlers: Set<string>
+  bundlers: Set<string>,
+  appRoot: string = process.cwd()
 ): string | null {
   if (createdFiles.length === 0) {
     return null
@@ -1081,7 +1084,8 @@ export function writeAiAnalysisPrompt(
     const aiPromptContent = AiPromptGenerator.generatePrompt(
       fileBasenames,
       targetDir,
-      bundler
+      bundler,
+      { includeReactOnRailsContext: detectReactOnRailsUsage(appRoot) }
     )
     const aiPromptFilename = AiPromptGenerator.PROMPT_FILENAME
     const aiPromptPath = resolve(targetDir, aiPromptFilename)
@@ -1096,6 +1100,67 @@ export function writeAiAnalysisPrompt(
     console.warn("   The exported configuration files are unaffected.")
     return null
   }
+}
+
+function detectReactOnRailsUsage(appRoot: string): boolean {
+  return (
+    packageJsonUsesReactOnRails(appRoot) ||
+    gemfileUsesReactOnRails(appRoot) ||
+    gemfileLockUsesReactOnRails(appRoot)
+  )
+}
+
+function packageJsonUsesReactOnRails(appRoot: string): boolean {
+  const packageJsonPath = resolve(appRoot, "package.json")
+  if (!existsSync(packageJsonPath)) {
+    return false
+  }
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      dependencies?: Record<string, unknown>
+      devDependencies?: Record<string, unknown>
+      optionalDependencies?: Record<string, unknown>
+      peerDependencies?: Record<string, unknown>
+    }
+
+    return [
+      packageJson.dependencies,
+      packageJson.devDependencies,
+      packageJson.optionalDependencies,
+      packageJson.peerDependencies
+    ].some(
+      (dependencies) =>
+        dependencies &&
+        Object.prototype.hasOwnProperty.call(dependencies, "react-on-rails")
+    )
+  } catch {
+    return false
+  }
+}
+
+function gemfileUsesReactOnRails(appRoot: string): boolean {
+  const gemfilePath = resolve(appRoot, "Gemfile")
+  if (!existsSync(gemfilePath)) {
+    return false
+  }
+
+  const gemfile = readFileSync(gemfilePath, "utf8")
+  return gemfile
+    .split(/\r?\n/)
+    .some((line) => /^\s*gem\s+["']react_on_rails["']/.test(line))
+}
+
+function gemfileLockUsesReactOnRails(appRoot: string): boolean {
+  const gemfileLockPath = resolve(appRoot, "Gemfile.lock")
+  if (!existsSync(gemfileLockPath)) {
+    return false
+  }
+
+  const gemfileLock = readFileSync(gemfileLockPath, "utf8")
+  return gemfileLock
+    .split(/\r?\n/)
+    .some((line) => /^\s+react_on_rails \(/.test(line))
 }
 
 function printDoctorSummary(

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -1103,10 +1103,40 @@ export function writeAiAnalysisPrompt(
 }
 
 function detectReactOnRailsUsage(appRoot: string): boolean {
+  return reactOnRailsDetectionRoots(appRoot).some(
+    (root) =>
+      packageJsonUsesReactOnRails(root) ||
+      gemfileUsesReactOnRails(root) ||
+      gemfileLockUsesReactOnRails(root)
+  )
+}
+
+function reactOnRailsDetectionRoots(appRoot: string): string[] {
+  const roots: string[] = []
+  let current = resolve(appRoot)
+
+  while (true) {
+    roots.push(current)
+    if (railsRootMarkerExists(current)) {
+      break
+    }
+
+    const parent = dirname(current)
+    if (parent === current) {
+      break
+    }
+
+    current = parent
+  }
+
+  return roots
+}
+
+function railsRootMarkerExists(path: string): boolean {
   return (
-    packageJsonUsesReactOnRails(appRoot) ||
-    gemfileUsesReactOnRails(appRoot) ||
-    gemfileLockUsesReactOnRails(appRoot)
+    existsSync(resolve(path, "Gemfile")) ||
+    existsSync(resolve(path, "Gemfile.lock")) ||
+    existsSync(resolve(path, "config", "shakapacker.yml"))
   )
 }
 
@@ -1145,10 +1175,14 @@ function gemfileUsesReactOnRails(appRoot: string): boolean {
     return false
   }
 
-  const gemfile = readFileSync(gemfilePath, "utf8")
-  return gemfile
-    .split(/\r?\n/)
-    .some((line) => /^\s*gem\s+["']react_on_rails["']/.test(line))
+  try {
+    const gemfile = readFileSync(gemfilePath, "utf8")
+    return gemfile
+      .split(/\r?\n/)
+      .some((line) => /^\s*gem\s+["']react_on_rails["']/.test(line))
+  } catch {
+    return false
+  }
 }
 
 function gemfileLockUsesReactOnRails(appRoot: string): boolean {
@@ -1157,10 +1191,14 @@ function gemfileLockUsesReactOnRails(appRoot: string): boolean {
     return false
   }
 
-  const gemfileLock = readFileSync(gemfileLockPath, "utf8")
-  return gemfileLock
-    .split(/\r?\n/)
-    .some((line) => /^\s+react_on_rails \(/.test(line))
+  try {
+    const gemfileLock = readFileSync(gemfileLockPath, "utf8")
+    return gemfileLock
+      .split(/\r?\n/)
+      .some((line) => /^\s+react_on_rails \(/.test(line))
+  } catch {
+    return false
+  }
 }
 
 function printDoctorSummary(

--- a/test/package/configExporter/aiPromptGenerator.test.js
+++ b/test/package/configExporter/aiPromptGenerator.test.js
@@ -268,6 +268,20 @@ describe("AiPromptGenerator", () => {
     expect(prompt).not.toContain("spec/dummy")
   })
 
+  test("generatePrompt omits React on Rails context when explicitly disabled", () => {
+    const prompt = AiPromptGenerator.generatePrompt(
+      ["webpack-development-client.yml"],
+      "/path/to/exports",
+      "webpack",
+      { includeReactOnRailsContext: false }
+    )
+
+    expect(prompt).not.toContain("## React on Rails Standard Configuration")
+    expect(prompt).not.toContain(
+      "https://reactonrails.com/docs/core-concepts/webpack-configuration"
+    )
+  })
+
   test("generatePrompt includes analysis objectives", () => {
     const exportedFiles = ["rspack-development-client.yml"]
     const targetDir = "/path/to/exports"

--- a/test/package/configExporter/cli.test.js
+++ b/test/package/configExporter/cli.test.js
@@ -3,7 +3,8 @@ const {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmSync
+  rmSync,
+  writeFileSync
 } = require("fs")
 const { tmpdir } = require("os")
 const { join, resolve } = require("path")
@@ -518,6 +519,95 @@ describe("configExporter/cli", () => {
       const content = readFileSync(promptPath, "utf8")
       expect(content).toContain("`webpack-development-all.yml`")
       expect(content).toContain("**Bundler**: webpack")
+    })
+
+    test("omits React on Rails context when app root has no React on Rails usage", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        tempDir
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).not.toContain("## React on Rails Standard Configuration")
+      expect(content).not.toContain(
+        "https://reactonrails.com/docs/core-concepts/webpack-configuration"
+      )
+    })
+
+    test("includes React on Rails context when package.json uses react-on-rails", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const appRoot = join(tempDir, "app")
+      mkdirSync(appRoot)
+      writeFileSync(
+        join(appRoot, "package.json"),
+        JSON.stringify({ dependencies: { "react-on-rails": "^14.0.0" } })
+      )
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        appRoot
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).toContain("## React on Rails Standard Configuration")
+      expect(content).toContain(
+        "https://reactonrails.com/docs/core-concepts/webpack-configuration"
+      )
+    })
+
+    test("includes React on Rails context when Gemfile uses react_on_rails", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const appRoot = join(tempDir, "app")
+      mkdirSync(appRoot)
+      writeFileSync(join(appRoot, "Gemfile"), "gem 'react_on_rails'\n")
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        appRoot
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).toContain("## React on Rails Standard Configuration")
+    })
+
+    test("includes React on Rails context when Gemfile.lock includes react_on_rails", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const appRoot = join(tempDir, "app")
+      mkdirSync(appRoot)
+      writeFileSync(
+        join(appRoot, "Gemfile.lock"),
+        "GEM\n  specs:\n    react_on_rails (14.0.0)\n"
+      )
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        appRoot
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).toContain("## React on Rails Standard Configuration")
     })
 
     test("lists each config once when createdFiles contains duplicates", () => {

--- a/test/package/configExporter/cli.test.js
+++ b/test/package/configExporter/cli.test.js
@@ -587,6 +587,31 @@ describe("configExporter/cli", () => {
       expect(content).toContain("## React on Rails Standard Configuration")
     })
 
+    test("includes React on Rails context when a nested frontend root has a parent Rails Gemfile", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const railsRoot = join(tempDir, "app")
+      const frontendRoot = join(railsRoot, "client")
+      mkdirSync(frontendRoot, { recursive: true })
+      writeFileSync(join(railsRoot, "Gemfile"), "gem 'react_on_rails'\n")
+      writeFileSync(
+        join(frontendRoot, "package.json"),
+        JSON.stringify({ dependencies: { webpack: "^5.0.0" } })
+      )
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        frontendRoot
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).toContain("## React on Rails Standard Configuration")
+    })
+
     test("includes React on Rails context when Gemfile.lock includes react_on_rails", () => {
       const {
         writeAiAnalysisPrompt
@@ -608,6 +633,27 @@ describe("configExporter/cli", () => {
 
       const content = readFileSync(join(tempDir, filename), "utf8")
       expect(content).toContain("## React on Rails Standard Configuration")
+    })
+
+    test("still writes the prompt when Rails marker files cannot be read", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const appRoot = join(tempDir, "app")
+      mkdirSync(join(appRoot, "Gemfile"), { recursive: true })
+      mkdirSync(join(appRoot, "Gemfile.lock"), { recursive: true })
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        appRoot
+      )
+
+      expect(filename).toBe("AI-ANALYSIS-PROMPT.md")
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).not.toContain("## React on Rails Standard Configuration")
     })
 
     test("lists each config once when createdFiles contains duplicates", () => {

--- a/test/package/configExporter/cli.test.js
+++ b/test/package/configExporter/cli.test.js
@@ -612,6 +612,29 @@ describe("configExporter/cli", () => {
       expect(content).toContain("## React on Rails Standard Configuration")
     })
 
+    test("does not detect React on Rails from an unrelated ancestor above the project boundary", () => {
+      const {
+        writeAiAnalysisPrompt
+      } = require("../../../package/configExporter/cli")
+      const outerRoot = join(tempDir, "outer")
+      const projectRoot = join(outerRoot, "nested-project")
+      const frontendRoot = join(projectRoot, "client")
+      mkdirSync(frontendRoot, { recursive: true })
+      mkdirSync(join(projectRoot, ".git"))
+      writeFileSync(join(outerRoot, "Gemfile"), "gem 'react_on_rails'\n")
+      const createdFiles = [join(tempDir, "webpack-development-all.yml")]
+
+      const filename = writeAiAnalysisPrompt(
+        createdFiles,
+        tempDir,
+        new Set(["webpack"]),
+        frontendRoot
+      )
+
+      const content = readFileSync(join(tempDir, filename), "utf8")
+      expect(content).not.toContain("## React on Rails Standard Configuration")
+    })
+
     test("includes React on Rails context when Gemfile.lock includes react_on_rails", () => {
       const {
         writeAiAnalysisPrompt


### PR DESCRIPTION
## Summary
- Gate the React on Rails section in generated AI analysis prompts on local app detection.
- Detect React on Rails through `package.json`, `Gemfile`, or `Gemfile.lock` without adding a new CLI flag.
- Preserve direct `AiPromptGenerator.generatePrompt(...)` default behavior unless callers explicitly disable the section.

Closes #1162

## Validation
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH yarn test --runInBand --runTestsByPath test/package/configExporter/cli.test.js test/package/configExporter/aiPromptGenerator.test.js`
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH yarn type-check`
- `PATH=/Users/justin/.local/share/mise/installs/node/22.20.0/bin:/Users/justin/.local/share/mise/installs/yarn/1.22.22/bin:$PATH yarn lint`
- `codex review --base origin/main` clean

## Notes
- Full `yarn test --runInBand` was not used as the deciding check because this worktree lacks generated JS build artifacts and unrelated existing suites fail before this slice completes.
- Full `.agents/bin/validate` is affected by the same local bare-node/mise shim hang observed in this batch; targeted checks above were run with the direct Node/Yarn path.