### PR TITLE
docs: add rspack migration workarounds

### DIFF
--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -100,13 +100,13 @@ For major version upgrades, always consult the version-specific upgrade guides f
 
 ## Adopting Supplemental Packages (10.1+)
 
-Shakapacker 10.1 introduces two optional npm packages — `shakapacker-webpack` and `shakapacker-rspack` — that bundle the managed-build stack as direct dependencies. Adopting one of them lets you replace explicit managed-build `devDependencies` (`shakapacker` + bundler + CLI + dev-server + manifest plugin for Rspack, or the webpack equivalents) with a single package that lockstep-pins to the exact versions Shakapacker is tested against.
+Shakapacker 10.1 introduces two optional npm packages — `shakapacker-webpack` and `shakapacker-rspack` — that declare the managed-build stack as required peer dependencies and keep `shakapacker` itself lockstep-pinned. On npm 7+, adopting one of them can replace explicit managed-build `devDependencies` (`shakapacker` + bundler + CLI + dev-server + manifest plugin for Rspack, or the webpack equivalents) with a single package because npm auto-installs required peers. npm <7, Yarn Classic, pnpm, and Yarn PnP users should keep packages imported by app config files as explicit app dependencies.
 
 **This is opt-in.** Apps that don't change anything keep working on 10.1 exactly as they did on 10.0.
 
-**Rspack apps** can replace `shakapacker` + `@rspack/core` + `@rspack/cli` + `@rspack/dev-server` + `rspack-manifest-plugin` with a single `shakapacker-rspack` dev dependency.
+**Rspack apps** on npm 7+ can replace `shakapacker` + `@rspack/core` + `@rspack/cli` + `@rspack/dev-server` + `rspack-manifest-plugin` with a single `shakapacker-rspack` dev dependency. npm <7, Yarn Classic, pnpm, and Yarn PnP apps should list `shakapacker-rspack` plus those direct imports explicitly unless their config imports the supplemental wrapper directly.
 
-**Webpack apps** can replace `shakapacker` + `webpack` + `webpack-cli` + `webpack-assets-manifest` with a single `shakapacker-webpack` dev dependency. One caveat: `shakapacker-webpack` pins `webpack-assets-manifest` to `~6.5.1`, so apps still on `webpack-assets-manifest@5.x` need to upgrade to v6 when adopting it.
+**Webpack apps** on npm 7+ can replace `shakapacker` + `webpack` + `webpack-cli` + `webpack-assets-manifest` with a single `shakapacker-webpack` dev dependency. npm <7, Yarn Classic, pnpm, and Yarn PnP apps should list direct imports explicitly. One caveat: `shakapacker-webpack` pins `webpack-assets-manifest` to `~6.5.1`, so apps still on `webpack-assets-manifest@5.x` need to upgrade to v6 when adopting it.
 
 **Custom-build apps** (apps that ship their own webpack/rspack/Vite setup and only use Shakapacker to read `manifest.json`) should **not** install a supplemental package — continue using bare `shakapacker`.
 
@@ -663,7 +663,7 @@ build and development workflows to confirm the gain on your app — see
 Error: Cannot read properties of undefined (reading 'tap')
 ```
 
-**Solution:** Remove `webpack.optimize.LimitChunkCountPlugin` and use `splitChunks` configuration instead.
+**Solution:** Replace `webpack.optimize.LimitChunkCountPlugin` with `rspack.optimize.LimitChunkCountPlugin` when you need equivalent chunk-limit behavior, or move the intent into `optimization.splitChunks` when the old plugin was only approximating chunk strategy.
 
 #### Issue: CSS not extracting
 

--- a/docs/config-diff.md
+++ b/docs/config-diff.md
@@ -4,6 +4,8 @@ Shakapacker includes a semantic configuration diff workflow for webpack/rspack c
 
 This gives you structured, meaningful diffs instead of raw line-by-line file diffs.
 
+Use this during webpack-to-Rspack migrations whenever you need to confirm that a generated or hand-rolled rspack config preserved the important behavior of the old webpack config. It is especially useful before deleting a custom webpack builder, changing SSR/client split configs, or replacing plugin chains.
+
 ## Why use this instead of `diff`?
 
 Traditional file diff tools are great for source code, but generated bundler configs are noisy and deeply nested.
@@ -26,8 +28,8 @@ bin/shakapacker-config --doctor
 
 # Compare development vs production client config
 bin/diff-bundler-config \
-  --left=shakapacker-config-exports/webpack-development-client.yaml \
-  --right=shakapacker-config-exports/webpack-production-client.yaml
+  --left=shakapacker-config-exports/webpack-development-client.yml \
+  --right=shakapacker-config-exports/webpack-production-client.yml
 ```
 
 ## Common Workflows
