### PR TITLE
Add Babel 8 preset smoke

### DIFF
--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -5,14 +5,14 @@ run `.agents/bin/<name>` in any repo without knowing this repo's specific
 commands. Each script is a thin, repo-owned wrapper. A script that is **absent**
 means that capability is n/a here.
 
-| Script     | Purpose                                  | This repo runs                                                   |
-| ---------- | ---------------------------------------- | ---------------------------------------------------------------- |
-| `setup`    | Install dependencies                     | `bundle install` + `yarn install`                                |
-| `validate` | Pre-push gate (run before pushing)       | `lint` + `test`                                                  |
-| `test`     | Run tests                                | `bundle exec rake test` (rspec) + `yarn test --runInBand` (jest) |
-| `lint`     | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint)                     |
-| `build`    | Build / type-check                       | `yarn build` + `yarn type-check`                                 |
-| `merge-readiness-check` | Pre-merge/replay readiness check | Verifies full `gh pr checks` completion, unresolved review threads, mergeability, and historical post-merge timing |
+| Script                  | Purpose                                  | This repo runs                                                                                                     |
+| ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `setup`                 | Install dependencies                     | `bundle install` + `yarn install`                                                                                  |
+| `validate`              | Pre-push gate (run before pushing)       | `lint` + `test`                                                                                                    |
+| `test`                  | Run tests                                | `bundle exec rake test` (rspec) + `yarn test --runInBand` (jest)                                                   |
+| `lint`                  | Lint / format (pass `-A` to fix RuboCop) | `bundle exec rubocop` + `yarn lint` (eslint)                                                                       |
+| `build`                 | Build / type-check                       | `yarn build` + `yarn type-check`                                                                                   |
+| `merge-readiness-check` | Pre-merge/replay readiness check         | Verifies full `gh pr checks` completion, unresolved review threads, mergeability, and historical post-merge timing |
 
 Canonical non-command policy lives in [`../../AGENTS.md`](../../AGENTS.md).
 [`../agent-workflow.yml`](../agent-workflow.yml) is retained only as a

--- a/.github/workflows/babel8-smoke.yml
+++ b/.github/workflows/babel8-smoke.yml
@@ -9,7 +9,6 @@ on:
       - "package.json"
       - "yarn.lock"
       - "package/babel/**"
-      - "package/rules/babel.ts"
       - "package/utils/**"
       - "test/packages/babel8-smoke.test.js"
   pull_request:
@@ -18,7 +17,6 @@ on:
       - "package.json"
       - "yarn.lock"
       - "package/babel/**"
-      - "package/rules/babel.ts"
       - "package/utils/**"
       - "test/packages/babel8-smoke.test.js"
   workflow_dispatch:

