### PR TITLE
docs: add css-loader to v10 Rspack upgrade commands

### DIFF
--- a/docs/v10_upgrade.md
+++ b/docs/v10_upgrade.md
@@ -155,6 +155,8 @@ Shakapacker 10.2 targets Rspack v2:
 - `rspack-manifest-plugin` must satisfy `^5.2.2`.
 - `@rspack/plugin-react-refresh` uses the v2 named
   `ReactRefreshRspackPlugin` export.
+- `css-loader` must satisfy `^7.1.4` when your Rspack build uses
+  Shakapacker-managed CSS loader rules.
 - Rspack v2 uses top-level `lazyCompilation`; Shakapacker disables it for the
   split Rails dev-server topology unless you explicitly configure a safe value.
 
@@ -163,11 +165,11 @@ Shakapacker 10.2 targets Rspack v2:
 Update the managed Rspack stack together:
 
 ```bash
-yarn add --dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2
+yarn add --dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2 css-loader@^7.1.4
 # or
-npm install --save-dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2
+npm install --save-dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2 css-loader@^7.1.4
 # or
-pnpm add --save-dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2
+pnpm add --save-dev @rspack/core@^2 @rspack/cli@^2 @rspack/dev-server@^2 rspack-manifest-plugin@^5.2.2 @rspack/plugin-react-refresh@^2 css-loader@^7.1.4
 ```
 
 If you use React Refresh in a custom Rspack config, use the v2 named export:


### PR DESCRIPTION
## Summary

Adds `css-loader@^7.1.4` to the v10 Rspack upgrade commands so apps using Shakapacker-managed CSS loader rules install the CSS loader version expected by the Rspack v2 stack.

Closes #1209.

## Validation

- `git diff --check origin/main..codex/1209-css-loader-v10-rspack`
- `git show codex/1209-css-loader-v10-rspack:docs/v10_upgrade.md | rg -n "css-loader|rspack|Rspack|TBD|PR #TBD|pull/TBD"`

## Notes

Docs-only change. `AGENTS.md` lists docs checks as `n/a` unless touched docs define their own focused check; no code/package files or lockfiles are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the upgrade guide to note a new required `css-loader` version when using the managed Rspack CSS setup.
  * Expanded the install commands for yarn, npm, and pnpm to include the updated dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->