@@ -38,8 +40,8 @@ bin/diff-bundler-config \
 bin/shakapacker-config --doctor
 
 bin/diff-bundler-config \
-  --left=shakapacker-config-exports/webpack-development-client.yaml \
-  --right=shakapacker-config-exports/webpack-production-client.yaml \
+  --left=shakapacker-config-exports/webpack-development-client.yml \
+  --right=shakapacker-config-exports/webpack-production-client.yml \
   --format=summary
 ```
 
@@ -49,8 +51,8 @@ bin/diff-bundler-config \
 bin/shakapacker-config --doctor
 
 bin/diff-bundler-config \
-  --left=shakapacker-config-exports/webpack-production-client.yaml \
-  --right=shakapacker-config-exports/webpack-production-server.yaml
+  --left=shakapacker-config-exports/webpack-production-client.yml \
+  --right=shakapacker-config-exports/webpack-production-server.yml
 ```
 
 ### 3. Webpack to Rspack migration validation
@@ -67,10 +69,12 @@ bin/shakapacker-config --doctor
 
 # Compare two snapshots (rename or copy files as needed)
 bin/diff-bundler-config \
-  --left=webpack-production-client.yaml \
-  --right=rspack-production-client.yaml \
+  --left=webpack-production-client.yml \
+  --right=rspack-production-client.yml \
   --ignore-paths="plugins.*"
 ```
+
+Run this comparison for each important build target, such as development client, production client, and SSR/server bundles. Start with `--format=summary`, then rerun without it for detailed paths when the summary shows a behavioral difference you did not expect.
 
 ### 4. Capture machine-readable report for CI or PR artifacts
 

--- a/docs/feature_testing.md
+++ b/docs/feature_testing.md
@@ -6,6 +6,7 @@ This guide shows how to manually verify that Shakapacker features are working co
 
 - [HTTP 103 Early Hints](#http-103-early-hints)
 - [Asset Compilation](#asset-compilation)
+  - [Test Environment Packs](#test-environment-packs)
 - [Code Splitting](#code-splitting)
 - [Subresource Integrity (SRI)](#subresource-integrity-sri)
 - [Source Maps](#source-maps)
@@ -272,6 +273,36 @@ ls -lh public/packs/
 <script src="/packs/application-xyz789.js"></script>
 ```
 
+### Test Environment Packs
+
+Development and test builds can write to different output directories. A typical `test` section in `config/shakapacker.yml` uses `public_output_path: packs-test`, so `bin/shakapacker` in development refreshes `public/packs` while `RAILS_ENV=test bin/shakapacker` refreshes `public/packs-test`.
+
+Before Rails tests that render pack helpers, prerender React components, or depend on React on Rails/RSC manifests, build the test packs explicitly:
+
+```bash
+RAILS_ENV=test bin/shakapacker
+RAILS_ENV=test bin/rails test
+```
+
+If your app uses an external React renderer during tests, start it as your app requires and keep the Rails test command in the test environment:
+
+```bash
+RAILS_ENV=test REACT_RENDERER_URL=http://127.0.0.1:3800 bin/rails test
+```
+
+In CI, run the test-environment Shakapacker build before the Rails test job:
+
+```bash
+bundle install
+yarn install --frozen-lockfile
+RAILS_ENV=test bin/shakapacker
+RAILS_ENV=test bin/rails test
+```
+
+For React on Rails or RSC test suites, the test build may also produce server bundles, client-reference manifests, or RSC manifests outside `public/packs-test`. Those files are still tied to `RAILS_ENV=test`; a development build does not prove the test manifests are fresh.
+
+Repeated "stale test assets detected" messages are expected after source changes or after removing generated test assets. They point to a misconfiguration when every test run rebuilds immediately after a clean `RAILS_ENV=test bin/shakapacker`. In that case, compare the test `public_output_path`, any server/RSC manifest paths, and the environment variables used by the prebuild and test commands.
+
 ## Code Splitting
 
 ### Verify Chunks Are Created
