### PR TITLE
Support Babel 8 peer ranges

### DIFF
--- a/docs/customizing_babel_config.md
+++ b/docs/customizing_babel_config.md
@@ -65,8 +65,7 @@ module.exports = function (api) {
       [
         "@babel/preset-react",
         {
-          development: isDevelopmentEnv || isTestEnv,
-          useBuiltIns: true
+          development: isDevelopmentEnv || isTestEnv
         }
       ]
     ].filter(Boolean),
@@ -87,3 +86,27 @@ module.exports = function (api) {
   return resultConfig
 }
 ```
+
+### Babel 8
+
+Shakapacker supports Babel 7 and Babel 8. If you use Babel 8, install matching
+Babel 8 packages for the Shakapacker preset and use `babel-loader` 10 or newer:
+
+```bash
+npm install --save-dev @babel/core@^8 @babel/plugin-transform-runtime@^8 @babel/preset-env@^8 @babel/runtime@^8 babel-loader@^10
+```
+
+Babel 8 requires Node `^22.18.0 || >=24.11.0` while running the build. It also
+removed some Babel 7 configuration options. The Shakapacker preset omits those
+removed options when Babel 8 is running, but app-level custom Babel config should
+also avoid Babel 7-only options such as `useBuiltIns` on `@babel/preset-react`
+or `helpers` on `@babel/plugin-transform-runtime`.
+
+Shakapacker validates the loader/core pairing when `javascript_transpiler:
+"babel"` is active. If your app installs Babel 8, install `babel-loader` 10 or
+newer; older `babel-loader` majors are only supported with Babel 7.
+
+If your app relied on Babel 7 `@babel/preset-env` `useBuiltIns: "entry"`
+polyfill rewriting, move polyfill injection to your app config for Babel 8, for
+example with `babel-plugin-polyfill-corejs3`, or keep explicit `core-js` imports
+that match your browser support policy.

--- a/docs/peer-dependencies.md
+++ b/docs/peer-dependencies.md
@@ -56,10 +56,10 @@ releases support.
 Installed when you explicitly use `javascript_transpiler: "babel"`:
 
 ```text
