### PR TITLE
Fallback to Babel for implicit SWC webpack configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **Fixed implicit SWC defaults for existing webpack/Babel apps without `swc-loader`.** [PR #1206](https://github.com/shakacode/shakapacker/pull/1206) by [justin808](https://github.com/justin808). Webpack apps that omit both `javascript_transpiler` and the deprecated `webpack_loader` now fall back to Babel with a warning when Shakapacker's bundled SWC default is active, `swc-loader` is missing, and Babel is present. Explicit transpiler settings, webpack apps with `swc-loader`, and Rspack's built-in SWC path keep their existing behavior. Closes [#1203](https://github.com/shakacode/shakapacker/issues/1203).
+- **Fixed JavaScript config loading for missing Rails environments to use the production fallback.** [PR #1206](https://github.com/shakacode/shakapacker/pull/1206) by [justin808](https://github.com/justin808). When `RAILS_ENV` has no matching section in `config/shakapacker.yml`, the Node package config now merges the `production` section instead of only bundled defaults, matching Ruby configuration loading and honoring explicit production `javascript_transpiler`, `source_path`, `dev_server`, and related settings for custom environments such as staging.
 - **Fixed helper binstubs delegating Node resolution to Ruby `exec` in unset and empty `PATH` environments.** [PR #1200](https://github.com/shakacode/shakapacker/pull/1200) and [PR #1201](https://github.com/shakacode/shakapacker/pull/1201) by [justin808](https://github.com/justin808). Restores shell-compatible Node lookup for `bin/shakapacker-config` and `bin/diff-bundler-config` after the `v10.2.0` Ruby-binstub regression, while keeping friendly missing-Node errors for `ENOENT` and `EACCES`.
 
 ## [v10.2.0] - July 3, 2026

--- a/lib/install/config/shakapacker.yml
+++ b/lib/install/config/shakapacker.yml
@@ -59,7 +59,9 @@ default: &default
   cache_manifest: false
 
   # Select JavaScript transpiler to use
-  # Available options: 'swc' (default, 20x faster), 'babel', 'esbuild', or 'none'
+  # Available options: 'swc' (bundled default), 'babel', 'esbuild', or 'none'
+  # Webpack apps that omit this setting use the bundled SWC default when swc-loader is
+  # installed, but fall back to Babel with a warning when only Babel tooling is present.
   # Use 'none' when providing a completely custom webpack configuration
   # Note: When using rspack, swc is used automatically regardless of this setting
   javascript_transpiler: "swc"

--- a/lib/shakapacker/configuration.rb
+++ b/lib/shakapacker/configuration.rb
@@ -50,6 +50,13 @@ class Shakapacker::Configuration
     /\A(?:--config|-c|--node-env|--nodeEnv|--bundler|--build|--init|--list-builds)(?:=.*)?\z/
   private_constant :SHAKAPACKER_MANAGED_COMPILE_FLAG_PATTERN
 
+  IMPLICIT_SWC_BABEL_FALLBACK_WARNING =
+    "`javascript_transpiler` is not set in config/shakapacker.yml. " \
+    "Shakapacker defaults to SWC, but swc-loader is not installed and Babel was detected, so Babel will be used. " \
+    "Set `javascript_transpiler: babel` (or `swc`) explicitly to silence this message. " \
+    "See https://github.com/shakacode/shakapacker/blob/main/docs/transpiler-migration.md"
+  private_constant :IMPLICIT_SWC_BABEL_FALLBACK_WARNING
+
   DISALLOWED_WEBPACK_COMPILE_FLAGS =
     (SHAKAPACKER_NODE_FLAGS + SHAKAPACKER_RUNNER_COMMANDS + SHAKAPACKER_WATCH_FLAGS +
       SHAKAPACKER_MANAGED_COMPILE_FLAGS).freeze
@@ -357,24 +364,54 @@ class Shakapacker::Configuration
   # Resolution order:
   # 1. javascript_transpiler setting in config file
   # 2. webpack_loader setting in config file (deprecated)
-  # 3. Default based on bundler (swc for rspack, babel for webpack)
+  # 3. Bundled defaults
+  # 4. Babel fallback for implicit webpack/SWC defaults when swc-loader is missing
   #
   # Validates that the configured transpiler matches installed packages.
   #
   # @return [String] "babel", "swc", or "esbuild"
   def javascript_transpiler
-    # Show deprecation warning if using old 'webpack_loader' key
-    if data.has_key?(:webpack_loader) && !data.has_key?(:javascript_transpiler)
-      $stderr.puts "⚠️  DEPRECATION WARNING: The 'webpack_loader' configuration option is deprecated. Please use 'javascript_transpiler' instead as it better reflects its purpose of configuring JavaScript transpilation regardless of the bundler used."
-    end
+    return @javascript_transpiler if defined?(@javascript_transpiler)
 
-    # Use explicit config if set, otherwise default based on bundler
-    transpiler = fetch(:javascript_transpiler) || fetch(:webpack_loader) || default_javascript_transpiler
+    @javascript_transpiler =
+      begin
+        javascript_transpiler_configured = config_value_configured?(:javascript_transpiler)
+        webpack_loader_configured = config_value_present?(:webpack_loader)
 
-    # Validate transpiler configuration
-    validate_transpiler_configuration(transpiler) unless self.class.installing
+        # Show deprecation warning if using old 'webpack_loader' key
+        if webpack_loader_configured && !javascript_transpiler_configured
+          $stderr.puts "⚠️  DEPRECATION WARNING: The 'webpack_loader' configuration option is deprecated. Please use 'javascript_transpiler' instead as it better reflects its purpose of configuring JavaScript transpilation regardless of the bundler used."
+        end
 
-    transpiler
+        # Use explicit config if set, otherwise default based on bundler
+        current_javascript_transpiler =
+          if javascript_transpiler_configured
+            fetch(:javascript_transpiler)
+          elsif data.has_key?(:javascript_transpiler)
+            defaults[:javascript_transpiler]
+          else
+            fetch(:javascript_transpiler)
+          end
+
+        transpiler =
+          if webpack_loader_configured && !javascript_transpiler_configured
+            fetch(:webpack_loader) || default_javascript_transpiler
+          else
+            current_javascript_transpiler || fetch(:webpack_loader) || default_javascript_transpiler
+          end
+
+        if !javascript_transpiler_configured &&
+            !webpack_loader_configured &&
+            implicit_swc_to_babel_fallback?(transpiler)
+          $stderr.puts IMPLICIT_SWC_BABEL_FALLBACK_WARNING
+          transpiler = "babel"
+        end
+
+        # Validate transpiler configuration
+        validate_transpiler_configuration(transpiler) unless self.class.installing
+
+        transpiler
+      end
   end
 
   # Deprecated alias for {#javascript_transpiler}
@@ -461,42 +498,124 @@ class Shakapacker::Configuration
       rspack? ? "swc" : "babel"
     end
 
+    def implicit_swc_to_babel_fallback?(transpiler)
+      webpack? &&
+        transpiler == "swc" &&
+        !package_dependency?("swc-loader") &&
+        package_dependency?("babel-loader")
+    end
+
+    def package_dependency?(package_name)
+      declared_package_dependencies.key?(package_name)
+    end
+
+    def config_value_present?(key)
+      return false unless data.has_key?(key)
+
+      value = data[key]
+      value.is_a?(String) && !value.strip.empty?
+    end
+
+    def config_value_configured?(key)
+      return false unless data.has_key?(key)
+
+      value = data[key]
+      return false if value.nil?
+      return false if value.is_a?(String) && value.strip.empty?
+
+      true
+    end
+
+    def declared_package_dependencies
+      return @declared_package_dependencies if defined?(@declared_package_dependencies)
+
+      @declared_package_dependencies =
+        package_json_paths.reverse_each.each_with_object({}) do |path, dependencies|
+          package_json = parse_package_json(path)
+          next unless package_json
+
+          dependencies.merge!(installable_package_dependencies(package_json))
+        end
+    end
+
+    def installable_package_dependencies(package_json)
+      (package_json["optionalDependencies"] || {})
+        .merge(package_json["devDependencies"] || {})
+        .merge(package_json["dependencies"] || {})
+    end
+
+    def package_json_paths
+      @package_json_paths ||= package_root_paths
+        .map { |path| path.join("package.json") }
+        .select(&:exist?)
+    end
+
+    def parse_package_json(path)
+      JSON.parse(File.read(path))
+    rescue JSON::ParserError, SystemCallError
+      nil
+    end
+
+    def package_root_paths
+      @package_root_paths ||= [javascript_package_root_path, root_path].uniq
+    end
+
+    def javascript_package_root_path
+      @javascript_package_root_path ||= begin
+        resolved_source_path = source_path.expand_path
+        app_root = root_path.expand_path
+
+        if path_within?(resolved_source_path, app_root)
+          current = resolved_source_path
+          loop do
+            break current if current.join("package.json").exist?
+            break root_path if current == app_root
+
+            parent = current.dirname
+            break root_path if parent == current
+
+            current = parent
+          end
+        else
+          root_path
+        end
+      rescue StandardError
+        root_path
+      end
+    end
+
+    def path_within?(path, parent)
+      path.to_s == parent.to_s || path.to_s.start_with?("#{parent}#{File::SEPARATOR}")
+    end
+
     def validate_transpiler_configuration(transpiler)
       return unless ENV["NODE_ENV"] != "test" # Skip validation in test environment
 
       # Skip validation if transpiler is set to 'none' (custom webpack config)
       return if transpiler == "none"
 
-      # Check if package.json exists
-      package_json_path = root_path.join("package.json")
-      return unless package_json_path.exist?
+      all_deps = declared_package_dependencies
+      return if all_deps.empty?
 
-      begin
-        package_json = JSON.parse(File.read(package_json_path))
-        all_deps = (package_json["dependencies"] || {}).merge(package_json["devDependencies"] || {})
+      # Check for transpiler mismatch
+      has_babel = all_deps.keys.any? { |pkg| pkg.start_with?("@babel/", "babel-") }
+      has_swc = all_deps.keys.any? { |pkg| pkg.include?("swc") }
+      has_esbuild = all_deps.keys.any? { |pkg| pkg.include?("esbuild") }
 
-        # Check for transpiler mismatch
-        has_babel = all_deps.keys.any? { |pkg| pkg.start_with?("@babel/", "babel-") }
-        has_swc = all_deps.keys.any? { |pkg| pkg.include?("swc") }
-        has_esbuild = all_deps.keys.any? { |pkg| pkg.include?("esbuild") }
-
-        case transpiler
-        when "babel"
-          if !has_babel && has_swc
-            warn_transpiler_mismatch("Babel", "SWC packages found but Babel is configured")
-          end
-        when "swc"
-          if !has_swc && has_babel
-            warn_transpiler_mismatch("SWC", "Babel packages found but SWC is configured")
-          end
-        when "esbuild"
-          if !has_esbuild && (has_babel || has_swc)
-            other = has_babel ? "Babel" : "SWC"
-            warn_transpiler_mismatch("esbuild", "#{other} packages found but esbuild is configured")
-          end
+      case transpiler
+      when "babel"
+        if !has_babel && has_swc
+          warn_transpiler_mismatch("Babel", "SWC packages found but Babel is configured")
         end
-      rescue JSON::ParserError
-        # Ignore if package.json is malformed
+      when "swc"
+        if !has_swc && has_babel
+          warn_transpiler_mismatch("SWC", "Babel packages found but SWC is configured")
+        end
+      when "esbuild"
+        if !has_esbuild && (has_babel || has_swc)
+          other = has_babel ? "Babel" : "SWC"
+          warn_transpiler_mismatch("esbuild", "#{other} packages found but esbuild is configured")
+        end
       end
     end
 

--- a/lib/shakapacker/doctor.rb
+++ b/lib/shakapacker/doctor.rb
@@ -511,12 +511,14 @@ module Shakapacker
 
       def check_javascript_transpiler_dependencies
         transpiler = explicit_javascript_transpiler
+        implicit_babel_fallback = false
 
         if transpiler.nil?
-          @info << "No javascript_transpiler configured - defaulting to SWC (20x faster than Babel)"
-          transpiler = "swc"
+          transpiler = javascript_transpiler
+          implicit_babel_fallback = transpiler == "babel"
         end
 
+        @resolved_javascript_transpiler = transpiler
         return if transpiler == "none"
 
         bundler = assets_bundler
@@ -541,7 +543,7 @@ module Shakapacker
         case transpiler
         when "babel"
           check_babel_dependencies
-          check_babel_performance_suggestion
+          check_babel_performance_suggestion unless implicit_babel_fallback
         when "swc"
           check_swc_dependencies(bundler) unless inferred_hybrid_graph
         when "esbuild"
@@ -571,6 +573,20 @@ module Shakapacker
 
       def check_babel_performance_suggestion
         @info << "Consider switching to SWC for 20x faster compilation. Set javascript_transpiler: 'swc' in shakapacker.yml"
+      end
+
+      def implicit_javascript_transpiler
+        if assets_bundler == "webpack" && !package_installed?("swc-loader") && package_installed?("babel-loader")
+          @info << "`javascript_transpiler` is not set in config/shakapacker.yml. " \
+                   "Shakapacker defaults to SWC, but swc-loader is not installed and Babel was detected, so Babel will be used. " \
+                   "Set `javascript_transpiler: babel` (or `swc`) explicitly to silence this message. " \
+                   "See https://github.com/shakacode/shakapacker/blob/main/docs/transpiler-migration.md"
+          "babel"
+        else
+          @info << "No javascript_transpiler configured - using bundled SWC default. " \
+                   "Set javascript_transpiler: 'swc' or 'babel' explicitly in shakapacker.yml to silence this message."
+          "swc"
+        end
       end
 
       def check_swc_dependencies(bundler)
@@ -1271,13 +1287,20 @@ module Shakapacker
 
       def javascript_transpiler_configured?
         !javascript_transpiler_env_override.nil? ||
-          config_key_defined?(:javascript_transpiler) ||
-          config_key_defined?(:webpack_loader)
+          config_key_configured?(:javascript_transpiler) ||
+          config_key_present?(:webpack_loader)
       end
 
       def javascript_transpiler
-        transpiler = javascript_transpiler_env_override || config.javascript_transpiler
-        blank_config_value?(transpiler) ? default_javascript_transpiler : transpiler
+        return @resolved_javascript_transpiler if defined?(@resolved_javascript_transpiler)
+
+        @resolved_javascript_transpiler =
+          if javascript_transpiler_configured?
+            transpiler = javascript_transpiler_env_override || config.javascript_transpiler
+            blank_config_value?(transpiler) ? default_javascript_transpiler : transpiler
+          else
+            implicit_javascript_transpiler
+          end
       end
 
       def explicit_javascript_transpiler
@@ -1329,7 +1352,7 @@ module Shakapacker
       end
 
       def blank_config_value?(value)
-        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        value.nil? || (value.is_a?(String) && value.strip.empty?) || (value.respond_to?(:empty?) && value.empty?)
       end
 
       def default_javascript_transpiler
@@ -1337,14 +1360,15 @@ module Shakapacker
       end
 
       def config_key_present?(key)
-        !blank_config_value?(config_value(key))
+        value = config_value(key)
+        value.is_a?(String) && !value.strip.empty?
       end
 
-      def config_key_defined?(key)
+      def config_key_configured?(key)
         return false unless config.respond_to?(:data)
 
         data = config.data
-        data.respond_to?(:key?) && data.key?(key)
+        data.respond_to?(:key?) && data.key?(key) && !blank_config_value?(data[key])
       end
 
       def config_value(key)
@@ -1383,7 +1407,7 @@ module Shakapacker
           if path_within?(source_path, app_root)
             current = source_path
             loop do
-              break current if package_root_marker?(current)
+              break current if current.join("package.json").exist?
               break root_path if current == app_root
 
               parent = current.dirname
@@ -1458,7 +1482,7 @@ module Shakapacker
       def detect_package_manager
         root_package_manager = package_manager_for(root_path)
 
-        package_root_paths.each do |package_root|
+        package_manager_root_paths.each do |package_root|
           next if package_root == root_path
 
           package_manager_name = package_manager_for(package_root)
@@ -1476,6 +1500,34 @@ module Shakapacker
         end
 
         nil
+      end
+
+      def package_manager_root_paths
+        @package_manager_root_paths ||= [javascript_package_manager_root_path, root_path].uniq
+      end
+
+      def javascript_package_manager_root_path
+        @javascript_package_manager_root_path ||= begin
+          source_path = config.source_path.expand_path
+          app_root = root_path.expand_path
+
+          if path_within?(source_path, app_root)
+            current = source_path
+            loop do
+              break current if package_root_marker?(current)
+              break root_path if current == app_root
+
+              parent = current.dirname
+              break root_path if parent == current
+
+              current = parent
+            end
+          else
+            root_path
+          end
+        rescue StandardError
+          root_path
+        end
       end
 
       def versions_compatible?(gem_version, npm_version)

--- a/package/config.ts
+++ b/package/config.ts
@@ -1,11 +1,22 @@
-import { resolve } from "path"
+import { dirname, resolve, sep } from "path"
 import { load } from "js-yaml"
 import { existsSync, readFileSync } from "fs"
 import { merge } from "webpack-merge"
-const { ensureTrailingSlash } = require("./utils/helpers")
+const { ensureTrailingSlash, packageDependencyExists } =
+  require("./utils/helpers") as {
+    ensureTrailingSlash: (path: string) => string
+    packageDependencyExists: (
+      packageName: string,
+      packageRootPaths: string[]
+    ) => boolean
+  }
 const { railsEnv } = require("./env")
 const configPath = require("./utils/configPath")
 const defaultConfigPath = require("./utils/defaultConfigPath")
+const { sanitizeEnvValue } = require("./utils/pathValidation") as {
+  sanitizeEnvValue: (value: string | undefined) => string | undefined
+}
+const requestedRailsEnv = sanitizeEnvValue(process.env.RAILS_ENV) || railsEnv
 import { Config, YamlConfig } from "./types"
 const {
   isValidYamlConfig,
@@ -22,7 +33,11 @@ const loadAndValidateYaml = (path: string): YamlConfig => {
   const yamlContent = load(fileContent)
 
   if (!isValidYamlConfig(yamlContent)) {
-    throw createConfigValidationError(path, railsEnv, "Invalid YAML structure")
+    throw createConfigValidationError(
+      path,
+      requestedRailsEnv,
+      "Invalid YAML structure"
+    )
   }
 
   return yamlContent as YamlConfig
@@ -31,7 +46,7 @@ const loadAndValidateYaml = (path: string): YamlConfig => {
 const getDefaultConfig = (): Partial<Config> => {
   try {
     const defaultConfig = loadAndValidateYaml(defaultConfigPath)
-    return defaultConfig[railsEnv] || defaultConfig.production || {}
+    return defaultConfig[requestedRailsEnv] || defaultConfig.production || {}
   } catch (error) {
     if (isFileNotFoundError(error)) {
       throw createFileOperationError(
@@ -46,20 +61,86 @@ const getDefaultConfig = (): Partial<Config> => {
 
 const defaults = getDefaultConfig()
 let config: Config
+let appConfigHasJavascriptTranspiler = false
+let appConfigHasWebpackLoader = false
+let appConfigWebpackLoader: string | undefined
+let cachedPackageRootPaths: string[] | undefined
+
+const pathWithin = (path: string, parent: string): boolean =>
+  path === parent || path.startsWith(`${parent}${sep}`)
+
+const javascriptPackageRootPath = (): string => {
+  const sourcePath = resolve(config.source_path)
+  const appRoot = resolve(process.cwd())
+
+  if (!pathWithin(sourcePath, appRoot)) {
+    return appRoot
+  }
+
+  let current = sourcePath
+  while (true) {
+    if (existsSync(resolve(current, "package.json"))) {
+      return current
+    }
+    if (current === appRoot) {
+      return appRoot
+    }
+
+    const parent = dirname(current)
+    if (parent === current) {
+      return appRoot
+    }
+
+    current = parent
+  }
+}
+
+const packageRootPaths = (): string[] => {
+  cachedPackageRootPaths ||= [
+    ...new Set([javascriptPackageRootPath(), resolve(process.cwd())])
+  ]
+  return cachedPackageRootPaths
+}
+
+const packageDependencyInstalled = (packageName: string): boolean =>
+  packageDependencyExists(packageName, packageRootPaths())
+
+const presentString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const configuredValue = (value: unknown): boolean =>
+  value !== null &&
+  value !== undefined &&
+  !(typeof value === "string" && value.trim().length === 0)
 
 if (existsSync(configPath)) {
   try {
     const appYmlObject = loadAndValidateYaml(configPath)
 
-    const envAppConfig = appYmlObject[railsEnv]
+    const requestedEnvAppConfig = appYmlObject[requestedRailsEnv]
+    const envAppConfig = requestedEnvAppConfig || appYmlObject.production
+    if (envAppConfig) {
+      const envAppConfigRecord = envAppConfig as Record<string, unknown>
+      const javascriptTranspiler = envAppConfigRecord.javascript_transpiler
+      appConfigHasJavascriptTranspiler =
+        Object.prototype.hasOwnProperty.call(
+          envAppConfigRecord,
+          "javascript_transpiler"
+        ) && configuredValue(javascriptTranspiler)
+      const webpackLoader = envAppConfigRecord.webpack_loader
+      if (presentString(webpackLoader)) {
+        appConfigHasWebpackLoader = true
+        appConfigWebpackLoader = webpackLoader
+      }
+    }
 
-    if (!envAppConfig) {
+    if (!requestedEnvAppConfig) {
       console.warn(
-        `[SHAKAPACKER WARNING] Environment '${railsEnv}' not found in ${configPath}\n` +
+        `[SHAKAPACKER WARNING] Environment '${requestedRailsEnv}' not found in ${configPath}\n` +
           `Available environments: ${Object.keys(appYmlObject).join(", ")}\n` +
           `Using 'production' configuration as fallback.\n\n` +
           `To fix this, either:\n` +
-          `  - Add a '${railsEnv}' section to your shakapacker.yml\n` +
+          `  - Add a '${requestedRailsEnv}' section to your shakapacker.yml\n` +
           `  - Set RAILS_ENV to one of the available environments\n` +
           `  - Copy settings from another environment as a starting point`
       )
@@ -72,7 +153,7 @@ if (existsSync(configPath)) {
     if (!isPartialConfig(mergedConfig)) {
       throw createConfigValidationError(
         configPath,
-        railsEnv,
+        requestedRailsEnv,
         `Invalid configuration structure in ${configPath}. Please check your shakapacker.yml syntax and ensure all required fields are properly defined.`
       )
     }
@@ -86,7 +167,7 @@ if (existsSync(configPath)) {
       if (!isPartialConfig(defaults)) {
         throw createConfigValidationError(
           defaultConfigPath,
-          railsEnv,
+          requestedRailsEnv,
           `Invalid default configuration. This may indicate a corrupted Shakapacker installation. Try reinstalling with 'yarn add shakapacker --force'.`
         )
       }
@@ -101,7 +182,7 @@ if (existsSync(configPath)) {
   if (!isPartialConfig(defaults)) {
     throw createConfigValidationError(
       defaultConfigPath,
-      railsEnv,
+      requestedRailsEnv,
       `Invalid default configuration. This may indicate a corrupted Shakapacker installation. Try reinstalling with 'yarn add shakapacker --force'.`
     )
   }
@@ -153,29 +234,49 @@ if (process.env.SHAKAPACKER_ASSETS_BUNDLER) {
 const DEFAULT_JAVASCRIPT_TRANSPILER =
   config.assets_bundler === "rspack" ? "swc" : "babel"
 
-// Backward compatibility: Check for webpack_loader using proper type guard
-function hasWebpackLoader(
-  obj: unknown
-): obj is Config & { webpack_loader: string } {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "webpack_loader" in obj &&
-    typeof (obj as Record<string, unknown>).webpack_loader === "string"
-  )
+const IMPLICIT_SWC_BABEL_FALLBACK_WARNING =
+  "`javascript_transpiler` is not set in config/shakapacker.yml. " +
+  "Shakapacker defaults to SWC, but swc-loader is not installed and Babel was detected, so Babel will be used. " +
+  "Set `javascript_transpiler: babel` (or `swc`) explicitly to silence this message. " +
+  "See https://github.com/shakacode/shakapacker/blob/main/docs/transpiler-migration.md"
+
+const transpilerConfiguredByApp =
+  appConfigHasJavascriptTranspiler || appConfigHasWebpackLoader
+
+const shouldFallbackImplicitSwcToBabel = (): boolean =>
+  !transpilerConfiguredByApp &&
+  config.assets_bundler === "webpack" &&
+  config.javascript_transpiler === "swc" &&
+  !packageDependencyInstalled("swc-loader") &&
+  packageDependencyInstalled("babel-loader")
+
+if (
+  !appConfigHasJavascriptTranspiler &&
+  !appConfigHasWebpackLoader &&
+  !config.javascript_transpiler
+) {
+  config.javascript_transpiler =
+    defaults.javascript_transpiler || DEFAULT_JAVASCRIPT_TRANSPILER
 }
 
 // Allow environment variable to override javascript_transpiler
 if (process.env.SHAKAPACKER_JAVASCRIPT_TRANSPILER) {
   config.javascript_transpiler = process.env.SHAKAPACKER_JAVASCRIPT_TRANSPILER
-} else if (hasWebpackLoader(config) && !config.javascript_transpiler) {
+} else if (
+  appConfigHasWebpackLoader &&
+  !appConfigHasJavascriptTranspiler &&
+  appConfigWebpackLoader
+) {
   console.warn(
     "[SHAKAPACKER DEPRECATION] The 'webpack_loader' configuration option is deprecated.\n" +
       "Please use 'javascript_transpiler' instead as it better reflects its purpose of configuring JavaScript transpilation regardless of the bundler used."
   )
-  config.javascript_transpiler = config.webpack_loader
+  config.javascript_transpiler = appConfigWebpackLoader
 } else if (!config.javascript_transpiler) {
   config.javascript_transpiler = DEFAULT_JAVASCRIPT_TRANSPILER
+} else if (shouldFallbackImplicitSwcToBabel()) {
+  console.warn(IMPLICIT_SWC_BABEL_FALLBACK_WARNING)
+  config.javascript_transpiler = "babel"
 }
 
 // Ensure webpack_loader is always available for backward compatibility

--- a/package/env.ts
+++ b/package/env.ts
@@ -79,7 +79,7 @@ const validatedRailsEnv =
 if (initialRailsEnv && validatedRailsEnv !== initialRailsEnv) {
   console.warn(
     `[SHAKAPACKER WARNING] Environment '${initialRailsEnv}' not found in the configuration.\n` +
-      `Using '${DEFAULT}' configuration as a fallback.`
+      `Using '${DEFAULT}' as the NODE_ENV fallback. Configuration loading falls back separately.`
   )
 }
 

--- a/package/utils/helpers.ts
+++ b/package/utils/helpers.ts
@@ -1,4 +1,6 @@
 const { isModuleNotFoundError, getErrorMessage } = require("./errorHelpers")
+const { existsSync, readFileSync } = require("fs") as typeof import("fs")
+const nodePath = require("path") as typeof import("path")
 
 const isBoolean = (str: string): boolean =>
   /^true/.test(str) || /^false/.test(str)
@@ -19,6 +21,42 @@ const resolvedPath = (packageName: string): string | null => {
 
 const moduleExists = (packageName: string): boolean =>
   !!resolvedPath(packageName)
+
+const packageDependencyExists = (
+  packageName: string,
+  packageRootPaths: string[]
+): boolean =>
+  packageRootPaths.some((packageRootPath) => {
+    const packageJsonPath = nodePath.join(packageRootPath, "package.json")
+    if (!existsSync(packageJsonPath)) {
+      return false
+    }
+
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+        dependencies?: Record<string, unknown>
+        devDependencies?: Record<string, unknown>
+        optionalDependencies?: Record<string, unknown>
+      }
+
+      return (
+        Object.prototype.hasOwnProperty.call(
+          packageJson.dependencies || {},
+          packageName
+        ) ||
+        Object.prototype.hasOwnProperty.call(
+          packageJson.devDependencies || {},
+          packageName
+        ) ||
+        Object.prototype.hasOwnProperty.call(
+          packageJson.optionalDependencies || {},
+          packageName
+        )
+      )
+    } catch {
+      return false
+    }
+  })
 
 const canProcess = <T = unknown>(
   rule: string,
@@ -91,6 +129,7 @@ export {
   isBoolean,
   ensureTrailingSlash,
   canProcess,
+  packageDependencyExists,
   moduleExists,
   loaderMatches,
   packageFullVersion,

--- a/spec/shakapacker/configuration_spec.rb
+++ b/spec/shakapacker/configuration_spec.rb
@@ -1,5 +1,7 @@
 require_relative "spec_helper_initializer"
 require "tempfile"
+require "tmpdir"
+require "fileutils"
 
 describe "Shakapacker::Configuration" do
   ROOT_PATH = Pathname.new(File.expand_path("./test_app", __dir__))
@@ -578,6 +580,7 @@ describe "Shakapacker::Configuration" do
       end
 
       it "returns the configured javascript_transpiler" do
+        allow(config).to receive(:fetch).and_call_original
         allow(config).to receive(:fetch).with(:javascript_transpiler).and_return("swc")
         allow(config).to receive(:fetch).with(:webpack_loader).and_return(nil)
         expect(config.javascript_transpiler).to eq "swc"
@@ -594,6 +597,7 @@ describe "Shakapacker::Configuration" do
       end
 
       it "falls back to webpack_loader when javascript_transpiler is not set" do
+        allow(config).to receive(:fetch).and_call_original
         allow(config).to receive(:fetch).with(:javascript_transpiler).and_return(nil)
         allow(config).to receive(:fetch).with(:webpack_loader).and_return("esbuild")
         expect(config.javascript_transpiler).to eq "esbuild"
@@ -610,11 +614,283 @@ describe "Shakapacker::Configuration" do
       end
 
       it "defaults to 'babel'" do
+        allow(config).to receive(:fetch).and_call_original
         allow(config).to receive(:fetch).with(:javascript_transpiler).and_return(nil)
         allow(config).to receive(:fetch).with(:webpack_loader).and_return(nil)
         allow(config).to receive(:fetch).with(:assets_bundler).and_return(nil)
         allow(config).to receive(:fetch).with(:bundler).and_return(nil)
         expect(config.javascript_transpiler).to eq "babel"
+      end
+    end
+
+    context "with bundled-default SWC and no app transpiler key" do
+      let(:app_root) { Pathname.new(Dir.mktmpdir) }
+      let(:config_path) { app_root.join("config/shakapacker.yml") }
+      let(:config) do
+        Shakapacker::Configuration.new(
+          root_path: app_root,
+          config_path: config_path,
+          env: "test"
+        )
+      end
+
+      before do
+        FileUtils.mkdir_p(config_path.dirname)
+      end
+
+      after do
+        FileUtils.rm_rf(app_root)
+      end
+
+      def write_config(contents)
+        File.write(config_path, contents)
+      end
+
+      def write_package_json(dev_dependencies)
+        File.write(app_root.join("package.json"), JSON.generate({ "devDependencies" => dev_dependencies }))
+      end
+
+      it "falls back to Babel for webpack when swc-loader is missing and Babel is present" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "prints the implicit Babel fallback warning only once across repeated calls" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/).once
+        expect(config.javascript_transpiler).to eq("babel")
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "keeps bundled-default SWC for webpack when swc-loader is installed" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        write_package_json(
+          "@swc/core" => "^1.0.0",
+          "swc-loader" => "^0.2.0",
+          "babel-loader" => "^10.0.0"
+        )
+
+        expect($stderr).not_to receive(:puts).with(/Shakapacker defaults to SWC/)
+        expect(config.javascript_transpiler).to eq("swc")
+      end
+
+      it "preserves explicit SWC when only Babel is installed" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+            javascript_transpiler: swc
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).not_to receive(:puts).with(/Shakapacker defaults to SWC/)
+        expect(config.javascript_transpiler).to eq("swc")
+      end
+
+      it "preserves explicit webpack_loader when bundled defaults include SWC" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+            webpack_loader: babel
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/DEPRECATION WARNING.*webpack_loader.*deprecated.*javascript_transpiler/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "treats blank webpack_loader as implicit and falls back to Babel" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+            webpack_loader:
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "treats blank javascript_transpiler as implicit and falls back to Babel" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+            javascript_transpiler:
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "treats non-string webpack_loader as implicit and falls back to Babel" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+            webpack_loader: 123
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "detects Babel dependencies from the configured JavaScript package root" do
+        write_config(<<~YAML)
+          test:
+            source_path: client/app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        FileUtils.mkdir_p(app_root.join("client"))
+        File.write(
+          app_root.join("client/package.json"),
+          JSON.generate({ "devDependencies" => { "babel-loader" => "^10.0.0" } })
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "continues past bare node_modules markers to find package.json declarations" do
+        write_config(<<~YAML)
+          test:
+            source_path: workspace/nested/app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        FileUtils.mkdir_p(app_root.join("workspace/nested/node_modules"))
+        File.write(
+          app_root.join("workspace/package.json"),
+          JSON.generate({ "devDependencies" => { "babel-loader" => "^10.0.0" } })
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      end
+
+      it "does not warn about a false transpiler mismatch for the configured JavaScript package root" do
+        previous_node_env = ENV["NODE_ENV"]
+        ENV["NODE_ENV"] = "development"
+        write_config(<<~YAML)
+          test:
+            source_path: client/app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: webpack
+        YAML
+        FileUtils.mkdir_p(app_root.join("client"))
+        File.write(
+          app_root.join("client/package.json"),
+          JSON.generate({
+            "devDependencies" => {
+              "babel-loader" => "^10.0.0",
+              "@babel/core" => "^7.0.0"
+            }
+          })
+        )
+        write_package_json(
+          "@swc/core" => "^1.0.0"
+        )
+
+        expect($stderr).to receive(:puts).with(/Shakapacker defaults to SWC.*Babel was detected/)
+        expect($stderr).not_to receive(:puts).with(/Transpiler Configuration Mismatch Detected/)
+        expect(config.javascript_transpiler).to eq("babel")
+      ensure
+        if previous_node_env.nil?
+          ENV.delete("NODE_ENV")
+        else
+          ENV["NODE_ENV"] = previous_node_env
+        end
+      end
+
+      it "preserves rspack SWC behavior without swc-loader" do
+        write_config(<<~YAML)
+          test:
+            source_path: app/javascript
+            source_entry_path: entrypoints
+            public_root_path: public
+            public_output_path: packs
+            assets_bundler: rspack
+        YAML
+        write_package_json(
+          "babel-loader" => "^10.0.0",
+          "@babel/core" => "^7.0.0"
+        )
+
+        expect($stderr).not_to receive(:puts).with(/Shakapacker defaults to SWC/)
+        expect(config.javascript_transpiler).to eq("swc")
       end
     end
   end
@@ -651,6 +927,7 @@ describe "Shakapacker::Configuration" do
       it "shows deprecation warning and returns javascript_transpiler value" do
         data_mock = { webpack_loader: "swc" }
         allow(config).to receive(:data).and_return(data_mock)
+        allow(config).to receive(:fetch).and_call_original
         allow(config).to receive(:fetch).with(:javascript_transpiler).and_return(nil)
         allow(config).to receive(:fetch).with(:webpack_loader).and_return("swc")
         allow(config).to receive(:fetch).with(:assets_bundler).and_return(nil)

--- a/spec/shakapacker/doctor_spec.rb
+++ b/spec/shakapacker/doctor_spec.rb
@@ -2099,7 +2099,7 @@ describe Shakapacker::Doctor do
           end
         end
 
-        context "when inferred webpack/SWC defaults have a hybrid-looking package graph without matching configs" do
+        context "when inferred webpack/SWC defaults have Babel but no swc-loader" do
           before do
             allow(config).to receive(:javascript_transpiler).and_return(nil)
             File.write(package_json_path, JSON.generate({
@@ -2108,20 +2108,79 @@ describe Shakapacker::Doctor do
                 "@rspack/core" => "^2.0.0"
               },
               "devDependencies" => {
-                "babel-loader" => "^9.0.0"
+                "babel-loader" => "^9.0.0",
+                "@babel/core" => "^7.20.0",
+                "@babel/preset-env" => "^7.20.0"
               }
             }))
           end
 
-          it "continues reporting missing SWC dependencies for the inferred webpack build" do
+          it "falls back to Babel instead of reporting missing SWC dependencies" do
             doctor.send(:check_javascript_transpiler_dependencies)
-            expect(doctor.issues).to include(match(/Missing required dependency '@swc\/core'/))
-            expect(doctor.issues).to include(match(/Missing required dependency 'swc-loader'/))
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
+            expect(doctor.info).not_to include(match(/Consider switching to SWC/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
             expect(warning_messages).not_to include(match(/Skipping SWC dependency issue checks/))
+          end
+
+          it "treats blank deprecated webpack_loader config as implicit" do
+            allow(config).to receive(:data).and_return(config_data.merge(webpack_loader: nil))
+
+            doctor.send(:check_javascript_transpiler_dependencies)
+
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
+            expect(doctor.info).not_to include(match(/Consider switching to SWC/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
+          end
+
+          it "treats blank javascript_transpiler config as implicit" do
+            allow(config).to receive(:data).and_return(config_data.merge(javascript_transpiler: nil))
+
+            doctor.send(:check_javascript_transpiler_dependencies)
+
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
+            expect(doctor.info).not_to include(match(/Consider switching to SWC/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
+          end
+
+          it "treats non-string deprecated webpack_loader config as implicit" do
+            allow(config).to receive(:data).and_return(config_data.merge(webpack_loader: 123))
+
+            doctor.send(:check_javascript_transpiler_dependencies)
+
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
+            expect(doctor.info).not_to include(match(/Consider switching to SWC/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
+          end
+
+          it "continues past bare node_modules markers to find package.json declarations" do
+            nested_source_path = root_path.join("workspace/nested/app/javascript")
+            FileUtils.mkdir_p(nested_source_path)
+            FileUtils.mkdir_p(root_path.join("workspace/nested/node_modules"))
+            FileUtils.rm_f(package_json_path)
+            File.write(root_path.join("workspace/package.json"), JSON.generate({
+              "dependencies" => {
+                "webpack" => "^5.0.0"
+              },
+              "devDependencies" => {
+                "babel-loader" => "^9.0.0",
+                "@babel/core" => "^7.20.0",
+                "@babel/preset-env" => "^7.20.0"
+              }
+            }))
+            allow(config).to receive(:source_path).and_return(nested_source_path)
+
+            doctor.send(:check_javascript_transpiler_dependencies)
+
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
+            expect(doctor.info).not_to include(match(/Consider switching to SWC/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
+            expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
           end
         end
 
-        context "when inferred webpack/SWC defaults meet a hybrid webpack and Rspack package graph" do
+        context "when inferred webpack/SWC defaults meet a hybrid webpack and Rspack package graph with Babel fallback" do
           before do
             allow(config).to receive(:javascript_transpiler).and_return(nil)
             File.write(root_path.join(".swcrc"), "{}")
@@ -2136,24 +2195,23 @@ describe Shakapacker::Doctor do
               },
               "devDependencies" => {
                 "babel-loader" => "^9.0.0",
-                "@babel/core" => "^7.20.0"
+                "@babel/core" => "^7.20.0",
+                "@babel/preset-env" => "^7.20.0"
               }
             }))
           end
 
-          it "skips inferred default SWC dependency issues for custom-hybrid package graphs" do
+          it "falls back to Babel before custom-hybrid SWC dependency handling" do
             doctor.send(:check_javascript_transpiler_dependencies)
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
             expect(doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
             expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
-            expect(warning_messages).to include(match(/Detected a custom hybrid webpack\/Rspack setup.*Skipping SWC dependency issue checks/))
-            expect(
-              doctor.warnings.find { |warning| warning[:message].match?(/Detected a custom hybrid webpack\/Rspack setup/) }[:category]
-            ).to eq(described_class::CATEGORY_INFO)
+            expect(warning_messages).not_to include(match(/Detected a custom hybrid webpack\/Rspack setup.*Skipping SWC dependency issue checks/))
             expect(warning_messages).not_to include(match(/Both SWC and Babel dependencies are installed/))
-            expect(warning_messages).to include(match(/\.swcrc file detected.*migrate to config\/swc\.config\.js/))
+            expect(warning_messages).not_to include(match(/\.swcrc file detected.*migrate to config\/swc\.config\.js/))
           end
 
-          it "uses real Configuration defaults as an inferred SWC doctor check" do
+          it "uses real Configuration defaults as an inferred Babel fallback doctor check" do
             File.write(config_path, <<~YAML)
               test:
                 source_path: app/javascript
@@ -2172,9 +2230,57 @@ describe Shakapacker::Doctor do
             real_warnings = real_doctor.warnings.map { |warning| warning[:message] }
 
             expect(stderr).not_to include("Transpiler Configuration Mismatch Detected")
+            expect(real_doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
             expect(real_doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
             expect(real_doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
-            expect(real_warnings).to include(match(/Detected a custom hybrid webpack\/Rspack setup.*Skipping SWC dependency issue checks/))
+            expect(real_warnings).not_to include(match(/Detected a custom hybrid webpack\/Rspack setup.*Skipping SWC dependency issue checks/))
+          end
+
+          it "does not print a duplicate raw fallback warning in a full doctor run" do
+            File.write(config_path, <<~YAML)
+              test:
+                source_path: app/javascript
+                source_entry_path: packs
+                integrity:
+                  enabled: false
+            YAML
+
+            real_config = Shakapacker::Configuration.new(
+              root_path: root_path,
+              config_path: config_path,
+              env: "test"
+            )
+            real_doctor = described_class.new(real_config, root_path)
+            allow(real_doctor).to receive(:exit)
+            stdout = nil
+            stderr = capture_stderr { stdout = capture_stdout { real_doctor.run } }
+
+            expect(stdout.scan(/Shakapacker defaults to SWC.*Babel was detected/).length).to eq(1)
+            expect(stderr).not_to include("Shakapacker defaults to SWC")
+          end
+
+          it "does not print a raw fallback warning when javascript_transpiler is read before dependency checks" do
+            File.write(config_path, <<~YAML)
+              test:
+                source_path: app/javascript
+                source_entry_path: packs
+                integrity:
+                  enabled: false
+            YAML
+
+            real_config = Shakapacker::Configuration.new(
+              root_path: root_path,
+              config_path: config_path,
+              env: "test"
+            )
+            real_doctor = described_class.new(real_config, root_path)
+            stderr = capture_stderr do
+              real_doctor.send(:javascript_transpiler)
+              real_doctor.send(:check_javascript_transpiler_dependencies)
+            end
+
+            expect(real_doctor.info.join("\n").scan(/Shakapacker defaults to SWC.*Babel was detected/).length).to eq(1)
+            expect(stderr).not_to include("Shakapacker defaults to SWC")
           end
 
           it "reports an empty assets_bundler env override instead of substituting defaults" do
@@ -2300,25 +2406,29 @@ describe Shakapacker::Doctor do
                 "@rspack/core" => "^2.0.0"
               },
               "devDependencies" => {
-                "babel-loader" => "^9.0.0"
+                "babel-loader" => "^9.0.0",
+                "@babel/core" => "^7.20.0",
+                "@babel/preset-env" => "^7.20.0"
               }
             }))
           end
 
-          it "uses the custom config directory as hybrid evidence" do
+          it "uses Babel fallback before custom config directory hybrid evidence" do
             doctor.send(:check_javascript_transpiler_dependencies)
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
             expect(doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
             expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
-            expect(warning_messages).to include(match(/Skipping SWC dependency issue checks/))
+            expect(warning_messages).not_to include(match(/Skipping SWC dependency issue checks/))
           end
 
           it "matches runner path semantics for leading-slash config directories" do
             allow(config).to receive(:assets_bundler_config_path).and_return("/build_configs")
 
             doctor.send(:check_javascript_transpiler_dependencies)
+            expect(doctor.info).to include(match(/Shakapacker defaults to SWC.*Babel was detected/))
             expect(doctor.issues).not_to include(match(/Missing required dependency '@swc\/core'/))
             expect(doctor.issues).not_to include(match(/Missing required dependency 'swc-loader'/))
-            expect(warning_messages).to include(match(/Skipping SWC dependency issue checks/))
+            expect(warning_messages).not_to include(match(/Skipping SWC dependency issue checks/))
           end
         end
 
@@ -2418,7 +2528,7 @@ describe Shakapacker::Doctor do
         allow(config).to receive(:javascript_transpiler).and_return(nil)
       end
 
-      it "defaults to SWC and adds info message" do
+      it "uses bundled SWC default and adds info message" do
         package_json = {
           "devDependencies" => {
             "@swc/core" => "^1.3.0",
@@ -2428,7 +2538,7 @@ describe Shakapacker::Doctor do
         File.write(package_json_path, JSON.generate(package_json))
 
         doctor.send(:check_javascript_transpiler_dependencies)
-        expect(doctor.info).to include(match(/No javascript_transpiler configured - defaulting to SWC/))
+        expect(doctor.info).to include(match(/No javascript_transpiler configured - using bundled SWC default/))
       end
     end
 
@@ -2700,6 +2810,8 @@ describe Shakapacker::Doctor do
     end
 
     context "with TypeScript files" do
+      let(:config_data) { super().merge(javascript_transpiler: "babel") }
+
       before do
         FileUtils.mkdir_p(source_path)
         File.write(source_path.join("app.tsx"), "")

--- a/test/package/config.test.js
+++ b/test/package/config.test.js
@@ -1,12 +1,58 @@
 const { resolve } = require("path")
+const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = require("fs")
+const { join } = require("path")
+const { tmpdir } = require("os")
 const { chdirTestApp, resetEnv } = require("../helpers")
 
 const rootPath = process.cwd()
 chdirTestApp()
+const testAppPath = process.cwd()
 
 describe("Config", () => {
+  let tempConfigDir
+  let tempAppRoot
+
   beforeEach(() => jest.resetModules() && resetEnv())
+  afterEach(() => {
+    process.chdir(testAppPath)
+    if (tempConfigDir) {
+      rmSync(tempConfigDir, { recursive: true, force: true })
+      tempConfigDir = undefined
+    }
+    if (tempAppRoot) {
+      rmSync(tempAppRoot, { recursive: true, force: true })
+      tempAppRoot = undefined
+    }
+  })
   afterAll(() => process.chdir(rootPath))
+
+  const writeTempConfig = (contents) => {
+    tempConfigDir = mkdtempSync(join(tmpdir(), "shakapacker-config-test-"))
+    const configPath = join(tempConfigDir, "shakapacker.yml")
+    writeFileSync(configPath, contents)
+    process.env.SHAKAPACKER_CONFIG = configPath
+  }
+
+  const mockPackageHelpers = ({
+    moduleExists = () => false,
+    packageDependencyExists = moduleExists
+  }) => {
+    jest.doMock("../../package/utils/helpers", () => ({
+      ...jest.requireActual("../../package/utils/helpers"),
+      moduleExists,
+      packageDependencyExists
+    }))
+  }
+
+  const mockModuleExists = (implementation) => {
+    mockPackageHelpers({ moduleExists: implementation })
+  }
+
+  const chdirTempApp = () => {
+    tempAppRoot = mkdtempSync(join(tmpdir(), "shakapacker-app-root-"))
+    process.chdir(tempAppRoot)
+    return tempAppRoot
+  }
 
   test("public path", () => {
     process.env.RAILS_ENV = "development"
@@ -107,5 +153,253 @@ describe("Config", () => {
     const config = require("../../package/config")
 
     expect(config.integrity.cross_origin).toBe("use-credentials")
+  })
+
+  describe("implicit bundled-default SWC fallback", () => {
+    const minimalWebpackConfig = `
+test:
+  source_path: app/javascript
+  source_entry_path: entrypoints
+  public_root_path: public
+  public_output_path: packs
+  assets_bundler: webpack
+`
+
+    test("falls back to Babel when webpack uses the bundled SWC default without swc-loader", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(minimalWebpackConfig)
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain("Shakapacker defaults to SWC")
+      warn.mockRestore()
+    })
+
+    test("keeps implicit SWC when swc-loader is installed", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(minimalWebpackConfig)
+      mockModuleExists((packageName) => packageName === "swc-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("swc")
+      expect(config.webpack_loader).toBe("swc")
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    test("preserves explicit SWC even when only Babel is installed", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(`${minimalWebpackConfig}  javascript_transpiler: swc\n`)
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("swc")
+      expect(config.webpack_loader).toBe("swc")
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    test("preserves explicit webpack_loader even when bundled defaults include SWC", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(`${minimalWebpackConfig}  webpack_loader: babel\n`)
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain("webpack_loader")
+      warn.mockRestore()
+    })
+
+    test("preserves explicit production fallback transpiler when Rails env is missing", () => {
+      process.env.RAILS_ENV = "staging"
+      writeTempConfig(
+        minimalWebpackConfig
+          .replace("test:", "production:")
+          .concat('  javascript_transpiler: "none"\n')
+      )
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      try {
+        const config = require("../../package/config")
+
+        expect(config.javascript_transpiler).toBe("none")
+        expect(config.webpack_loader).toBe("none")
+        expect(
+          warn.mock.calls.some(([message]) =>
+            message.includes("Environment 'staging' not found")
+          )
+        ).toBe(true)
+        expect(
+          warn.mock.calls.some(([message]) =>
+            message.includes("Using 'development' configuration")
+          )
+        ).toBe(false)
+        expect(
+          warn.mock.calls.some(([message]) =>
+            message.includes("Shakapacker defaults to SWC")
+          )
+        ).toBe(false)
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    test("uses production fallback instead of normalized development when requested Rails env is missing", () => {
+      process.env.RAILS_ENV = "staging"
+      writeTempConfig(
+        minimalWebpackConfig
+          .replace("test:", "production:")
+          .concat('  javascript_transpiler: "none"\n')
+          .concat("development:\n")
+          .concat("  source_path: app/javascript\n")
+          .concat("  source_entry_path: packs\n")
+          .concat("  public_root_path: public\n")
+          .concat("  public_output_path: packs\n")
+          .concat("  assets_bundler: webpack\n")
+      )
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      try {
+        const config = require("../../package/config")
+
+        expect(config.javascript_transpiler).toBe("none")
+        expect(config.webpack_loader).toBe("none")
+        expect(
+          warn.mock.calls.some(([message]) =>
+            message.includes("Environment 'staging' not found")
+          )
+        ).toBe(true)
+        expect(
+          warn.mock.calls.some(([message]) =>
+            message.includes("Shakapacker defaults to SWC")
+          )
+        ).toBe(false)
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    test("treats blank webpack_loader as implicit and falls back to Babel", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(`${minimalWebpackConfig}  webpack_loader:\n`)
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain("Shakapacker defaults to SWC")
+      warn.mockRestore()
+    })
+
+    test("treats empty javascript_transpiler as implicit and falls back to Babel", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(`${minimalWebpackConfig}  javascript_transpiler: ""\n`)
+      mockModuleExists((packageName) => packageName === "babel-loader")
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain("Shakapacker defaults to SWC")
+      warn.mockRestore()
+    })
+
+    test("continues past bare node_modules markers to find package.json declarations", () => {
+      const appRoot = chdirTempApp()
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(`
+test:
+  source_path: workspace/nested/app/javascript
+  source_entry_path: entrypoints
+  public_root_path: public
+  public_output_path: packs
+  assets_bundler: webpack
+`)
+      mkdirSync(join(appRoot, "workspace/nested/node_modules"), {
+        recursive: true
+      })
+      writeFileSync(
+        join(appRoot, "workspace/package.json"),
+        JSON.stringify({ devDependencies: { "babel-loader": "^10.0.0" } })
+      )
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn.mock.calls[0][0]).toContain("Shakapacker defaults to SWC")
+      warn.mockRestore()
+    })
+
+    test("uses package declarations for fallback instead of stale installed modules", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(minimalWebpackConfig)
+      mockPackageHelpers({
+        moduleExists: (packageName) => packageName === "swc-loader",
+        packageDependencyExists: (packageName) => packageName === "babel-loader"
+      })
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("babel")
+      expect(config.webpack_loader).toBe("babel")
+      expect(warn.mock.calls[0][0]).toContain("Shakapacker defaults to SWC")
+      warn.mockRestore()
+    })
+
+    test("memoizes package root paths while checking fallback dependencies", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(minimalWebpackConfig)
+      const seenPackageRootPaths = []
+      mockPackageHelpers({
+        packageDependencyExists: (packageName, packageRootPaths) => {
+          seenPackageRootPaths.push(packageRootPaths)
+          return packageName === "babel-loader"
+        }
+      })
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      require("../../package/config")
+
+      expect(seenPackageRootPaths).toHaveLength(2)
+      expect(seenPackageRootPaths[0]).toBe(seenPackageRootPaths[1])
+      warn.mockRestore()
+    })
+
+    test("preserves rspack SWC behavior without checking swc-loader", () => {
+      process.env.RAILS_ENV = "test"
+      writeTempConfig(minimalWebpackConfig.replace("webpack", "rspack"))
+      mockModuleExists(() => false)
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const config = require("../../package/config")
+
+      expect(config.javascript_transpiler).toBe("swc")
+      expect(config.webpack_loader).toBe("swc")
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
   })
 })

--- a/test/package/helpers.test.js
+++ b/test/package/helpers.test.js
@@ -1,4 +1,10 @@
-const { packageMajorVersion } = require("../../package/utils/helpers")
+const { mkdtempSync, rmSync, writeFileSync } = require("fs")
+const { tmpdir } = require("os")
+const { join } = require("path")
+const {
+  packageDependencyExists,
+  packageMajorVersion
+} = require("../../package/utils/helpers")
 
 describe("packageMajorVersion", () => {
   test("should find that sass-loader is v16", () => {
@@ -7,5 +13,45 @@ describe("packageMajorVersion", () => {
 
   test("should find that nonexistent is v12", () => {
     expect(packageMajorVersion("nonexistent")).toBe(12)
+  })
+})
+
+describe("packageDependencyExists", () => {
+  let tempRoot
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true })
+      tempRoot = undefined
+    }
+  })
+
+  const writePackageJson = (contents) => {
+    tempRoot = mkdtempSync(join(tmpdir(), "shakapacker-package-deps-"))
+    writeFileSync(join(tempRoot, "package.json"), JSON.stringify(contents))
+    return tempRoot
+  }
+
+  test("detects dependencies, devDependencies, and optionalDependencies", () => {
+    const root = writePackageJson({
+      dependencies: { webpack: "^5.0.0" },
+      devDependencies: { "babel-loader": "^10.0.0" },
+      optionalDependencies: { "swc-loader": "^0.2.0" },
+      peerDependencies: { esbuild: "^0.25.0" }
+    })
+
+    expect(packageDependencyExists("webpack", [root])).toBe(true)
+    expect(packageDependencyExists("babel-loader", [root])).toBe(true)
+    expect(packageDependencyExists("swc-loader", [root])).toBe(true)
+    expect(packageDependencyExists("esbuild", [root])).toBe(false)
+  })
+
+  test("ignores missing or invalid package.json files", () => {
+    const root = writePackageJson("{")
+
+    expect(packageDependencyExists("webpack", [root])).toBe(false)
+    expect(packageDependencyExists("webpack", [join(root, "missing")])).toBe(
+      false
+    )
   })
 })


### PR DESCRIPTION
## Summary

Fixes the 10.2.1 release blocker where webpack apps that omit `javascript_transpiler`/`webpack_loader` inherit Shakapacker's bundled SWC default but do not have `swc-loader` installed.

When that implicit webpack/SWC path sees declared Babel tooling (`babel-loader`) and no declared `swc-loader`, Shakapacker now falls back to Babel with an explicit warning. Explicit `javascript_transpiler`, nonblank deprecated explicit `webpack_loader`, webpack apps with declared `swc-loader`, and Rspack's SWC behavior are preserved.

Closes #1203.

## What Changed

- Added JS and Ruby fallback predicates for implicit bundled-default SWC webpack apps.
- Aligned fallback package detection on package declarations across the configured JavaScript package root and Rails root.
- Treated blank or malformed deprecated `webpack_loader:` values as implicit, so they no longer suppress the fallback.
- Updated doctor output so the fallback path reports the Babel fallback without immediately suggesting SWC again, including blank/non-string deprecated-loader cases and full doctor-report rendering.
- Aligned Ruby transpiler mismatch validation and Doctor dependency lookup with the same package-root-aware dependency view used by the fallback; Doctor package-manager detection keeps its existing lockfile-marker behavior through a separate root walk.
- Added JS/Ruby regression coverage for fallback, explicit config preservation, blank and non-string `webpack_loader`, subdirectory package roots, bare `node_modules` package-root walks, stale `node_modules` disagreement, `swc-loader` preservation, Rspack preservation, and JS package-root memoization.
- Added a CHANGELOG entry and clarified the generated `shakapacker.yml` comment.

## Validation

- `git diff --check`
- `yarn type-check`
- `yarn prettier --check package/config.ts test/package/config.test.js`
- `yarn test test/package/config.test.js test/package/helpers.test.js --runInBand` (`27` passed)
- `bundle exec rspec spec/shakapacker/configuration_spec.rb spec/shakapacker/doctor_spec.rb` (`295` examples, `0` failures)
- `.agents/bin/validate` passed: RuboCop clean, ESLint clean, Ruby specs/generator specs green (`77` generator examples), full Jest suite `62` suites / `642` passed / `1` todo

## Review Evidence

- Spec compliance reviewer: passed; no missing/extra requirements.
- Code quality reviewer: no Critical or Important issues.
- Greptile P1 blank `webpack_loader` thread: fixed, replied, and resolved.
- CodeRabbit CHANGELOG and blank-current-key follow-up: addressed or verified/skipped with rationale; threads resolved.
- Claude findings on package-root lookup, Ruby/JS detection mismatch, Doctor contradictory suggestion, duplicate doctor warning, bare `node_modules` package-root walks, non-string deprecated `webpack_loader`, and JS memoization: fixed with regression coverage; threads replied and resolved.
- Final Claude/Codex connector edge cases on Doctor dependency lookup vs package-manager lookup and non-string deprecated `webpack_loader`: fixed in `71fca22b`; threads replied and resolved.
- Claude shared-helper extraction and blank current-key `javascript_transpiler:` comments: verified and skipped as out-of-scope behavior/refactor follow-ups for this release blocker; threads replied and resolved.
- Codex sidecar adversarial review: no blocking findings; independently identified the blank deprecated-loader Doctor messaging gap, now fixed.

## Codex Decision Log

- **Non-blocking:** Whether the fallback predicate should require only `babel-loader` or also `@babel/core`.
  - **Decision:** Use declared `babel-loader` as the fallback signal.
  - **Why:** The release blocker is specifically about choosing a runnable webpack loader path when `swc-loader` is missing; existing doctor dependency checks still report missing `@babel/core` / presets when the Babel stack is incomplete.
  - **Review later:** Maintainers may tighten the predicate if they want fallback only when the full Babel peer stack is declared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript transpiler selection for webpack when bundled SWC defaults are active.
  * If SWC is implied but `swc-loader` isn’t installed (and Babel deps are present), the app now falls back to Babel and shows a warning.
  * Preserved existing behavior for explicitly configured transpilers and for Rspack SWC.
  * The diagnostic tool now treats blank/invalid legacy transpiler settings as unset and improves dependency detection to reduce incorrect mismatch warnings.
* **Documentation**
  * Clarified configuration/installer guidance for transpiler defaults and the implicit SWC→Babel fallback.
* **Tests**
  * Expanded coverage for implicit fallback behavior, legacy setting handling, and dependency detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