@@ -436,6 +467,7 @@ Use this checklist to verify a complete Shakapacker setup:
 
 - [ ] **Assets compile:** `bundle exec rake assets:precompile` succeeds
 - [ ] **Manifest exists:** `public/packs/manifest.json` contains entrypoints
+- [ ] **Test manifest exists:** `RAILS_ENV=test bin/shakapacker` refreshes `public/packs-test/manifest.json` before Rails tests that need packs
 - [ ] **Assets load:** Page loads without 404s for pack files
 - [ ] **Code splitting works:** Multiple chunks load in Network tab
 - [ ] **Source maps work:** Can debug original source in DevTools

--- a/docs/rspack.md
+++ b/docs/rspack.md
@@ -28,16 +28,20 @@ See the [Rspack v2 breaking changes discussion](https://github.com/web-infra-dev
 
 ### Recommended (Shakapacker 10.1+): `shakapacker-rspack`
 
-`shakapacker-rspack` bundles `shakapacker`, `@rspack/core`, `@rspack/cli`, `@rspack/dev-server`, and `rspack-manifest-plugin` as direct dependencies, so a single install pulls in the full managed Rspack stack:
+`shakapacker-rspack` ships `shakapacker` as a direct dependency and declares `@rspack/core`, `@rspack/cli`, `@rspack/dev-server`, and `rspack-manifest-plugin` as required peer dependencies. npm 7+ auto-installs those peers, so npm users can install the managed Rspack stack with one command:
 
 ```bash
 npm install shakapacker-rspack -D
+```
+
+npm <7, Yarn Classic, pnpm, and Yarn PnP users should keep app-imported packages explicit in `package.json`. The default generated rspack config imports `shakapacker/rspack`, so list the supplemental package, `shakapacker`, and the required peers together:
+
+```bash
+npm install shakapacker-rspack shakapacker @rspack/core @rspack/cli @rspack/dev-server rspack-manifest-plugin -D
 # or
-yarn add shakapacker-rspack -D
+yarn add shakapacker-rspack shakapacker @rspack/core @rspack/cli @rspack/dev-server rspack-manifest-plugin -D
 # or
-pnpm add shakapacker-rspack -D
-# or
-bun add shakapacker-rspack -D
+pnpm add shakapacker-rspack shakapacker @rspack/core @rspack/cli @rspack/dev-server rspack-manifest-plugin -D
 ```
 
 See [`packages/shakapacker-rspack/README.md`](../packages/shakapacker-rspack/README.md) for the full install reference and the [v10.1 supplemental packages migration guide](./migration/v10.1-supplemental-packages.md) for swapping an existing rspack install over to the supplemental package.
@@ -227,6 +231,8 @@ Actual gains depend on project size, configuration, source maps, cache state, an
 4. **Remove CoffeeScript files** (if any) - not supported by Rspack
 
 5. **Test your application** - same commands work automatically
+
+6. **Compare the generated configs** - use [`bin/diff-bundler-config`](./config-diff.md) when you are converting custom webpack configuration or need to prove the rspack config kept the same entrypoints, loaders, output paths, and plugin intent.
 
 ## Troubleshooting
 

--- a/docs/rspack_migration_guide.md
+++ b/docs/rspack_migration_guide.md
@@ -11,6 +11,7 @@
   - [Server-Side Rendering (SSR) Considerations](#server-side-rendering-ssr-considerations)
 - [Key Differences from Webpack](#key-differences-from-webpack)
 - [Migration Steps](#migration-steps)
+- [Migrating Custom Webpack Configs](#migrating-custom-webpack-configs)
 - [Build Verification](#build-verification)
 - [Configuration Best Practices](#configuration-best-practices)
 - [Common Migration Issues](#common-migration-issues)
@@ -121,7 +122,7 @@ Rspack provides built-in loaders for better performance:
 
 The following webpack plugins are NOT compatible with Rspack:
 
-- `webpack.optimize.LimitChunkCountPlugin` - Use `optimization.splitChunks` configuration instead
+- `webpack.optimize.LimitChunkCountPlugin` - Use `rspack.optimize.LimitChunkCountPlugin` when you need equivalent chunk-limit behavior, or `optimization.splitChunks` when the old plugin was only approximating chunk strategy
 - `webpack-manifest-plugin` - Use `rspack-manifest-plugin` instead
 - Git revision plugins - Use alternative approaches
 
@@ -310,6 +311,81 @@ bin/shakapacker --mode production
 - [ ] Update CI/CD pipelines
 - [ ] Deploy to staging
 - [ ] Monitor performance improvements
+
+## Migrating Custom Webpack Configs
+
+Apps with a hand-rolled webpack builder should migrate in two passes: first preserve behavior, then simplify toward Shakapacker's generated structure. Avoid rewriting every customization while also changing bundlers.
+
+### Start from the generated rspack config when possible
+
+Prefer `generateRspackConfig()` as the base config because it wires Shakapacker's expected defaults, output paths, dev-server behavior, and manifest integration:
+
+```javascript
+// config/rspack/rspack.config.js
+const { generateRspackConfig, merge } = require("shakapacker/rspack")
+
+const baseConfig = generateRspackConfig()
+
+module.exports = merge(baseConfig, {
+  resolve: {
+    extensions: [".js", ".jsx", ".ts", ".tsx", ".bs.js"]
+  }
+})
+```
+
+If your webpack setup currently has a `client/webpack/builder.js` plus a series of `set-*.js` modules, map those concerns onto the generated config shape:
+
+- Put shared loaders, aliases, extensions, CSS-module rules, and polyfills in the common config.
+- Put browser-only plugins, dev-server behavior, HMR, and React Refresh in the client config.
+- Put SSR-only output, target, externals, and CSS-extraction filtering in the server config.
+- Express customizations as `merge(baseConfig, customOptions)` or small functions that return a fresh config. Avoid mutating a module-level config object that can leak state between client, server, development, and production builds.
+
+### Preserve real custom behavior explicitly
+
+Custom builders often include app-specific behavior that generated configs cannot infer. Recreate only the pieces the app still needs:
+
+- SCSS-as-CSS-modules rules or custom `css-loader` module options.
+- `sass-resources-loader` or global Sass resource injection.
+- Node polyfills and `resolve.fallback` entries.
+- A non-SWC `babel-loader` rule with a custom `caller`.
+- Extra extensions such as ReScript `.bs.js`.
+- Import shims, such as `imports-loader` rules for legacy packages.
+
+For apps whose JavaScript source lives under a subdirectory such as `client/`, keep the binstub or wrapper that changes into that directory or sets `SHAKAPACKER_CONFIG` before invoking Shakapacker. The important invariant is that the config file, `config/shakapacker.yml`, generated output paths, and deployed runtime paths all agree on the same project root.
+
+### Plugin and manifest migration notes
+
+The plugin replacement tables above cover the common swaps. Fully custom configs should also check these cases:
+
+| Webpack usage                            | Rspack migration note                                                     |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| `webpack.DefinePlugin`                   | Use `rspack.DefinePlugin` from `@rspack/core`                             |
+| `webpack.ProvidePlugin`                  | Use `rspack.ProvidePlugin` from `@rspack/core`                            |
+| `webpack.optimize.LimitChunkCountPlugin` | Use `rspack.optimize.LimitChunkCountPlugin` or `splitChunks`              |
+| `webpack-assets-manifest`                | Prefer Shakapacker's generated rspack config and `rspack-manifest-plugin` |
+
+If you cannot use `generateRspackConfig()`, verify that your custom manifest still has the shape Shakapacker view helpers and React on Rails integrations expect, including top-level file entries and `entrypoints.{name}.assets.js` / `entrypoints.{name}.assets.css`. Shakapacker's internal manifest-generation code is not a documented public helper yet, so prefer the generated config path instead of copying internals into long-lived app code.
+
+### Prove the custom migration with semantic diffs
+
+Before deleting the old webpack builder, export and compare the resolved configs:
+
+```bash
+# Export webpack state before the migration
+bin/shakapacker-config --doctor
+cp -R shakapacker-config-exports shakapacker-config-exports-webpack
+
+# Export rspack state after the migration
+bin/shakapacker-config --doctor
+
+# Compare the important build targets
+bin/diff-bundler-config \
+  --left=shakapacker-config-exports-webpack/webpack-production-client.yml \
+  --right=shakapacker-config-exports/rspack-production-client.yml \
+  --format=summary
+```
+
+Run the same comparison for SSR/server bundles when the app renders server-side. Expected differences include plugin class names and Rspack's built-in loaders; unexpected differences in entrypoints, aliases, output paths, CSS-module options, or split-chunk strategy deserve a closer look before shipping the migration.
 
 ## Build Verification
 
@@ -596,6 +672,61 @@ module.exports = merge({}, baseConfig, commonOptions)
 - [ ] Run full test suite multiple times
 - [ ] Check for error patterns listed in Build Verification
 
+### 5. Native Rspack Binding Missing After Optional Dependencies Were Skipped
+
+**Problem**: Rspack loads a platform-specific native binding from optional dependencies. Install commands that skip optional dependencies can leave `@rspack/core` installed without the native package it needs at runtime.
+
+**Symptoms**:
+
+- Error: `Cannot find module '@rspack/binding-linux-x64-gnu'`
+- Similar missing modules for the current platform, such as `@rspack/binding-darwin-arm64`
+- CI only fails after a cache miss or after clearing `node_modules`
+
+**Solution**: Install the Rspack project without optional-dependency skip flags:
+
+- Yarn Classic: remove `yarn install --ignore-optional`
+- npm: remove `npm install --omit=optional` or the legacy `npm install --no-optional`
+- pnpm: remove `pnpm install --no-optional`
+
+Then clear the stale install cache for that project and reinstall dependencies. If your CI image skips optional dependencies for other JavaScript projects, scope that optimization so the Shakapacker/Rspack app install still includes optional dependencies.
+
+### 6. Testing with Jest or Older CommonJS Resolvers
+
+**Problem**: Under `assets_bundler: rspack`, tests that import Shakapacker config modules may pull Rspack packages into the CommonJS require graph. Older Jest resolvers can fail on package `exports` maps, ESM-only packages, or `node:` built-in specifiers used by Rspack dependencies.
+
+**Symptoms**:
+
+- Error: `Cannot find module '@rspack/core'`
+- Error: `Cannot find module 'node:path'`
+- Unit tests fail while the actual Shakapacker build succeeds
+
+**Solution**: Prefer upgrading Jest to a version whose resolver understands modern package exports and `node:` specifiers. If you must stay on an older Jest version, isolate config tests from the real Rspack packages with mocks:
+
+```javascript
+// jest.config.js
+module.exports = {
+  moduleNameMapper: {
+    "^@rspack/core$": "<rootDir>/__mocks__/@rspack/core.js",
+    "^@rspack/plugin-react-refresh$":
+      "<rootDir>/__mocks__/@rspack/plugin-react-refresh.js",
+    "^rspack-manifest-plugin$": "<rootDir>/__mocks__/rspack-manifest-plugin.js"
+  }
+}
+```
+
+For specs that only need Shakapacker paths or manifest values, mock `shakapacker` itself instead of loading the full bundler config:
+
+```javascript
+jest.mock("shakapacker", () => ({
+  config: {
+    manifestPath: "public/packs-test/manifest.json",
+    publicPathWithoutCDN: "/packs-test/"
+  }
+}))
+```
+
+Keep those mocks limited to tests that inspect app configuration. Build verification should still run the real `bin/shakapacker` command so Rspack integration failures are not hidden.
+
 ### Configuration Differences: webpack vs Rspack Summary
 
 Quick reference for the key differences that cause migration issues:
@@ -775,7 +906,7 @@ npx patch-package @package/name
 
 **Error:** `Cannot read properties of undefined (reading 'tap')`
 
-**Solution:** Remove `webpack.optimize.LimitChunkCountPlugin` and use `splitChunks` configuration instead.
+**Solution:** Replace `webpack.optimize.LimitChunkCountPlugin` with `rspack.optimize.LimitChunkCountPlugin` when you need equivalent chunk-limit behavior, or move the intent into `optimization.splitChunks` when the old plugin was only approximating chunk strategy.
 
 ### Issue: Missing Loaders
 
@@ -835,8 +966,8 @@ bin/shakapacker-config --doctor
 
 # Compare with semantic config diffing
 bin/diff-bundler-config \
-  --left=shakapacker-config-exports/webpack-production-client.yaml \
-  --right=shakapacker-config-exports/rspack-production-client.yaml \
+  --left=shakapacker-config-exports/webpack-production-client.yml \
+  --right=shakapacker-config-exports/rspack-production-client.yml \
   --format=summary
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,20 +54,20 @@ If you're experiencing FOUC where content briefly appears unstyled before CSS lo
    ```bash
    # Save current environment configs with auto-generated names
    bin/shakapacker-config --save
-   # Creates: webpack-development-client.yaml, webpack-development-server.yaml
+   # Creates: webpack-development-client.yml, webpack-development-server.yml
 
    # Save to specific directory
    bin/shakapacker-config --save --save-dir=./debug-configs
 
    # Export only client config for production
    bin/shakapacker-config --save --env=production --client-only
-   # Creates: webpack-production-client.yaml
+   # Creates: webpack-production-client.yml
 
    # Compare development vs production configs
    bin/shakapacker-config --save --save-dir=./configs
    bin/diff-bundler-config \
-     --left=configs/webpack-development-client.yaml \
-     --right=configs/webpack-production-client.yaml \
+     --left=configs/webpack-development-client.yml \
+     --right=configs/webpack-production-client.yml \
      --format=summary
 
    # View config in terminal (no files created)
@@ -81,7 +81,7 @@ If you're experiencing FOUC where content briefly appears unstyled before CSS lo
    ```
 
    **Config files are automatically named:** `{bundler}-{env}-{type}.{ext}`
-   - Examples: `webpack-development-client.yaml`, `rspack-production-server.yaml`
+   - Examples: `webpack-development-client.yml`, `rspack-production-server.yml`
    - YAML format includes inline documentation explaining each config key
    - Separate files for client and server bundles (cleaner than combined)
    - Pair with `bin/diff-bundler-config` for semantic comparisons
@@ -335,6 +335,24 @@ In `package.json`:
   Therefore, make sure webpack
   (i.e `./bin/shakapacker-dev-server`) is running and has
   completed the compilation successfully before loading a view.
+
+## Rspack dev server listens but requests hang
+
+If `bin/shakapacker-dev-server` or `rspack serve` starts and accepts TCP connections, but every request hangs with no response body, inspect the dev-server build output before changing Rails or proxy settings. A common signature is:
+
+- The dev-server port is open, but `curl --max-time 5 http://localhost:3035/packs/manifest.json` times out.
+- Rails pages that load assets from the dev server hang because the asset request never finishes.
+- One-shot builds such as `bin/shakapacker` still succeed.
+- CPU stays low and no obvious compile error reaches the browser.
+
+One cause is a desktop-notification plugin, such as a `webpack-notifier` or `node-notifier` wrapper, throwing from a native helper spawn inside an rspack plugin callback. That can leave the dev middleware waiting forever while the server socket remains open.
+
+To diagnose and work around it:
+
+1. Run the dev server in the foreground and keep the bundler pane visible.
+2. Temporarily disable notifier plugins for dev-server builds. The dev server already provides terminal output and browser overlays.
+3. Re-test a real asset or manifest endpoint with `curl --max-time 5`.
+4. If disabling the notifier fixes the hang, keep it disabled under `WEBPACK_SERVE=true` or guard the notifier so spawn failures are caught and logged instead of escaping the plugin hook.
 
 ## throw er; // Unhandled 'error' event
 


### PR DESCRIPTION
## Summary

Fixes #1164.
Fixes #1166.
Fixes #1169.
Fixes #1174.
Fixes #1173.
Fixes #1165.
Fixes #1156.

Docs-only pass for Shakapacker 10.1 Rspack and React on Rails v17 migration context:

- Clarifies that `shakapacker-rspack` ships `shakapacker` directly while the Rspack stack is required peer dependencies, with package-manager-specific install guidance.
- Adds workarounds for older Jest/CommonJS resolver failures, skipped optional Rspack native bindings, and dev-server hangs caused by notifier/plugin spawn failures.
- Adds custom webpack-to-Rspack migration guidance around `generateRspackConfig`, preserving app-specific behavior, manifest expectations, and `bin/diff-bundler-config`.
- Documents test-environment pack generation for `packs-test` and React on Rails/RSC test suites in the existing feature testing guide.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts` using the pinned local Node/Yarn runtime so docs formatting dependencies were available.
- `yarn prettier --check docs/common-upgrades.md docs/config-diff.md docs/feature_testing.md docs/rspack.md docs/rspack_migration_guide.md docs/troubleshooting.md`
- `git diff --check`
- Local markdown link existence check across modified docs.
- Targeted stale-pattern checks for generated config `.yml` examples and the dev-server manifest probe path.
- `codex review --uncommitted` initially found two doc issues; both were fixed, and the rerun was clean.

Full `.agents/bin/validate` was not run because this batch was docs-only low-risk and the batch QA lane allowed focused docs/link checks.

## Notes

- `docs/feature_testing.md` was the discovered docs-only home for #1156 because it already covers asset compilation, manifests, and test pack behavior.
- This intentionally stays inside the Batch 1 docs lane. Runtime doctor/export-helper changes remain later-batch scope.