--- a/.github/workflows/babel8-smoke.yml
+++ b/.github/workflows/babel8-smoke.yml
@@ -1,0 +1,57 @@
+name: Babel 8 smoke
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/babel8-smoke.yml"
+      - "package.json"
+      - "yarn.lock"
+      - "package/babel/**"
+      - "package/rules/babel.ts"
+      - "package/utils/**"
+      - "test/packages/babel8-smoke.test.js"
+  pull_request:
+    paths:
+      - ".github/workflows/babel8-smoke.yml"
+      - "package.json"
+      - "yarn.lock"
+      - "package/babel/**"
+      - "package/rules/babel.ts"
+      - "package/utils/**"
+      - "test/packages/babel8-smoke.test.js"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  babel8-smoke:
+    name: Babel 8 smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --non-interactive --prefer-offline
+
+      - name: Build TypeScript
+        run: yarn build
+
+      - name: Babel 8 smoke
+        run: yarn jest test/packages/babel8-smoke.test.js --runInBand
+        env:
+          BABEL_ENV: production
+          RUN_BABEL8_SMOKE: "1"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -82,8 +82,7 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.sha }}
           if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '^.github/workflows'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            response=$(curl -sf https://api.github.com/repos/rhysd/actionlint/releases/latest)
-            if [ $? -eq 0 ]; then
+            if response=$(curl -sf https://api.github.com/repos/rhysd/actionlint/releases/latest); then
               actionlint_version=$(echo "$response" | jq -r .tag_name)
               if [ -z "$actionlint_version" ]; then
                 echo "Failed to parse Actionlint version"
@@ -141,7 +140,7 @@ jobs:
             --skipLibCheck \
             --moduleResolution bundler \
             --types node \
-            *.d.ts
+            ./*.d.ts
   test:
     name: Testing
     strategy:

--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -4,6 +4,10 @@
 // Babel 7. Enable this smoke with RUN_BABEL8_SMOKE=1 after `yarn build`; it
 // installs Babel 8 packages into a temp app and runs Webpack through
 // babel-loader 10 with Shakapacker's built Babel preset.
+//
+// Keep the pinned Babel 8 package versions below in sync during Babel
+// compatibility reviews. This smoke covers the published preset path; the
+// babel-loader version guard is covered by test/package/rules/babel.test.js.
 
 const { spawnSync } = require("child_process")
 const fs = require("fs")

--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -8,6 +8,8 @@
 // Keep the pinned Babel 8 package versions below in sync during Babel
 // compatibility reviews. This smoke covers the published preset path; the
 // babel-loader version guard is covered by test/package/rules/babel.test.js.
+// Babel 8 transform targets are app-owned, so this avoids asserting
+// target-sensitive downlevel output.
 
 const { spawnSync } = require("child_process")
 const fs = require("fs")
@@ -104,6 +106,8 @@ const appRequire = createRequire(path.join(workRoot, "package.json"))
 
 const compiler = webpack({
   mode: "development",
+  devtool: false,
+  target: ["web", "es5"],
   context: workRoot,
   entry: path.join(srcDir, "index.js"),
   output: {
@@ -242,8 +246,7 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
       env: { ...process.env, BABEL_ENV: "production" }
     })
 
-    expect(fs.readFileSync(path.join(distDir, "bundle.js"), "utf8")).toContain(
-      "42"
-    )
+    const bundle = fs.readFileSync(path.join(distDir, "bundle.js"), "utf8")
+    expect(bundle).toContain("42")
   }, 180000)
 })

--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -1,0 +1,245 @@
+// Opt-in Babel 8 compatibility smoke.
+//
+// The normal test suite intentionally keeps repository development pins on
+// Babel 7. Enable this smoke with RUN_BABEL8_SMOKE=1 after `yarn build`; it
+// installs Babel 8 packages into a temp app and runs Webpack through
+// babel-loader 10 with Shakapacker's built Babel preset.
+
+const { spawnSync } = require("child_process")
+const fs = require("fs")
+const { createRequire } = require("module")
+const os = require("os")
+const path = require("path")
+
+const repoRoot = path.resolve(__dirname, "../..")
+const builtPackageDir = path.join(repoRoot, "package")
+const builtPresetPath = path.join(builtPackageDir, "babel/preset.js")
+const webpackPath = require.resolve("webpack")
+const babel8SmokePackages = [
+  "@babel/core@8.0.1",
+  "@babel/plugin-transform-runtime@8.0.1",
+  "@babel/preset-env@8.0.2",
+  "@babel/runtime@8.0.0",
+  "babel-loader@10.1.1"
+]
+const optedIn = process.env.RUN_BABEL8_SMOKE === "1"
+const coreIsBuilt = fs.existsSync(builtPresetPath)
+
+const toolVersion = (cmd) => {
+  const r = spawnSync(cmd, ["--version"], {
+    encoding: "utf8",
+    cwd: os.tmpdir()
+  })
+  return r.status === 0 ? r.stdout.trim() : null
+}
+
+const npmVersion = toolVersion("npm")
+const hasNpm = npmVersion !== null
+const shouldRun = optedIn && coreIsBuilt && hasNpm
+
+const run = (cmd, args, options) => {
+  const r = spawnSync(cmd, args, {
+    encoding: "utf8",
+    timeout: 180000,
+    ...options
+  })
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${options.cwd}\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`
+    )
+  }
+  return r
+}
+
+const packageVersion = (appRequire, packageName) => {
+  const packageJsonPath = appRequire.resolve(`${packageName}/package.json`)
+  return appRequire(packageJsonPath).version
+}
+
+const installBuiltShakapackerPackage = (workRoot) => {
+  const packageRoot = path.join(workRoot, "node_modules/shakapacker")
+  const sourcePackageJson = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
+  )
+  fs.mkdirSync(packageRoot, { recursive: true })
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: sourcePackageJson.name,
+        version: sourcePackageJson.version,
+        private: true,
+        main: sourcePackageJson.main,
+        exports: sourcePackageJson.exports,
+        files: sourcePackageJson.files
+      },
+      null,
+      2
+    )
+  )
+
+  fs.cpSync(builtPackageDir, path.join(packageRoot, "package"), {
+    recursive: true
+  })
+}
+
+const writeWebpackSmokeRunner = ({ workRoot, srcDir, distDir, presetPath }) => {
+  const runnerPath = path.join(workRoot, "run-webpack-smoke.cjs")
+  fs.writeFileSync(
+    runnerPath,
+    `
+const { createRequire } = require("module")
+const path = require("path")
+const webpack = require(${JSON.stringify(webpackPath)})
+
+const workRoot = ${JSON.stringify(workRoot)}
+const srcDir = ${JSON.stringify(srcDir)}
+const distDir = ${JSON.stringify(distDir)}
+const presetPath = ${JSON.stringify(presetPath)}
+const appRequire = createRequire(path.join(workRoot, "package.json"))
+
+const compiler = webpack({
+  mode: "development",
+  context: workRoot,
+  entry: path.join(srcDir, "index.js"),
+  output: {
+    path: distDir,
+    filename: "bundle.js"
+  },
+  module: {
+    rules: [
+      {
+        test: /\\.js$/,
+        include: srcDir,
+        use: [
+          {
+            loader: appRequire.resolve("babel-loader"),
+            options: {
+              cacheDirectory: false,
+              cwd: workRoot,
+              envName: "production",
+              presets: [presetPath]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  optimization: {
+    minimize: false
+  }
+})
+
+const finish = (failure) => {
+  compiler.close((closeError) => {
+    const finalError = closeError || failure
+    if (finalError) {
+      console.error(finalError.stack || finalError.message || String(finalError))
+      process.exit(1)
+    }
+  })
+}
+
+compiler.run((error, stats) => {
+  if (error) {
+    finish(error)
+    return
+  }
+
+  if (stats.hasErrors()) {
+    finish(
+      new Error(
+        stats.toString({
+          all: false,
+          errors: true,
+          errorDetails: true,
+          moduleTrace: true
+        })
+      )
+    )
+    return
+  }
+
+  finish()
+})
+`
+  )
+  return runnerPath
+}
+
+const computeSkipReason = () => {
+  if (!optedIn) return "RUN_BABEL8_SMOKE=1 not set"
+  if (!coreIsBuilt) return "shakapacker not built (run `yarn build`)"
+  if (!hasNpm) return "npm unavailable on PATH"
+  return "unknown skip reason"
+}
+
+describe("Babel 8 preset smoke (issue #1191)", () => {
+  let workRoot
+
+  beforeAll(() => {
+    if (!shouldRun) return
+
+    workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shaka-babel8-smoke-"))
+    fs.writeFileSync(
+      path.join(workRoot, "package.json"),
+      JSON.stringify({ name: "shaka-babel8-smoke", private: true }, null, 2)
+    )
+    run(
+      "npm",
+      [
+        "install",
+        "--no-audit",
+        "--no-fund",
+        "--save-dev",
+        ...babel8SmokePackages
+      ],
+      { cwd: workRoot }
+    )
+    installBuiltShakapackerPackage(workRoot)
+  }, 180000)
+
+  afterAll(() => {
+    if (!workRoot) return
+    fs.rmSync(workRoot, { recursive: true, force: true })
+  })
+
+  if (!shouldRun) {
+    test.todo(`Babel 8 smoke skipped (${computeSkipReason()})`)
+    return
+  }
+
+  test("compiles through babel-loader 10 with the Shakapacker Babel preset and Babel 8", () => {
+    const srcDir = path.join(workRoot, "src")
+    const distDir = path.join(workRoot, "dist")
+    fs.mkdirSync(srcDir)
+    const entryPath = path.join(srcDir, "index.js")
+    fs.writeFileSync(entryPath, "var answer = 42;\nconsole.log(answer);\n")
+
+    const appRequire = createRequire(path.join(workRoot, "package.json"))
+    const presetPath = appRequire.resolve("shakapacker/package/babel/preset.js")
+    expect(packageVersion(appRequire, "@babel/core")).toBe("8.0.1")
+    expect(packageVersion(appRequire, "@babel/preset-env")).toBe("8.0.2")
+    expect(packageVersion(appRequire, "@babel/plugin-transform-runtime")).toBe(
+      "8.0.1"
+    )
+    expect(packageVersion(appRequire, "@babel/runtime")).toBe("8.0.0")
+    expect(packageVersion(appRequire, "babel-loader")).toBe("10.1.1")
+
+    const runnerPath = writeWebpackSmokeRunner({
+      workRoot,
+      srcDir,
+      distDir,
+      presetPath
+    })
+
+    run(process.execPath, [runnerPath], {
+      cwd: workRoot,
+      env: { ...process.env, BABEL_ENV: "production" }
+    })
+
+    expect(fs.readFileSync(path.join(distDir, "bundle.js"), "utf8")).toContain(
+      "42"
+    )
+  }, 180000)
+})


### PR DESCRIPTION
## Summary
- add an opt-in Babel 8 smoke test under `test/packages/` that installs exact Babel 8 plus `babel-loader` 10 versions into a temp npm app
- compile a fixture through Webpack using Shakapacker's built Babel preset copied into a temp consumer `node_modules/shakapacker` layout
- add a dedicated Babel 8 smoke workflow on Node 22 with narrow path filters plus `workflow_dispatch`, without changing normal Babel 7 dev pins
- fix existing node workflow actionlint findings that would block workflow-change PRs

Closes #1191

## Local validation
- `yarn install --frozen-lockfile --non-interactive --prefer-offline`
- `yarn build`
- `BABEL_ENV=production RUN_BABEL8_SMOKE=1 node node_modules/jest/bin/jest.js test/packages/babel8-smoke.test.js --runInBand --no-cache`
- `node node_modules/eslint/bin/eslint.js test/packages/babel8-smoke.test.js`
- `node node_modules/prettier/bin/prettier.cjs --check .github/workflows/babel8-smoke.yml .github/workflows/node.yml test/packages/babel8-smoke.test.js`
- `actionlint .github/workflows/babel8-smoke.yml .github/workflows/node.yml`
- `git diff --check origin/main...HEAD`