### PR TITLE
Fix .cjs matching in webpack transpiler rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed webpack Babel, SWC, and esbuild rules skipping explicitly included `.cjs` files.** [PR #1219](https://github.com/shakacode/shakapacker/pull/1219) by [oiahoon](https://github.com/oiahoon). Fixes [#1218](https://github.com/shakacode/shakapacker/issues/1218).
+
 ## [v10.3.0] - July 5, 2026
 
 ### Added

--- a/package/rules/babel.ts
+++ b/package/rules/babel.ts
@@ -38,7 +38,7 @@ export = loaderMatches(javascriptTranspiler, "babel", () => {
   validateBabelLoaderCompatibility()
 
   return {
-    test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
+    test: /\.(js|jsx|mjs|cjs|ts|tsx|coffee)?(\.erb)?$/,
     ...jscommon,
     use: [
       {

--- a/package/rules/esbuild.ts
+++ b/package/rules/esbuild.ts
@@ -4,7 +4,7 @@ const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const jscommon = require("./jscommon")
 
 export = loaderMatches(javascriptTranspiler, "esbuild", () => ({
-  test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
+  test: /\.(ts|tsx|js|jsx|mjs|cjs|coffee)?(\.erb)?$/,
   ...jscommon,
   use: ({ resource }: { resource: string }) => getEsbuildLoaderConfig(resource)
 }))

--- a/package/rules/swc.ts
+++ b/package/rules/swc.ts
@@ -4,7 +4,7 @@ const { javascript_transpiler: javascriptTranspiler } = require("../config")
 const jscommon = require("./jscommon")
 
 export = loaderMatches(javascriptTranspiler, "swc", () => ({
-  test: /\.(ts|tsx|js|jsx|mjs|coffee)?(\.erb)?$/,
+  test: /\.(ts|tsx|js|jsx|mjs|cjs|coffee)?(\.erb)?$/,
   ...jscommon,
   use: ({ resource }: { resource: string }) => getSwcLoaderConfig(resource)
 }))

--- a/test/package/rules/babel.test.js
+++ b/test/package/rules/babel.test.js
@@ -141,6 +141,14 @@ if (!babelConfig) {
       await compiler.run()
       expect(tracked[included]).toBeTruthy()
     })
+
+    test("explicitly included .cjs files should be transpiled", async () => {
+      const included = `${pathToNodeModulesIncluded}/a.cjs`
+      const [tracked, loader] = createTrackLoader()
+      const compiler = createTestCompiler(createWebpackConfig(included, loader))
+      await compiler.run()
+      expect(tracked[included]).toBeTruthy()
+    })
   })
 } // end of else block for babelConfig check
 

--- a/test/package/rules/esbuild.test.js
+++ b/test/package/rules/esbuild.test.js
@@ -65,4 +65,12 @@ describe("esbuild", () => {
     await compiler.run()
     expect(tracked[included]).toBeTruthy()
   })
+
+  test("explicitly included .cjs files should be transpiled", async () => {
+    const included = `${pathToNodeModulesIncluded}/a.cjs`
+    const [tracked, loader] = createTrackLoader()
+    const compiler = createTestCompiler(createWebpackConfig(included, loader))
+    await compiler.run()
+    expect(tracked[included]).toBeTruthy()
+  })
 })

--- a/test/package/rules/swc.test.js
+++ b/test/package/rules/swc.test.js
@@ -66,5 +66,13 @@ if (!swcConfig) {
       await compiler.run()
       expect(tracked[included]).toBeTruthy()
     })
+
+    test("explicitly included .cjs files should be transpiled", async () => {
+      const included = `${pathToNodeModulesIncluded}/a.cjs`
+      const [tracked, loader] = createTrackLoader()
+      const compiler = createTestCompiler(createWebpackConfig(included, loader))
+      await compiler.run()
+      expect(tracked[included]).toBeTruthy()
+    })
   })
 } // end of else block for swcConfig check


### PR DESCRIPTION
### Summary

- include `.cjs` resources in the Babel, SWC, and esbuild webpack transpiler rule predicates
- add focused in-memory webpack coverage for explicitly included `.cjs` files across all three transpilers
- document the fix in the Unreleased changelog

Fixes #1218.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file
- [x] Before merge, verify the current head with the repository merge-readiness check after CI and review threads settle

### Validation

- focused rule tests: 18 passed
- full Jest suite after build: 63 suites passed, 649 tests passed, 2 todo
- `yarn build`
- `yarn type-check`
- `yarn lint`
- RuboCop: 172 files, no offenses
- Prettier and `git diff --check`

