### PR TITLE
Fix 502s from proxied packs under rack-proxy v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - **Fixed webpack Babel, SWC, and esbuild rules skipping explicitly included `.cjs` files.** [PR #1219](https://github.com/shakacode/shakapacker/pull/1219) by [oiahoon](https://github.com/oiahoon). Fixes [#1218](https://github.com/shakacode/shakapacker/issues/1218).
+- **Fixed 502 responses for proxied dev server assets under `rack-proxy` v1.** [PR #1222](https://github.com/shakacode/shakapacker/pull/1222) by [jcbpl](https://github.com/jcbpl). Fixes [#1220](https://github.com/shakacode/shakapacker/issues/1220).
 
 ## [v10.3.0] - July 5, 2026
 

--- a/lib/shakapacker/dev_server_proxy.rb
+++ b/lib/shakapacker/dev_server_proxy.rb
@@ -11,6 +11,8 @@ class Shakapacker::DevServerProxy < Rack::Proxy
 
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && dev_server.running?
+      # rack-proxy v1 refuses to derive the backend from the Host header.
+      env["rack.backend"] = URI("#{dev_server.protocol}://#{dev_server.host_with_port}")
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = dev_server.host
       env["HTTP_X_FORWARDED_SERVER"] = dev_server.host_with_port
       env["HTTP_PORT"] = env["HTTP_X_FORWARDED_PORT"] = dev_server.port.to_s

--- a/lib/shakapacker/dev_server_proxy.rb
+++ b/lib/shakapacker/dev_server_proxy.rb
@@ -12,7 +12,9 @@ class Shakapacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && dev_server.running?
       # rack-proxy v1 refuses to derive the backend from the Host header.
-      env["rack.backend"] = URI("#{dev_server.protocol}://#{dev_server.host_with_port}")
+      env["rack.backend"] = URI::Generic.build(
+        scheme: dev_server.protocol, host: dev_server.host, port: dev_server.port
+      )
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = dev_server.host
       env["HTTP_X_FORWARDED_SERVER"] = dev_server.host_with_port
       env["HTTP_PORT"] = env["HTTP_X_FORWARDED_PORT"] = dev_server.port.to_s

--- a/spec/shakapacker/dev_server_proxy_spec.rb
+++ b/spec/shakapacker/dev_server_proxy_spec.rb
@@ -1,0 +1,89 @@
+require_relative "spec_helper_initializer"
+
+require "socket"
+require "shakapacker/dev_server_proxy"
+
+describe "Shakapacker::DevServerProxy" do
+  PACK_RESPONSE_BODY = "console.log('hi');".freeze
+
+  def with_dev_server_listening
+    server = TCPServer.new("127.0.0.1", 0)
+
+    thread = Thread.new do
+      socket = server.accept
+      loop do
+        line = socket.gets
+        break if line.nil? || line == "\r\n"
+      end
+      socket.write(
+        "HTTP/1.1 200 OK\r\n" \
+        "Content-Type: application/javascript\r\n" \
+        "Content-Length: #{PACK_RESPONSE_BODY.bytesize}\r\n" \
+        "\r\n#{PACK_RESPONSE_BODY}"
+      )
+      socket.close
+    rescue IOError, Errno::EBADF, Errno::ECONNRESET
+      nil
+    end
+
+    yield server.addr[1]
+  ensure
+    thread&.kill
+    server&.close
+  end
+
+  def rack_env(path)
+    Rack::MockRequest.env_for("https://example.com#{path}")
+  end
+
+  # The streaming body responds to #each but is not Enumerable.
+  def read_body(response)
+    body = response[2]
+    buffer = +""
+    body.each { |chunk| buffer << chunk }
+    buffer
+  ensure
+    body.close if body.respond_to?(:close)
+  end
+
+  let(:app) { ->(_env) { [204, {}, []] } }
+  let(:proxy) { Shakapacker::DevServerProxy.new(app) }
+
+  around do |example|
+    with_rails_env("development") { example.run }
+  end
+
+  context "when the dev server is running" do
+    around do |example|
+      with_dev_server_listening do |port|
+        @port = port
+        example.run
+      end
+    end
+
+    before do
+      dev_server = Shakapacker.dev_server
+      allow(dev_server).to receive(:running?).and_return(true)
+      allow(dev_server).to receive(:host).and_return("127.0.0.1")
+      allow(dev_server).to receive(:port).and_return(@port)
+      allow(dev_server).to receive(:host_with_port).and_return("127.0.0.1:#{@port}")
+    end
+
+    it "proxies a request for a pack to the dev server" do
+      response = proxy.call(rack_env("/packs/application.js"))
+
+      expect(response[0]).to eq 200
+      expect(read_body(response)).to eq PACK_RESPONSE_BODY
+    end
+
+    it "passes a request outside the output path to the app" do
+      expect(proxy.call(rack_env("/home"))[0]).to eq 204
+    end
+  end
+
+  it "passes a request for a pack to the app when the dev server is not running" do
+    allow(Shakapacker.dev_server).to receive(:running?).and_return(false)
+
+    expect(proxy.call(rack_env("/packs/application.js"))[0]).to eq 204
+  end
+end


### PR DESCRIPTION
### Summary

As of [1.0.0](https://github.com/ncr/rack-proxy/releases/tag/v1.0.0), rack-proxy refuses to derive a backend from the request's `Host` header unless the app opts in. The dev server proxy set `HTTP_HOST` and relied on that derivation, so on v1 every proxied asset request gets a 502. The gemspec sets no upper bound, so any app resolving its dependencies fresh installs v1.

This sets `env["rack.backend"]` to the dev server's URI. Passing `allow_dynamic_backend: true` would also work, since the `Host` is overwritten from config rather than supplied by the client, but the URI also carries the port and scheme, which previously reached the backend only through `X-Forwarded-Port` and `X-Forwarded-Proto`. Older rack-proxy releases honor the same key, so the dependency constraint is unchanged and the spec passes on both 0.7.7 and 1.0.1.

The proxy previously had no spec. The new one serves the request from a TCP socket rather than a stubbed `Net::HTTP`, so the proxy has to resolve the backend and connect. `Gemfile.lock` stays on 0.7.7 because the `gemfiles/` matrix leaves rack-proxy unpinned and resolves it fresh, so those jobs exercise v1. The Ruby 2.7 legs cover 0.x, since rack-proxy 1.0 requires Ruby 3.0.

Fixes #1220

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file
- [ ] Before merge, verify the current head with `.agents/bin/merge-readiness-check <PR_NUMBER>` so the full `gh pr checks` list and review threads are settled, not only required checks

### Other Information

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development-server asset requests that could return 502 errors under `rack-proxy` v1.
  * Improved proxying for matching asset paths while preserving pass-through behavior for other requests or when the development server is unavailable.

* **Tests**
  * Added coverage for proxying, pass-through behavior, and development-server availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->