### PR TITLE
Fix false-positive dev server liveness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- **Fixed dev-server liveness checks treating refused macOS 27 connections as running.** The Ruby probe now verifies the connected socket's `SO_ERROR` result before proxying asset requests, avoiding false-positive dev-server detection and resulting 502 responses. Fixes [#1224](https://github.com/shakacode/shakapacker/issues/1224).
 - **Fixed webpack Babel, SWC, and esbuild rules skipping explicitly included `.cjs` files.** [PR #1219](https://github.com/shakacode/shakapacker/pull/1219) by [oiahoon](https://github.com/oiahoon). Fixes [#1218](https://github.com/shakacode/shakapacker/issues/1218).
 
 ## [v10.3.0] - July 5, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- **Fixed dev-server liveness checks treating refused macOS 27 connections as running.** The Ruby probe now verifies the connected socket's `SO_ERROR` result before proxying asset requests, avoiding false-positive dev-server detection and resulting 502 responses. Fixes [#1224](https://github.com/shakacode/shakapacker/issues/1224).
+- **Fixed dev-server liveness checks treating refused macOS 27 connections as running.** The Ruby probe now verifies the connected socket's `SO_ERROR` result before proxying asset requests, avoiding false-positive dev-server detection and resulting 502 responses. [PR #1225](https://github.com/shakacode/shakapacker/pull/1225) by [justin808](https://github.com/justin808). Fixes [#1224](https://github.com/shakacode/shakapacker/issues/1224).
 - **Fixed webpack Babel, SWC, and esbuild rules skipping explicitly included `.cjs` files.** [PR #1219](https://github.com/shakacode/shakapacker/pull/1219) by [oiahoon](https://github.com/oiahoon). Fixes [#1218](https://github.com/shakacode/shakapacker/issues/1218).
 
 ## [v10.3.0] - July 5, 2026

--- a/lib/shakapacker/dev_server.rb
+++ b/lib/shakapacker/dev_server.rb
@@ -47,8 +47,13 @@ class Shakapacker::DevServer
   # @return [Boolean] true if the dev server is running
   def running?
     if config.dev_server.present?
-      Socket.tcp(host, port, connect_timeout: connect_timeout).close
-      true
+      socket = Socket.tcp(host, port, connect_timeout: connect_timeout)
+
+      begin
+        socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int.zero?
+      ensure
+        socket.close
+      end
     else
       false
     end

--- a/spec/shakapacker/dev_server_spec.rb
+++ b/spec/shakapacker/dev_server_spec.rb
@@ -13,11 +13,13 @@ describe "DevServer" do
     allow(socket).to receive(:getsockopt)
       .with(Socket::SOL_SOCKET, Socket::SO_ERROR)
       .and_return(socket_error)
-    expect(socket).to receive(:close)
+    allow(socket).to receive(:close)
 
     with_rails_env("development") do
       expect(Shakapacker.dev_server.running?).to be false
     end
+
+    expect(socket).to have_received(:close)
   end
 
   it "runs when the connected socket reports no error" do
@@ -28,11 +30,13 @@ describe "DevServer" do
     allow(socket).to receive(:getsockopt)
       .with(Socket::SOL_SOCKET, Socket::SO_ERROR)
       .and_return(socket_error)
-    expect(socket).to receive(:close)
+    allow(socket).to receive(:close)
 
     with_rails_env("development") do
       expect(Shakapacker.dev_server.running?).to be true
     end
+
+    expect(socket).to have_received(:close)
   end
 
   it "uses localhost as host in development environment" do

--- a/spec/shakapacker/dev_server_spec.rb
+++ b/spec/shakapacker/dev_server_spec.rb
@@ -5,6 +5,36 @@ describe "DevServer" do
     expect(Shakapacker.dev_server.running?).to be_falsy
   end
 
+  it "doesn't run when the connected socket reports an error" do
+    socket = instance_double(Socket)
+    socket_error = instance_double(Socket::Option, int: Errno::ECONNREFUSED::Errno)
+
+    allow(Socket).to receive(:tcp).and_return(socket)
+    allow(socket).to receive(:getsockopt)
+      .with(Socket::SOL_SOCKET, Socket::SO_ERROR)
+      .and_return(socket_error)
+    expect(socket).to receive(:close)
+
+    with_rails_env("development") do
+      expect(Shakapacker.dev_server.running?).to be false
+    end
+  end
+
+  it "runs when the connected socket reports no error" do
+    socket = instance_double(Socket)
+    socket_error = instance_double(Socket::Option, int: 0)
+
+    allow(Socket).to receive(:tcp).and_return(socket)
+    allow(socket).to receive(:getsockopt)
+      .with(Socket::SOL_SOCKET, Socket::SO_ERROR)
+      .and_return(socket_error)
+    expect(socket).to receive(:close)
+
+    with_rails_env("development") do
+      expect(Shakapacker.dev_server.running?).to be true
+    end
+  end
+
   it "uses localhost as host in development environment" do
     with_rails_env("development") do
       expect(Shakapacker.dev_server.host).to eq "localhost"


### PR DESCRIPTION
## Summary

- verify a connected dev-server probe socket has a zero `SO_ERROR` before reporting it as running
- close the probe socket on healthy, refused, and option-read paths
- add regression coverage for the macOS 27/Ruby phantom-connect behavior and document the fix in Unreleased

Closes #1224.

## Why

On macOS 27, Ruby's `Socket.tcp` can return a socket even though the connection was refused, with the failure still present in `SO_ERROR`. Treating that socket as healthy makes Shakapacker proxy `/packs` requests to a nonexistent dev server and return 502 responses.

## Validation

- RED: `bundle exec rspec spec/shakapacker/dev_server_spec.rb:8 --format documentation` failed before the implementation with `expected false, got true`
- GREEN: the same example passed after the implementation
- `.agents/bin/validate` at implementation commit `3a388b3c7b2668c82d3897c3bf9ef101f1e1e613`
  - RuboCop: 146 files, no offenses
  - ESLint: passed
  - Ruby: 1,276 examples, 0 failures, 6 pending
  - dummy webpack and Rspack apps: 3 examples each, 0 failures
  - generator specs: 77 examples, 0 failures
  - Jest: 63 suites, 649 passed, 2 todo
- Ruby 2.7.8 syntax and live `getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int` compatibility probe
- current-head review-fix validation: `.agents/bin/lint`; 1,276 gem examples with 0 failures; changelog Prettier; `git diff --check`
- independent Sol/xhigh adversarial review at implementation commit `3a388b3c7b2668c82d3897c3bf9ef101f1e1e613`: no `BLOCKING` or `DISCUSS` findings
- `git diff --check origin/main...HEAD`

## Codex Decision Log

- **Non-blocking:** Whether the probe should retry or perform an application-layer health check.
  - **Decision:** Check only `SO_ERROR` on the socket returned by `Socket.tcp`.
  - **Why:** This is the minimum condition needed to reject the reported phantom connection without adding latency or changing dev-server readiness policy.
  - **Review later:** None.
- **Non-blocking:** Whether to add explicit specs for `getsockopt` and `close` raising.
  - **Decision:** Keep the focused zero/nonzero `SO_ERROR` coverage in this PR.
  - **Why:** The existing method-level rescue already preserves fail-closed behavior for probe and cleanup exceptions; the independent review classified extra exception-path specs as optional hardening.
  - **Review later:** Consider only if this area needs broader socket-failure coverage.

### QA Evidence

- QA lane: not required; a single narrow, non-UI socket-probe behavior was covered by deterministic regression specs, full repository validation, and an independent checker
- Scope checked: `DevServer#running?`, socket error/closure behavior, Ruby 2.7 compatibility, focused specs, changelog, and the full repository validation surface
- Tested at: current head `24ebaa40d27d433e1b51d70a9ff5c9b26acab1d8`; full repository validation and adversarial review at implementation commit `3a388b3c7b2668c82d3897c3bf9ef101f1e1e613`
- Automated checks: fail-before/pass-after focused RSpec; full `.agents/bin/validate` at the implementation commit; current-head lint and 1,276 gem examples; Prettier; Ruby 2.7.8 syntax/API checks; `git diff --check`
- Manual checks: exact base implementation inspected against the regression mechanism; independent adversarial review of correctness, compatibility, minimality, changelog, and exception paths
- User-visible UI change: no
- Visual evidence: not applicable: no user-visible UI change
- Interaction change: no; the change only corrects an internal TCP liveness decision
- Interaction evidence: not applicable: no user interaction change
- Visual fix: no; this is a socket-probe correctness fix
- Negative control: not applicable: no visual fix
- Performance evidence: not applicable: one `SO_ERROR` syscall is added to a short-lived control-plane probe; no rendered-page, asset, or bundle surface changes
- Findings: none blocking; independent review classified explicit exception-path specs as optional follow-up hardening
- QA required: no
- QA required rationale: the change is narrow, non-UI, deterministically covered, and independently reviewed; it does not meet the repository's broad-runtime QA-lane threshold
- QA lane status: not_applicable
- Release-blocking status: not_applicable
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: no
status: not_applicable
head_sha: 24ebaa40d27d433e1b51d70a9ff5c9b26acab1d8
tested_at: full repository validation and adversarial review at implementation commit 3a388b3c7b2668c82d3897c3bf9ef101f1e1e613 with current review-fix validation at head 24ebaa40d27d433e1b51d70a9ff5c9b26acab1d8
scope: DevServer running probe socket error and closure behavior Ruby 2.7 compatibility focused specs changelog full repository validation and independent adversarial review
automated_checks: fail-before and pass-after focused RSpec plus full .agents/bin/validate at implementation commit and current-head lint 1276 gem examples Prettier Ruby 2.7.8 syntax and socket API probe and git diff check
manual_checks: exact base behavior and final diff independently inspected for correctness compatibility minimality changelog and exception paths
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered target
interaction_change: no
interaction_evidence: not applicable: no user interaction change
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: one SO_ERROR syscall on a short-lived control-plane probe and no rendered-page asset or bundle surface change
findings: none blocking; optional exception-path spec hardening does not affect readiness
release_blocking: not_applicable
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
status: not_applicable
head_sha: 24ebaa40d27d433e1b51d70a9ff5c9b26acab1d8
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS 27 development-server liveness detection.
  * Prevented refused connections from being treated as active, avoiding resulting 502 errors when loading assets.
* **Tests**
  * Added coverage for successful and refused connections, including proper socket cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->