The full Ruby task ran 1,274 examples with 13 failures and 6 pending. The 13 failures are confined to Yarn-classic runner cases where Corepack requests the retired `yarn-1.2.3.tgz` URL and receives HTTP 404. Running those same runner specs on unchanged `origin/main` reproduced the identical 13 failures (141 examples, 13 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transpilation for explicitly included CommonJS `.cjs` files when using Babel, SWC, or esbuild.
  * Ensured eligible `.cjs` files in included dependencies are processed consistently.

* **Tests**
  * Added coverage verifying `.cjs` files are transpiled correctly across all three build tools.

* **Documentation**
  * Added the fix to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Coordinator verification

- Security preflight on issue #1218 and PR #1219: clean; no suspicious text, incomplete API coverage, high-risk files, secrets, commands, dependencies, hooks, workflows, or agent-instruction changes.
- Reversible pre-fix proof: removing only the three `cjs` regex alternatives produced exactly three failures (the new `.cjs` loader assertions), with the other 15 focused assertions passing.
- Restored current head `2e78a238d68d8057717dda11d9a16c60f345a97c`: 3 focused suites and all 18 tests passed.
- Changed-file ESLint, `yarn type-check`, Prettier, and `git diff --check origin/main...HEAD`: passed.
- Independent adversarial review: no code-level `BLOCKING` or `DISCUSS` finding; regex boundaries, Babel/SWC/esbuild loader semantics, compatibility, security, and excluded scope were verified independently.
- Address-review: zero must-fix, discuss, optional, inline, or unresolved-thread items; [cutoff-safe summary](https://github.com/shakacode/shakapacker/pull/1219#issuecomment-4972776828).
- Current-head hosted matrix: all visible checks passed after the held fork workflows were explicitly approved; the zero-job `pull_request_review` workflow triggered by CodeRabbit was re-requested and recorded its expected skipped result, clearing the stale merge-state flag.
- Review churn: the existing contributor head was accepted unchanged; zero follow-up commits, zero fix rounds, and zero CI reruns caused by code churn.

## Codex Decision Log

- **Non-blocking:** Keep Rspack, `.cts` / `.mts`, and Babel project-wide configuration outside this fix.
  - **Decision:** Limit the change to the Babel, SWC, and esbuild webpack rule predicates and their focused tests.
  - **Why:** Rspack uses separate built-in SWC rules and hard-excludes `node_modules`; `.cts` / `.mts` need parser/loader handling beyond a regex; Babel config scope is a separate package-boundary concern.
  - **Review later:** Consider separate issues only if those independently scoped behaviors are desired.
- **Non-blocking:** An independent checker suggested a separate maintainer-approval gate for this runtime-behavior lane.
  - **Decision:** Do not add an unstated gate.
  - **Why:** This repository's ordinary-development policy requires the full current-head check list green, all review threads resolved, and a clean merge state; the maintainer directly supplied `auto_merge_when_gates_pass` authority for this exact target.
  - **Review later:** None.

### QA Evidence

- QA lane: `pr1219-checker-20260714T184500Z`, detached worktree `/Users/justin/.codex/worktrees/shakapacker-pr1219-checker`; private claim not applicable to the read-only independent checker.
- Scope checked: PR #1219 at the exact current head; Babel, SWC, and esbuild `.cjs` rule selection, loader mapping, regex boundaries, existing-extension compatibility, excluded Rspack/typed-extension scope, security, changelog, reviews, and CI.
- Tested at: PR #1219 head `2e78a238d68d8057717dda11d9a16c60f345a97c`.
- Automated checks: fail-before/pass-after focused Jest proof; 3 suites/18 current-head tests; changed-file ESLint; `yarn type-check`; Prettier; `git diff --check`; full current-head GitHub Actions matrix.
- Manual checks: regex boundaries accepted `.cjs` and `.cjs.erb` while rejecting `.cjsx`, `.notcjs`, `.cjs.map`, `.cts`, `.mts`, and `.CJS`; Babel/SWC/esbuild loader mappings inspected.
- Findings: none remaining; the held-fork-CI gate was cleared by approving the exact current-head runs.
- QA required: yes.
- QA required rationale: package/runtime rule behavior warranted independent fail-before/pass-after proof and current-head matrix validation.
- QA lane status: satisfied.
- Release-blocking status: clear.
- Process-gap disposition: not applicable.

<!-- qa-evidence v1
required: yes
status: satisfied
head_sha: 2e78a238d68d8057717dda11d9a16c60f345a97c
tested_at: PR #1219 head 2e78a238d68d8057717dda11d9a16c60f345a97c
scope: Babel SWC and esbuild cjs rule selection loader mapping regex boundaries compatibility security changelog reviews and CI
automated_checks: fail-before and pass-after focused Jest plus ESLint type-check Prettier diff-check and full current-head Actions matrix
manual_checks: regex boundary cases and loader mappings independently inspected
findings: none
release_blocking: clear
process_gap_disposition: not applicable
-->

<!-- priority-finding-dispositions v1
status: not_applicable
head_sha: 2e78a238d68d8057717dda11d9a16c60f345a97c
-->
