### PR TITLE
Update changelog for v10.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@
 
 ## [Unreleased]
 
+## [v10.3.1] - August 3, 2026
+
 ### Fixed
 
 - **Fixed 502 responses for proxied dev server assets under `rack-proxy` v1.** [PR #1222](https://github.com/shakacode/shakapacker/pull/1222) by [jcbpl](https://github.com/jcbpl). Fixes [#1220](https://github.com/shakacode/shakapacker/issues/1220).
 - **Fixed dev-server liveness checks treating refused macOS 27 connections as running.** The Ruby probe now verifies the connected socket's `SO_ERROR` result before proxying asset requests, avoiding false-positive dev-server detection and resulting 502 responses. [PR #1225](https://github.com/shakacode/shakapacker/pull/1225) by [justin808](https://github.com/justin808). Fixes [#1224](https://github.com/shakacode/shakapacker/issues/1224).
 - **Fixed webpack Babel, SWC, and esbuild rules skipping explicitly included `.cjs` files.** [PR #1219](https://github.com/shakacode/shakapacker/pull/1219) by [oiahoon](https://github.com/oiahoon). Fixes [#1218](https://github.com/shakacode/shakapacker/issues/1218).
+- **Added a `shakapacker:doctor` warning for Rspack React Refresh v2 configs that still use the v1 default-export constructor pattern.** [PR #1207](https://github.com/shakacode/shakapacker/pull/1207) by [justin808](https://github.com/justin808). Existing configs with `const ReactRefreshPlugin = require("@rspack/plugin-react-refresh")` followed by `new ReactRefreshPlugin()` can fail after upgrading to `@rspack/plugin-react-refresh` v2 with `ReactRefreshPlugin is not a constructor`; Doctor now points to the affected JS/TS config file and suggests the named-export/default/module compatibility form. Fixes [#1204](https://github.com/shakacode/shakapacker/issues/1204).
+- **Fixed the missing-`@babel/core` failure to report an actionable install message.** [PR #1212](https://github.com/shakacode/shakapacker/pull/1212) by [justin808](https://github.com/justin808). Babel-transpiled builds whose app lacks `@babel/core` previously surfaced a raw module-resolution error from the Babel 8 compatibility check; the rule now explains which package to install and how to switch `javascript_transpiler` instead. Refs [#1163](https://github.com/shakacode/shakapacker/issues/1163).
+
+### Documentation
+
+- **Documented the required `css-loader@^7.1.4` in the v10 Rspack upgrade instructions.** [PR #1211](https://github.com/shakacode/shakapacker/pull/1211) by [justin808](https://github.com/justin808). The v10 upgrade guide's copy-paste Rspack v2 commands omitted `css-loader`, so apps following them could upgrade into an unsatisfied peer dependency.
 
 ## [v10.3.0] - July 5, 2026
 
@@ -26,7 +34,6 @@
 
 - **Fixed implicit SWC defaults for existing webpack/Babel apps without `swc-loader`.** [PR #1206](https://github.com/shakacode/shakapacker/pull/1206) by [justin808](https://github.com/justin808). Webpack apps that omit both `javascript_transpiler` and the deprecated `webpack_loader` now fall back to Babel with a warning when Shakapacker's bundled SWC default is active, `swc-loader` is missing, and Babel is present. Explicit transpiler settings, webpack apps with `swc-loader`, and Rspack's built-in SWC path keep their existing behavior. Closes [#1203](https://github.com/shakacode/shakapacker/issues/1203).
 - **Fixed JavaScript config loading for missing Rails environments to use the production fallback.** [PR #1206](https://github.com/shakacode/shakapacker/pull/1206) by [justin808](https://github.com/justin808). When `RAILS_ENV` has no matching section in `config/shakapacker.yml`, the Node package config now merges the `production` section instead of only bundled defaults, matching Ruby configuration loading and honoring explicit production `javascript_transpiler`, `source_path`, `dev_server`, and related settings for custom environments such as staging.
-- **Added a `shakapacker:doctor` warning for Rspack React Refresh v2 configs that still use the v1 default-export constructor pattern.** [PR #1207](https://github.com/shakacode/shakapacker/pull/1207) by [justin808](https://github.com/justin808). Existing configs with `const ReactRefreshPlugin = require("@rspack/plugin-react-refresh")` followed by `new ReactRefreshPlugin()` can fail after upgrading to `@rspack/plugin-react-refresh` v2 with `ReactRefreshPlugin is not a constructor`; Doctor now points to the affected JS/TS config file and suggests the named-export/default/module compatibility form. Fixes [#1204](https://github.com/shakacode/shakapacker/issues/1204).
 - **Fixed helper binstubs delegating Node resolution to Ruby `exec` in unset and empty `PATH` environments.** [PR #1200](https://github.com/shakacode/shakapacker/pull/1200) and [PR #1201](https://github.com/shakacode/shakapacker/pull/1201) by [justin808](https://github.com/justin808). Restores shell-compatible Node lookup for `bin/shakapacker-config` and `bin/diff-bundler-config` after the `v10.2.0` Ruby-binstub regression, while keeping friendly missing-Node errors for `ENOENT` and `EACCES`.
 
 ## [v10.2.0] - July 3, 2026
@@ -993,7 +1000,8 @@ Note: [Rubygem is 6.3.0.pre.rc.1](https://rubygems.org/gems/shakapacker/versions
 
 See [CHANGELOG.md in rails/webpacker (up to v5.4.3)](https://github.com/rails/webpacker/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.3.0...main
+[Unreleased]: https://github.com/shakacode/shakapacker/compare/v10.3.1...main
+[v10.3.1]: https://github.com/shakacode/shakapacker/compare/v10.3.0...v10.3.1
 [v10.3.0]: https://github.com/shakacode/shakapacker/compare/v10.2.0...v10.3.0
 [v10.2.0]: https://github.com/shakacode/shakapacker/compare/v10.1.0...v10.2.0
 [v10.1.0]: https://github.com/shakacode/shakapacker/compare/v10.0.0...v10.1.0


### PR DESCRIPTION
Stamps the `v10.3.1` release section in `CHANGELOG.md` ahead of the release, and reconciles entries that were misfiled relative to the `v10.3.0` tag.

## Changes

- **Stamped `## [v10.3.1] - August 3, 2026`** immediately after `## [Unreleased]`, moving the three accumulated entries (#1222, #1225, #1219) into it.
- **Moved the PR #1207 entry out of the `v10.3.0` section.** That commit (`9314693f`) merged 2026-07-06, after the `v10.3.0` tag was cut on 2026-07-05, and the entry was not present in `CHANGELOG.md` at the tag. It ships in `v10.3.1`, not `v10.3.0`.
- **Added two missing entries** for post-tag PRs:
  - #1212 — Babel rule now raises an actionable "install `@babel/core`" message instead of a raw module-resolution error.
  - #1211 — v10 upgrade guide's Rspack v2 commands were missing the required `css-loader@^7.1.4`.
- **Updated compare links**: `[Unreleased]` now compares from `v10.3.1...main`, plus a new `[v10.3.1]: v10.3.0...v10.3.1` link.

## Classification sweep (`v10.3.0..origin/main`)

All 12 merged PRs in the range, no `UNKNOWN` rows.

| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #1207 | Warn for Rspack React Refresh v2 constructor configs | entry-needed | doctor-diagnostics | Adds a user-facing `shakapacker:doctor` warning in `lib/shakapacker/doctor.rb`; merged after the v10.3.0 tag, so its entry moves into v10.3.1. |
| #1211 | docs: add css-loader to v10 Rspack upgrade commands | entry-needed | documentation | Upgrade guide's copy-paste commands omitted a required peer dependency, so following them left Rspack v2 upgrades with an unsatisfied `css-loader`. |
| #1212 | Resolve Babel 8 migration follow-ups | entry-needed | transpiler-runtime | `package/rules/babel.ts` replaces a raw `MODULE_NOT_FOUND` with an actionable install/config message when `@babel/core` is absent. |
| #1213 | Add merge readiness replay helper | no-entry | agent-workflow | Adds `.agents/bin/merge-readiness-check` plus PR-template and CI wiring; contributor tooling with no runtime effect. |
| #1214 | Add Babel 8 preset smoke | no-entry | ci-tests | Adds a `babel8-smoke` workflow and test file only; no shipped code changes. |
| #1215 | Add security policy | no-entry | repo-policy | Adds `SECURITY.md` vulnerability-reporting policy; not a security fix or behavior change. |
| #1216 | Harden Claude workflow permission gate | no-entry | ci | Tightens permissions in `.github/workflows/claude.yml`; repo automation only. |
| #1217 | Fix agent workflow seam pointer | no-entry | agent-workflow | Corrects `.agents/agent-workflow.yml` / `AGENTS.md` discovery pointers for contributors. |
| #1219 | Fix .cjs matching in webpack transpiler rules | entry-needed | transpiler-runtime | Babel/SWC/esbuild rules skipped explicitly included `.cjs` files; already under `[Unreleased]`. |
| #1221 | Configure agent workflow repo policy | no-entry | agent-workflow | Adds process policy keys to `.agents/agent-workflow.yml`; no product surface. |
| #1222 | Fix 502s from proxied packs under rack-proxy v1 | entry-needed | dev-server-proxy | Runtime fix for 502s on proxied dev-server assets; already under `[Unreleased]`. |
| #1225 | Fix false-positive dev server liveness checks | entry-needed | dev-server | Runtime fix for false-positive dev-server detection; already under `[Unreleased]`. |

## Validation

- `git diff --check` — clean.
- `npx prettier --check CHANGELOG.md` — "All matched files use Prettier code style!"
- Trailing newline present; `## [v10.3.1]` header is unique and newest-first; compare links verified (`[Unreleased]` → `v10.3.1...main`, `[v10.3.1]` → `v10.3.0...v10.3.1`).
- Replayed `rakelib/release.rake`'s bump-consistency logic against the new section: headings are `### Fixed` + `### Documentation` → inferred bump `:patch`, matching `v10.3.0 → v10.3.1`. (Adding an `### Added` heading here would have made the release task expect a minor bump and abort.)

Note: the `lint-staged` pre-commit hook could not spawn `prettier` because this worktree has no `node_modules`; the same check was run directly via `npx prettier --check` and passed.

After merge, run the release task (no args) — it reads `v10.3.1` from the changelog and creates the GitHub release from this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issues with proxied development-server assets and liveness checks.
  * Improved `.cjs` rule handling and React Refresh v2 diagnostics.
  * Added clearer errors when Babel core is missing.

* **Documentation**
  * Added release notes for version 10.3.1, including Rspack upgrade guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->