### PR TITLE
Update changelog for v10.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## [Unreleased]
 
+## [v10.2.1] - July 5, 2026
+
 ### Added
 
 - **Allowed `webpack-dev-server` v6**. [PR #1102](https://github.com/shakacode/shakapacker/pull/1102) by [G-Rath](https://github.com/G-Rath).
@@ -984,7 +986,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.2.0...main
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.2.1...main
+[v10.2.1]: https://github.com/shakacode/shakapacker/compare/v10.2.0...v10.2.1
 [v10.2.0]: https://github.com/shakacode/shakapacker/compare/v10.1.0...v10.2.0
 [v10.1.0]: https://github.com/shakacode/shakapacker/compare/v10.0.0...v10.1.0
 [v10.0.0]: https://github.com/shakacode/shakapacker/compare/v9.7.0...v10.0.0


### PR DESCRIPTION
## Summary
- Stamps `## [v10.2.1] - July 5, 2026` immediately after `## [Unreleased]`, moving the existing unreleased entries (webpack-dev-server v6 support, SWC/Babel fallback fixes, production-env config fallback, and helper binstub PATH fix) into the new version section.
- Adds the `[v10.2.1]` compare link and updates `[Unreleased]` to compare from `v10.2.1...main`.

No new entries were needed: a classification sweep of `v10.2.0..origin/main` found only #1102, #1206, #1200, and #1201 as user-visible (all already present in Unreleased), plus #1202 (CI-only) and #1208 (docs-only) which are correctly excluded.

## Test plan
- [x] Verified CHANGELOG.md diff manually
- [x] Confirmed file ends with a trailing newline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a new **v10.2.1** release entry dated July 5, 2026.
  * Refreshed version comparison links so the latest release is now shown against the main branch, with a new link for comparing **v10.2.0** to **v10.2.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->