-"@babel/core": "^7.17.9"
-"@babel/plugin-transform-runtime": "^7.17.0"
-"@babel/preset-env": "^7.16.11"
-"@babel/runtime": "^7.17.9"
+"@babel/core": "^7.17.9 || ^8.0.0"
+"@babel/plugin-transform-runtime": "^7.17.0 || ^8.0.0"
+"@babel/preset-env": "^7.16.11 || ^8.0.0"
+"@babel/runtime": "^7.17.9 || ^8.0.0"
 "babel-loader": "^8.2.4 || ^9.0.0 || ^10.0.0"
 ```
 

--- a/package.json
+++ b/package.json
@@ -102,10 +102,10 @@
     "webpack-subresource-integrity": "5.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.17.9",
-    "@babel/plugin-transform-runtime": "^7.17.0",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/runtime": "^7.17.9",
+    "@babel/core": "^7.17.9 || ^8.0.0",
+    "@babel/plugin-transform-runtime": "^7.17.0 || ^8.0.0",
+    "@babel/preset-env": "^7.16.11 || ^8.0.0",
+    "@babel/runtime": "^7.17.9 || ^8.0.0",
     "@rspack/cli": "^2.0.0",
     "@rspack/core": "^2.0.0",
     "@rspack/dev-server": "^2.0.0",

--- a/package/babel/preset.ts
+++ b/package/babel/preset.ts
@@ -3,6 +3,11 @@ import type { ConfigAPI, PluginItem } from "@babel/core"
 
 const CORE_JS_VERSION_REGEX = /^\d+\.\d+/
 
+const babelMajorVersion = (api: ConfigAPI & { version?: string }): number => {
+  const version = api.version?.match(/^\d+/)
+  return version ? parseInt(version[0], 10) : 7
+}
+
 const coreJsVersion = (): string => {
   try {
     const version = packageFullVersion("core-js").match(CORE_JS_VERSION_REGEX)
@@ -33,23 +38,33 @@ export = function config(api: ConfigAPI): {
     )
   }
 
-  const presets: PluginItem[] = [
-    isTestEnv && ["@babel/preset-env", { targets: { node: "current" } }],
-    (isProductionEnv || isDevelopmentEnv) && [
-      "@babel/preset-env",
-      {
+  const isBabel8 = babelMajorVersion(api) >= 8
+  const presetEnvOptions = isBabel8
+    ? {
+        modules: "auto",
+        exclude: ["transform-typeof-symbol"]
+      }
+    : {
         useBuiltIns: "entry",
         corejs: coreJsVersion(),
         modules: "auto",
         bugfixes: true,
         exclude: ["transform-typeof-symbol"]
       }
+
+  const presets: PluginItem[] = [
+    isTestEnv && ["@babel/preset-env", { targets: { node: "current" } }],
+    (isProductionEnv || isDevelopmentEnv) && [
+      "@babel/preset-env",
+      presetEnvOptions
     ],
     moduleExists("@babel/preset-typescript") && "@babel/preset-typescript"
   ].filter(Boolean) as PluginItem[]
 
   const plugins: PluginItem[] = [
-    ["@babel/plugin-transform-runtime", { helpers: false }]
+    isBabel8
+      ? "@babel/plugin-transform-runtime"
+      : ["@babel/plugin-transform-runtime", { helpers: false }]
   ].filter(Boolean) as PluginItem[]
 
   return {

--- a/package/rules/babel.ts
+++ b/package/rules/babel.ts
@@ -1,19 +1,35 @@
-const { loaderMatches } = require("../utils/helpers")
+const { loaderMatches, packageMajorVersion } = require("../utils/helpers")
 const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const { isProduction } = require("../env")
 const jscommon = require("./jscommon")
 
-export = loaderMatches(javascriptTranspiler, "babel", () => ({
-  test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
-  ...jscommon,
-  use: [
-    {
-      loader: require.resolve("babel-loader"),
-      options: {
-        cacheDirectory: true,
-        cacheCompression: isProduction,
-        compact: isProduction
+const validateBabelLoaderCompatibility = (): void => {
+  if (
+    packageMajorVersion("@babel/core") >= 8 &&
+    packageMajorVersion("babel-loader") < 10
+  ) {
+    throw new Error(
+      "Babel 8 requires babel-loader 10 or newer. " +
+        "Install babel-loader@^10 or use @babel/core@^7."
+    )
+  }
+}
+
+export = loaderMatches(javascriptTranspiler, "babel", () => {
+  validateBabelLoaderCompatibility()
+
+  return {
+    test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
+    ...jscommon,
+    use: [
+      {
+        loader: require.resolve("babel-loader"),
+        options: {
+          cacheDirectory: true,
+          cacheCompression: isProduction,
+          compact: isProduction
+        }
       }
-    }
-  ]
-}))
+    ]
+  }
+})

--- a/packages/shakapacker-webpack/package.json
+++ b/packages/shakapacker-webpack/package.json
@@ -39,7 +39,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0 || ^0.6.0",
     "@swc/core": "^1.3.0",
     "swc-loader": "^0.1.15 || ^0.2.0",
-    "@babel/core": "^7.17.9",
+    "@babel/core": "^7.17.9 || ^8.0.0",
     "babel-loader": "^8.2.4 || ^9.0.0 || ^10.0.0",
     "esbuild": ">=0.14.0 <1.0.0",
     "esbuild-loader": "^2.0.0 || ^3.0.0 || ^4.0.0",

--- a/test/package/rules/babel.test.js
+++ b/test/package/rules/babel.test.js
@@ -16,6 +16,37 @@ jest.mock("../../../package/config", () => {
 })
 
 const babelConfig = require("../../../package/rules/babel")
+const shakapackerBabelPreset = require("../../../package/babel/preset")
+const shakapackerManifest = require("../../../package.json")
+const shakapackerWebpackManifest = require("../../../packages/shakapacker-webpack/package.json")
+
+const createBabelApi = (envName, version) => ({
+  version,
+  env: jest.fn((name) => (name ? name === envName : envName))
+})
+
+const presetEnvOptions = (config) =>
+  config.presets.find(
+    (preset) => Array.isArray(preset) && preset[0] === "@babel/preset-env"
+  )[1]
+
+const loadBabelRuleWithPackageMajors = (packageMajors) => {
+  jest.resetModules()
+  jest.doMock("../../../package/config", () => ({
+    javascript_transpiler: "babel"
+  }))
+  jest.doMock("../../../package/env", () => ({
+    isProduction: false
+  }))
+  jest.doMock("../../../package/rules/jscommon", () => ({}))
+  jest.doMock("../../../package/utils/helpers", () => ({
+    loaderMatches: (_configLoader, _loaderToCheck, ruleFactory) =>
+      ruleFactory(),
+    packageMajorVersion: (packageName) => packageMajors[packageName]
+  }))
+
+  return require("../../../package/rules/babel")
+}
 
 // Skip tests if babel config is not available (not the active transpiler)
 if (!babelConfig) {
@@ -83,3 +114,82 @@ if (!babelConfig) {
     })
   })
 } // end of else block for babelConfig check
+
+describe("babel loader compatibility", () => {
+  afterEach(() => {
+    jest.dontMock("../../../package/config")
+    jest.dontMock("../../../package/env")
+    jest.dontMock("../../../package/rules/jscommon")
+    jest.dontMock("../../../package/utils/helpers")
+    jest.resetModules()
+  })
+
+  test("rejects Babel 8 with babel-loader older than 10", () => {
+    expect(() =>
+      loadBabelRuleWithPackageMajors({
+        "@babel/core": 8,
+        "babel-loader": 9
+      })
+    ).toThrow(/Babel 8 requires babel-loader 10 or newer/)
+  })
+
+  test("allows Babel 8 with babel-loader 10", () => {
+    expect(
+      loadBabelRuleWithPackageMajors({
+        "@babel/core": 8,
+        "babel-loader": 10
+      }).use[0].loader
+    ).toContain("babel-loader")
+  })
+})
+
+describe("babel preset", () => {
+  test("keeps Babel 7 preset-env and transform-runtime options", () => {
+    const config = shakapackerBabelPreset(
+      createBabelApi("production", "7.29.0")
+    )
+
+    expect(presetEnvOptions(config)).toMatchObject({
+      useBuiltIns: "entry",
+      corejs: "3.8",
+      modules: "auto",
+      bugfixes: true,
+      exclude: ["transform-typeof-symbol"]
+    })
+    expect(config.plugins).toContainEqual([
+      "@babel/plugin-transform-runtime",
+      { helpers: false }
+    ])
+  })
+
+  test("omits options Babel 8 removed", () => {
+    const config = shakapackerBabelPreset(createBabelApi("production", "8.0.1"))
+    const options = presetEnvOptions(config)
+
+    expect(options).toMatchObject({
+      modules: "auto",
+      exclude: ["transform-typeof-symbol"]
+    })
+    expect(options).not.toHaveProperty("useBuiltIns")
+    expect(options).not.toHaveProperty("corejs")
+    expect(options).not.toHaveProperty("bugfixes")
+    expect(config.plugins).toContain("@babel/plugin-transform-runtime")
+    expect(config.plugins).not.toContainEqual([
+      "@babel/plugin-transform-runtime",
+      { helpers: false }
+    ])
+  })
+
+  test("allows Babel 8 peers without changing Babel 7 development pins", () => {
+    expect(shakapackerManifest.devDependencies["@babel/core"]).toMatch(/^7\./)
+    expect(shakapackerManifest.peerDependencies).toMatchObject({
+      "@babel/core": "^7.17.9 || ^8.0.0",
+      "@babel/plugin-transform-runtime": "^7.17.0 || ^8.0.0",
+      "@babel/preset-env": "^7.16.11 || ^8.0.0",
+      "@babel/runtime": "^7.17.9 || ^8.0.0"
+    })
+    expect(shakapackerWebpackManifest.peerDependencies["@babel/core"]).toBe(
+      "^7.17.9 || ^8.0.0"
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- allow Babel 8 peer ranges in the main package and webpack supplemental package
- make the Shakapacker Babel preset omit options removed by Babel 8 while preserving Babel 7 behavior
- document Babel 8 install/runtime requirements and align peer-dependency docs
- keep repository development pins on Babel 7 while adding Babel 8 compatibility tests

## Batch disposition
- Refs #1163.
- PR warranted: Babel 8 is available, and `babel-loader` 10 supports Babel 8. The change is scoped to peer ranges, preset option compatibility, and docs/tests; it does not broadly bump the repo's Babel dev dependencies.
- Batch started against `536a5fb`; this branch was rebased onto current `origin/main` `1d7a12a5` before publishing.

## Validation
- `node node_modules/jest/bin/jest.js test/package/rules/babel.test.js --runInBand` - 6 tests passed
- `node node_modules/jest/bin/jest.js test/packages/package-metadata.test.js --runInBand` - 18 tests passed
- `node node_modules/eslint/bin/eslint.js package/babel/preset.ts test/package/rules/babel.test.js`
- `node node_modules/prettier/bin/prettier.cjs --check package/babel/preset.ts package.json packages/shakapacker-webpack/package.json test/package/rules/babel.test.js docs/customizing_babel_config.md docs/peer-dependencies.md`
- `node node_modules/typescript/bin/tsc --noEmit`
- direct build equivalent: `tsc && cp package/index.d.ts.template package/index.d.ts && node scripts/remove-use-strict.js && prettier --write 'package/**/*.js' 'package/**/*.ts'` - completed with generated files unchanged
- `git diff --check origin/main...HEAD`

## QA Lane
- Required because this changes package/runtime compatibility.
- Temporary consumer smoke installed `@babel/core@8.0.1`, `@babel/plugin-transform-runtime@8`, `@babel/preset-env@8`, `@babel/runtime@8`, and used this branch's built Shakapacker preset in a real Babel transform. Result: `babel 8.0.1`, transform completed without removed-option errors.

## References
- https://babeljs.io/docs/v8-migration/
- https://babeljs.io/blog/2026/06/16/8.0.0/
- https://github.com/babel/babel-loader/releases
- https://webpack.js.org/loaders/babel-loader/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Babel 8 support guidance and updated compatibility ranges so projects can use newer Babel releases.
  * Babel configuration now adapts automatically based on the detected Babel major version.

* **Bug Fixes**
  * Improved handling of Babel 8 by removing incompatible preset options and adjusting runtime behavior.
  * Added a clear compatibility check to prevent unsupported Babel and loader combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->