### PR TITLE
[codex] Delegate helper binstub Node resolution to exec

### DIFF
--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "rbconfig"
 require "yaml"
 
 # This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
@@ -14,36 +13,36 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_executable_candidates(executable)
-  extensions = [
-    RbConfig::CONFIG["EXEEXT"],
-    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
-  ].compact.reject(&:empty?)
-  return [executable] if extensions.empty? || File.extname(executable) != ""
-
-  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
-end
-
-def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
-    search_path = path.empty? ? Dir.pwd : path
-
-    shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(search_path, candidate)
-      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
-    end
-  end
-
-  nil
-end
-
 def shakapacker_node_binary
-  node_bin = shakapacker_find_executable("node")
-  return node_bin if node_bin
+  "node"
+end
 
+def shakapacker_warn_missing_node
   warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
+end
+
+def shakapacker_exec_env(launch_dir)
+  return {} unless ENV.key?("PATH")
+
+  normalized_path = ENV["PATH"].split(File::PATH_SEPARATOR, -1).map do |entry|
+    entry.empty? ? launch_dir : File.absolute_path(entry, launch_dir)
+  end.join(File::PATH_SEPARATOR)
+
+  { "PATH" => normalized_path }
+end
+
+def shakapacker_exec_node(script_path, argv, launch_dir)
+  exec_env = shakapacker_exec_env(launch_dir)
+
+  if exec_env.empty?
+    exec shakapacker_node_binary, script_path, *argv
+  else
+    exec exec_env, shakapacker_node_binary, script_path, *argv
+  end
+rescue Errno::ENOENT
+  shakapacker_warn_missing_node
 end
 
 def shakapacker_node_env
@@ -130,9 +129,9 @@ end
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"] ||= shakapacker_node_env
 
+launch_dir = Dir.pwd
 app_root = shakapacker_app_root
 client_root = shakapacker_client_root(app_root)
-node_bin = shakapacker_node_binary
 script_paths = shakapacker_package_script_paths(app_root, client_root, "diff-bundler-config.cjs")
 script_path = script_paths.find { |path| File.file?(path) }
 
@@ -142,5 +141,5 @@ unless script_path
 end
 
 Dir.chdir(app_root) do
-  exec node_bin, script_path, *ARGV
+  shakapacker_exec_node(script_path, ARGV, launch_dir)
 end

--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -41,7 +41,7 @@ def shakapacker_exec_node(script_path, argv, launch_dir)
   else
     exec exec_env, shakapacker_node_binary, script_path, *argv
   end
-rescue Errno::ENOENT
+rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end
 

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "rbconfig"
 require "yaml"
 
 # This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
@@ -14,36 +13,36 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_executable_candidates(executable)
-  extensions = [
-    RbConfig::CONFIG["EXEEXT"],
-    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
-  ].compact.reject(&:empty?)
-  return [executable] if extensions.empty? || File.extname(executable) != ""
-
-  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
-end
-
-def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
-    search_path = path.empty? ? Dir.pwd : path
-
-    shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(search_path, candidate)
-      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
-    end
-  end
-
-  nil
-end
-
 def shakapacker_node_binary
-  node_bin = shakapacker_find_executable("node")
-  return node_bin if node_bin
+  "node"
+end
 
+def shakapacker_warn_missing_node
   warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
+end
+
+def shakapacker_exec_env(launch_dir)
+  return {} unless ENV.key?("PATH")
+
+  normalized_path = ENV["PATH"].split(File::PATH_SEPARATOR, -1).map do |entry|
+    entry.empty? ? launch_dir : File.absolute_path(entry, launch_dir)
+  end.join(File::PATH_SEPARATOR)
+
+  { "PATH" => normalized_path }
+end
+
+def shakapacker_exec_node(script_path, argv, launch_dir)
+  exec_env = shakapacker_exec_env(launch_dir)
+
+  if exec_env.empty?
+    exec shakapacker_node_binary, script_path, *argv
+  else
+    exec exec_env, shakapacker_node_binary, script_path, *argv
+  end
+rescue Errno::ENOENT
+  shakapacker_warn_missing_node
 end
 
 def shakapacker_node_env
@@ -130,9 +129,9 @@ end
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"] ||= shakapacker_node_env
 
+launch_dir = Dir.pwd
 app_root = shakapacker_app_root
 client_root = shakapacker_client_root(app_root)
-node_bin = shakapacker_node_binary
 script_paths = shakapacker_package_script_paths(app_root, client_root, "shakapacker-config.cjs")
 script_path = script_paths.find { |path| File.file?(path) }
 
@@ -142,5 +141,5 @@ unless script_path
 end
 
 Dir.chdir(app_root) do
-  exec node_bin, script_path, *ARGV
+  shakapacker_exec_node(script_path, ARGV, launch_dir)
 end

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -41,7 +41,7 @@ def shakapacker_exec_node(script_path, argv, launch_dir)
   else
     exec exec_env, shakapacker_node_binary, script_path, *argv
   end
-rescue Errno::ENOENT
+rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end
 

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -535,7 +535,6 @@ export function createBinStub(binStubPath: string): void {
   const stubContent = `#!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "rbconfig"
 require "yaml"
 
 # This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
@@ -548,36 +547,36 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_executable_candidates(executable)
-  extensions = [
-    RbConfig::CONFIG["EXEEXT"],
-    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
-  ].compact.reject(&:empty?)
-  return [executable] if extensions.empty? || File.extname(executable) != ""
-
-  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
-end
-
-def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
-    search_path = path.empty? ? Dir.pwd : path
-
-    shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(search_path, candidate)
-      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
-    end
-  end
-
-  nil
-end
-
 def shakapacker_node_binary
-  node_bin = shakapacker_find_executable("node")
-  return node_bin if node_bin
+  "node"
+end
 
+def shakapacker_warn_missing_node
   warn '[Shakapacker] Could not find Node.js executable "node". ' \\
        "Install Node.js and try again."
   exit 1
+end
+
+def shakapacker_exec_env(launch_dir)
+  return {} unless ENV.key?("PATH")
+
+  normalized_path = ENV["PATH"].split(File::PATH_SEPARATOR, -1).map do |entry|
+    entry.empty? ? launch_dir : File.absolute_path(entry, launch_dir)
+  end.join(File::PATH_SEPARATOR)
+
+  { "PATH" => normalized_path }
+end
+
+def shakapacker_exec_node(script_path, argv, launch_dir)
+  exec_env = shakapacker_exec_env(launch_dir)
+
+  if exec_env.empty?
+    exec shakapacker_node_binary, script_path, *argv
+  else
+    exec exec_env, shakapacker_node_binary, script_path, *argv
+  end
+rescue Errno::ENOENT
+  shakapacker_warn_missing_node
 end
 
 def shakapacker_node_env
@@ -664,9 +663,9 @@ end
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"] ||= shakapacker_node_env
 
+launch_dir = Dir.pwd
 app_root = shakapacker_app_root
 client_root = shakapacker_client_root(app_root)
-node_bin = shakapacker_node_binary
 script_paths = shakapacker_package_script_paths(app_root, client_root, "${packageScript}")
 script_path = script_paths.find { |path| File.file?(path) }
 
@@ -676,7 +675,7 @@ unless script_path
 end
 
 Dir.chdir(app_root) do
-  exec node_bin, script_path, *ARGV
+  shakapacker_exec_node(script_path, ARGV, launch_dir)
 end
 `
 

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -575,7 +575,7 @@ def shakapacker_exec_node(script_path, argv, launch_dir)
   else
     exec exec_env, shakapacker_node_binary, script_path, *argv
   end
-rescue Errno::ENOENT
+rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (10.1.0)
+    shakapacker (10.2.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "rbconfig"
 require "yaml"
 
 # This binstub is managed by Shakapacker. Delete it and rerun the install or init command to regenerate it.
@@ -14,36 +13,36 @@ def shakapacker_app_root
   Dir.pwd
 end
 
-def shakapacker_executable_candidates(executable)
-  extensions = [
-    RbConfig::CONFIG["EXEEXT"],
-    *ENV.fetch("PATHEXT", "").split(File::PATH_SEPARATOR)
-  ].compact.reject(&:empty?)
-  return [executable] if extensions.empty? || File.extname(executable) != ""
-
-  ([executable] + extensions.map { |extension| "#{executable}#{extension}" }).uniq
-end
-
-def shakapacker_find_executable(executable)
-  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR, -1).each do |path|
-    search_path = path.empty? ? Dir.pwd : path
-
-    shakapacker_executable_candidates(executable).each do |candidate|
-      executable_path = File.join(search_path, candidate)
-      return executable_path if File.file?(executable_path) && File.executable?(executable_path)
-    end
-  end
-
-  nil
-end
-
 def shakapacker_node_binary
-  node_bin = shakapacker_find_executable("node")
-  return node_bin if node_bin
+  "node"
+end
 
+def shakapacker_warn_missing_node
   warn '[Shakapacker] Could not find Node.js executable "node". ' \
        "Install Node.js and try again."
   exit 1
+end
+
+def shakapacker_exec_env(launch_dir)
+  return {} unless ENV.key?("PATH")
+
+  normalized_path = ENV["PATH"].split(File::PATH_SEPARATOR, -1).map do |entry|
+    entry.empty? ? launch_dir : File.absolute_path(entry, launch_dir)
+  end.join(File::PATH_SEPARATOR)
+
+  { "PATH" => normalized_path }
+end
+
+def shakapacker_exec_node(script_path, argv, launch_dir)
+  exec_env = shakapacker_exec_env(launch_dir)
+
+  if exec_env.empty?
+    exec shakapacker_node_binary, script_path, *argv
+  else
+    exec exec_env, shakapacker_node_binary, script_path, *argv
+  end
+rescue Errno::ENOENT
+  shakapacker_warn_missing_node
 end
 
 def shakapacker_node_env
@@ -130,9 +129,9 @@ end
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"] ||= shakapacker_node_env
 
+launch_dir = Dir.pwd
 app_root = shakapacker_app_root
 client_root = shakapacker_client_root(app_root)
-node_bin = shakapacker_node_binary
 script_paths = shakapacker_package_script_paths(app_root, client_root, "shakapacker-config.cjs")
 script_path = script_paths.find { |path| File.file?(path) }
 
@@ -142,5 +141,5 @@ unless script_path
 end
 
 Dir.chdir(app_root) do
-  exec node_bin, script_path, *ARGV
+  shakapacker_exec_node(script_path, ARGV, launch_dir)
 end

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -41,7 +41,7 @@ def shakapacker_exec_node(script_path, argv, launch_dir)
   else
     exec exec_env, shakapacker_node_binary, script_path, *argv
   end
-rescue Errno::ENOENT
+rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end
 

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -442,6 +442,100 @@ RSpec.describe "helper binstubs" do
       end
     end
 
+    it "delegates unset PATH handling to Ruby's native exec for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        wrapper_path = File.join(app_path, "capture_exec.rb")
+        File.write(wrapper_path, <<~RUBY)
+          require "json"
+
+          module Kernel
+            def exec(*args)
+              File.write(ENV.fetch("SHAKAPACKER_EXEC_ARGS_OUTPUT"), JSON.generate(args))
+              exit 0
+            end
+          end
+
+          binstub_path = ARGV.fetch(0)
+          ARGV.replace([])
+          load binstub_path
+        RUBY
+
+        exec_args_path = File.join(app_path, "exec-args.json")
+        _stdout, stderr, status = Bundler.with_unbundled_env do
+          Open3.capture3(
+            {
+              "BUNDLE_GEMFILE" => nil,
+              "PATH" => nil,
+              "RUBYOPT" => nil,
+              "SHAKAPACKER_EXEC_ARGS_OUTPUT" => exec_args_path
+            },
+            RbConfig.ruby,
+            wrapper_path,
+            binstub_path,
+            chdir: app_path
+          )
+        end
+
+        expect(status).to be_success, stderr
+        expect(JSON.parse(File.read(exec_args_path))).to eq(
+          ["node", File.realpath(File.join(app_path, "node_modules/shakapacker/package/bin/#{command}.cjs"))]
+        )
+      end
+    end
+
+    it "honors a relative PATH entry from the launch directory for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        node_path = real_node_path
+        skip "node not found in PATH" unless node_path
+
+        launch_path = File.join(app_path, "launch")
+        relative_bin_path = File.join(launch_path, "relative-bin")
+        FileUtils.mkdir_p(relative_bin_path)
+        fake_node_path = File.join(relative_bin_path, "node")
+        File.write(fake_node_path, <<~SH)
+          #!/bin/sh
+          exec #{node_path.shellescape} "$@"
+        SH
+        FileUtils.chmod(0o755, fake_node_path)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        output_path = File.join(app_path, "binstub-output.json")
+        _stdout, stderr, status = Bundler.with_unbundled_env do
+          Open3.capture3(
+            {
+              "BUNDLE_GEMFILE" => nil,
+              "PATH" => "relative-bin#{File::PATH_SEPARATOR}/nonexistent",
+              "RUBYOPT" => nil,
+              "SHAKAPACKER_BINSTUB_OUTPUT" => output_path
+            },
+            RbConfig.ruby,
+            binstub_path,
+            chdir: launch_path
+          )
+        end
+
+        expect(status).to be_success, stderr
+        expect(JSON.parse(File.read(output_path))).to include(
+          "cwd" => File.realpath(app_path)
+        )
+      end
+    end
+
     {
       "leading" => "#{File::PATH_SEPARATOR}/nonexistent",
       "trailing" => "/nonexistent#{File::PATH_SEPARATOR}"

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -630,5 +630,43 @@ RSpec.describe "helper binstubs" do
         expect(stderr).to include('[Shakapacker] Could not find Node.js executable "node"')
       end
     end
+
+    it "exits with a contextual error when native exec reports node is not executable for #{command}" do
+      Dir.mktmpdir("shakapacker-binstub-") do |app_path|
+        File.write(File.join(app_path, "Gemfile"), "")
+        FileUtils.mkdir_p(File.join(app_path, "bin"))
+        install_fake_node_script(app_path, command)
+
+        binstub_path = File.join(app_path, "bin", command)
+        FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
+        FileUtils.chmod(0o755, binstub_path)
+
+        wrapper_path = File.join(app_path, "deny_exec.rb")
+        File.write(wrapper_path, <<~RUBY)
+          module Kernel
+            def exec(*)
+              raise Errno::EACCES, "node"
+            end
+          end
+
+          binstub_path = ARGV.fetch(0)
+          ARGV.replace([])
+          load binstub_path
+        RUBY
+
+        _stdout, stderr, status = Bundler.with_unbundled_env do
+          Open3.capture3(
+            { "BUNDLE_GEMFILE" => nil, "RUBYOPT" => nil },
+            RbConfig.ruby,
+            wrapper_path,
+            binstub_path,
+            chdir: app_path
+          )
+        end
+
+        expect(status.exitstatus).to eq(1)
+        expect(stderr).to include('[Shakapacker] Could not find Node.js executable "node"')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Remove the helper binstubs' manual `node` executable scan and delegate resolution to Ruby's native `exec`.
- Keep Shakapacker's friendly missing-Node message by rescuing native exec failures for missing or non-executable `node` (`Errno::ENOENT`, `Errno::EACCES`).
- Preserve prior launch-directory behavior for empty and relative `PATH` entries before the binstub `chdir`s into the app root.
- Add regression coverage for unset `PATH`, relative `PATH` entries, and permission-denied native exec failures.
- Update `spec/dummy/Gemfile.lock` from Shakapacker `10.1.0` to `10.2.0` so CI's frozen Bundler setup accepts the current path gemspec.

## Review notes
The original review comment was directionally right: helper binstubs should not pre-scan for `node`; the user's shell/environment and Ruby `exec` should resolve it. This was not just stylistic, though: the manual scan caused an unset-`PATH` regression because the previous code converted missing `PATH` into an immediate Shakapacker failure instead of letting native exec handle resolution.

Greptile later caught a real follow-up regression: native `exec` can report `Errno::EACCES` for an unusable `node`, which previously leaked as a Ruby exception. The current head handles that path with the same controlled Shakapacker missing-Node message and covers it with a regression spec for both helper commands.

## CI fix
The first push broke the `Test Both Bundlers` workflow at Bundler setup. The failing jobs were not failing inside the new binstub logic; they failed before test execution because `spec/dummy/Gemfile.lock` still listed the local path gem as `shakapacker (10.1.0)` while the repo version is `10.2.0`. The lockfile commit updates only that version line. A broad `bundle lock --update` was intentionally rejected because it changed unrelated dependency versions.

## Validation
- `BUNDLE_FROZEN=true BUNDLE_DEPLOYMENT=true BUNDLE_PATH=/tmp/shakapacker-dummy-bundle bundle install --jobs 4` in `spec/dummy`
- `bundle exec rspec spec/shakapacker/helper_binstubs_spec.rb:634` failed before the `EACCES` fix and passes after it
- `bundle exec rspec spec/shakapacker/helper_binstubs_spec.rb spec/shakapacker/binstub_sync_spec.rb` (40 examples, 0 failures)
- `ruby -c lib/install/bin/shakapacker-config`, `ruby -c lib/install/bin/diff-bundler-config`, `ruby -c spec/dummy/bin/shakapacker-config`
- `yarn test --runInBand test/package/configExporter/cli.test.js` (63 tests passed)
- `/usr/bin/env XDG_CACHE_HOME=/private/tmp bundle exec rubocop --cache false lib/install/bin/shakapacker-config lib/install/bin/diff-bundler-config spec/dummy/bin/shakapacker-config spec/shakapacker/helper_binstubs_spec.rb` (no offenses)
- `yarn type-check`
- `git diff --check`
- `.agents/bin/validate` after the latest fix (full local validation passed: RuboCop, ESLint, Shakapacker RSpec, dummy webpack/rspack specs, generator specs, full Jest)
- `codex review --uncommitted` after the latest fix: no actionable correctness issues
- `$pr-batch` security preflight for PR #1200: `SECURITY_PREFLIGHT_OK`

## Lockfile note
- Changed dependency metadata: local path gem `shakapacker` in `spec/dummy/Gemfile.lock`, `10.1.0 -> 10.2.0`.
- Rationale: keep dummy app's frozen Bundler setup aligned with `lib/shakapacker/version.rb` / `shakapacker.gemspec`.
- Sibling-lock comparison: root `Gemfile.lock` already had `shakapacker (10.2.0)`.
- Platform/build impact: no platform-precompiled or source-build dependency changed; only the local path gem version line changed.