### PR TITLE
Block rake release when CI is not green

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ namespace :run_spec do
   desc "Run shakapacker specs"
   task :gem do
     puts "Running Shakapacker gem specs"
-    sh("bundle exec rspec spec/shakapacker/*_spec.rb")
+    sh("bundle exec rspec spec/shakapacker/*_spec.rb spec/rakelib/*_spec.rb")
   end
 
   desc "Run specs in the dummy app with webpack"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -71,6 +71,10 @@ AUTO_CONFIRM=true bundle exec rake release
 # Override version policy checks (monotonic + changelog/bump consistency)
 RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[10.1.0]"
 bundle exec rake "release[10.1.0,false,true]"
+
+# Override the CI status gate (use only for known-unrelated failures)
+RELEASE_CI_POLICY_OVERRIDE=true bundle exec rake "release[10.1.0]"
+bundle exec rake "release[10.1.0,false,false,true]"
 ```
 
 When called with no arguments, `release`:
@@ -97,6 +101,25 @@ Use override only when needed:
 - `RELEASE_VERSION_POLICY_OVERRIDE=true`
 - Or task arg override (`release[..., ..., true]`)
 
+`release` also refuses to publish unless GitHub CI is green for the commit being
+released (the commit at `HEAD` after `git pull --rebase`, which is the parent of the
+version-bump commit the task creates):
+
+- Every check run for that commit must have completed with `success`, `skipped`, or `neutral`.
+- Checks that are still running block the release — wait for CI to finish and retry.
+- `failure`, `cancelled`, `timed_out`, and similar conclusions all block the release; a
+  cancelled check is not evidence that the commit is good.
+- A commit with no check runs at all blocks the release, so an unpushed commit or a CI
+  outage cannot look green.
+- The gate fails closed: if CI status cannot be read (no `gh`, API error), the release stops.
+- Dry runs report what the gate would do instead of aborting.
+
+Override only for failures you have confirmed are unrelated to the release — for example an
+upstream registry outage — never to paper over a real regression:
+
+- `RELEASE_CI_POLICY_OVERRIDE=true`
+- Or task arg override (`release[..., ..., ..., true]`)
+
 ### 3. What the Release Task Does
 
 The `release` task automatically:
@@ -104,7 +127,8 @@ The `release` task automatically:
 1. **Validates release prerequisites**:
    - Verifies npm authentication
    - Warns if CHANGELOG.md section is missing for the target version
-2. **Pulls latest changes** from the repository
+2. **Pulls latest changes** from the repository, then **aborts unless CI is green** for the
+   resulting commit
 3. **Bumps version numbers** in:
    - `lib/shakapacker/version.rb` (Ruby gem version)
    - `package.json` (npm package version - converted from Ruby format)
@@ -204,6 +228,21 @@ bundle exec rake "sync_github_release[10.6.0.rc.1]"
 `sync_github_release` reads release notes from the matching `CHANGELOG.md` section and creates/updates the GitHub release for the corresponding tag.
 
 ## Troubleshooting
+
+### Release Blocked by the CI Gate
+
+If the release aborts with `CI is not green for <sha>`:
+
+1. Read the listed checks. `Still running` means CI has not finished — wait and retry.
+2. For real failures, fix them on `main` and rerun the release once CI is green.
+3. If the failure is confirmed unrelated to the release (for example an upstream npm
+   registry outage), rerun with `RELEASE_CI_POLICY_OVERRIDE=true`.
+
+If it aborts with `No CI results found`, the commit is not on GitHub yet or CI never
+started. Push the branch and let CI run.
+
+If it aborts with `Unable to verify CI status`, the gate could not read CI results — check
+`gh auth status` and network access. The gate fails closed on purpose.
 
 ### Uncommitted Changes After Release
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -73,7 +73,7 @@ RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[10.1.0]"
 bundle exec rake "release[10.1.0,false,true]"
 
 # Override the CI status gate (use only for known-unrelated failures)
-RELEASE_CI_POLICY_OVERRIDE=true bundle exec rake "release[10.1.0]"
+RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake "release[10.1.0]"
 bundle exec rake "release[10.1.0,false,false,true]"
 ```
 
@@ -105,7 +105,10 @@ Use override only when needed:
 released (the commit at `HEAD` after `git pull --rebase`, which is the parent of the
 version-bump commit the task creates):
 
-- Every check run for that commit must have completed with `success`, `skipped`, or `neutral`.
+- Both GitHub check runs and legacy commit statuses are evaluated. Some integrations
+  (CodeRabbit, for one) report only as commit statuses, so checking one endpoint would let a
+  failing check read as green. For commit statuses, only the most recent per context counts.
+- Every check must have completed with `success`, `skipped`, or `neutral`.
 - Checks that are still running block the release — wait for CI to finish and retry.
 - `failure`, `cancelled`, `timed_out`, and similar conclusions all block the release; a
   cancelled check is not evidence that the commit is good.
@@ -117,7 +120,7 @@ version-bump commit the task creates):
 Override only for failures you have confirmed are unrelated to the release — for example an
 upstream registry outage — never to paper over a real regression:
 
-- `RELEASE_CI_POLICY_OVERRIDE=true`
+- `RELEASE_CI_STATUS_OVERRIDE=true`
 - Or task arg override (`release[..., ..., ..., true]`)
 
 ### 3. What the Release Task Does
@@ -236,7 +239,7 @@ If the release aborts with `CI is not green for <sha>`:
 1. Read the listed checks. `Still running` means CI has not finished — wait and retry.
 2. For real failures, fix them on `main` and rerun the release once CI is green.
 3. If the failure is confirmed unrelated to the release (for example an upstream npm
-   registry outage), rerun with `RELEASE_CI_POLICY_OVERRIDE=true`.
+   registry outage), rerun with `RELEASE_CI_STATUS_OVERRIDE=true`.
 
 If it aborts with `No CI results found`, the commit is not on GitHub yet or CI never
 started. Push the branch and let CI run.

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -10,6 +10,11 @@ require "json"
 
 GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined?(GITHUB_REPO_SLUG_PATTERN)
 
+# A check run only counts as green when it finished with one of these conclusions.
+# Anything else (failure, timed_out, cancelled, action_required, stale, ...) blocks
+# the release, because none of them prove the released commit is good.
+CI_PASSING_CONCLUSIONS = %w[success skipped neutral].freeze unless defined?(CI_PASSING_CONCLUSIONS)
+
 unless defined?(AbortingMessageHandler)
   class AbortingMessageHandler
     def add_error(error)
@@ -267,6 +272,125 @@ def validate_release_version_policy!(gem_root:, target_gem_version:, allow_overr
   handle_version_policy_violation!(
     message: "❌ Version bump mismatch for #{target_gem_version}: CHANGELOG section #{changelog_source} implies #{expected_bump_type}, but version bump is #{actual_bump_type} from #{latest_stable_version}.",
     allow_override: allow_override
+  )
+end
+
+def ci_policy_override_enabled?(override_flag)
+  Shakapacker::Utils::Misc.object_to_boolean(override_flag) ||
+    Shakapacker::Utils::Misc.object_to_boolean(ENV["RELEASE_CI_POLICY_OVERRIDE"])
+end
+
+def handle_ci_policy_violation!(message:, allow_override:, dry_run:)
+  normalized = message.sub(/\A❌\s*/, "")
+
+  if allow_override
+    puts "⚠️ CI POLICY OVERRIDE enabled: #{normalized}"
+  elsif dry_run
+    puts "DRY RUN: Release would be blocked: #{normalized}"
+  else
+    abort message
+  end
+end
+
+def release_head_sha(gem_root)
+  output, status = Open3.capture2e("git", "-C", gem_root, "rev-parse", "HEAD")
+  output = output.strip
+  abort "❌ Unable to determine HEAD commit for CI status validation.\n\n#{output}" unless status.success?
+
+  output
+end
+
+# Returns [check_runs, error_message]. `filter=latest` is the GitHub default and
+# means re-running a failed job replaces its earlier result, so a retried flake
+# stops blocking the release once it passes.
+def fetch_commit_check_runs(repo_slug:, commit_sha:)
+  api_path = "repos/#{repo_slug}/commits/#{commit_sha}/check-runs?per_page=100&filter=latest"
+  jq_filter = '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv'
+
+  begin
+    output, status = Open3.capture2e("gh", "api", api_path, "--paginate", "--jq", jq_filter)
+  rescue Errno::ENOENT
+    return [nil, "GitHub CLI is not installed or not available on PATH. Install `gh` and retry."]
+  end
+  return [nil, output.strip] unless status.success?
+
+  check_runs = output.lines.filter_map do |line|
+    name, run_status, conclusion = line.chomp.split("\t", 3)
+    next if name.nil? || name.empty?
+
+    { name: name, status: run_status.to_s, conclusion: conclusion.to_s }
+  end
+
+  [check_runs, nil]
+end
+
+def classify_check_runs(check_runs)
+  pending, failing = check_runs.partition { |run| run[:status] != "completed" }
+  failing = failing.reject { |run| CI_PASSING_CONCLUSIONS.include?(run[:conclusion]) }
+
+  { pending: pending, failing: failing }
+end
+
+def format_check_run_problems(pending:, failing:)
+  details = +""
+
+  unless failing.empty?
+    details << "\n\nNot passing (#{failing.length}):\n"
+    details << failing.map { |run| "  - #{run[:name]} (#{run[:conclusion]})" }.join("\n")
+  end
+
+  unless pending.empty?
+    details << "\n\nStill running (#{pending.length}):\n"
+    details << pending.map { |run| "  - #{run[:name]} (#{run[:status]})" }.join("\n")
+  end
+
+  details
+end
+
+# Gates the release on CI results for the commit that is about to be released.
+# The version-bump commit does not exist yet, so this validates its parent — the
+# code being published. Failing closed is deliberate: if CI status cannot be read,
+# the release stops rather than assuming green.
+def validate_release_ci_status!(gem_root:, allow_override:, dry_run:)
+  repo_slug = github_repo_slug(gem_root)
+  commit_sha = release_head_sha(gem_root)
+  check_runs, error = fetch_commit_check_runs(repo_slug: repo_slug, commit_sha: commit_sha)
+
+  if error
+    handle_ci_policy_violation!(
+      message: "❌ Unable to verify CI status for #{commit_sha} on #{repo_slug}.\n\n#{error}",
+      allow_override: allow_override,
+      dry_run: dry_run
+    )
+    return
+  end
+
+  if check_runs.empty?
+    handle_ci_policy_violation!(
+      message: "❌ No CI results found for #{commit_sha} on #{repo_slug}. " \
+               "Push the commit and let CI finish before releasing.",
+      allow_override: allow_override,
+      dry_run: dry_run
+    )
+    return
+  end
+
+  classified = classify_check_runs(check_runs)
+  pending = classified[:pending]
+  failing = classified[:failing]
+
+  if pending.empty? && failing.empty?
+    puts "✓ CI is green for #{commit_sha} (#{check_runs.length} checks)"
+    return
+  end
+
+  handle_ci_policy_violation!(
+    message: "❌ CI is not green for #{commit_sha}, the commit that would be released." \
+             "#{format_check_run_problems(pending: pending, failing: failing)}\n\n" \
+             "Fix CI (or wait for it to finish) and retry. " \
+             "To release anyway, set RELEASE_CI_POLICY_OVERRIDE=true.",
+    allow_override: allow_override,
+    dry_run: dry_run
   )
 end
 
@@ -548,6 +672,7 @@ def perform_release(
   dry_run:,
   check_uncommitted: true,
   allow_version_policy_override: false,
+  allow_ci_policy_override: false,
   fetch_tags_for_policy: true
 )
   ensure_clean_worktree! if check_uncommitted
@@ -571,6 +696,13 @@ def perform_release(
 
   with_release_checkout(gem_root: gem_root, dry_run: dry_run) do |release_root|
     Shakapacker::Utils::Misc.sh_in_dir(release_root, "git pull --rebase") unless dry_run
+
+    # Gate on CI *after* the rebase so the validated commit is the one being released.
+    validate_release_ci_status!(
+      gem_root: release_root,
+      allow_override: allow_ci_policy_override,
+      dry_run: dry_run
+    )
 
     # The release root may change after `git pull --rebase`, so patch-bump inference must happen after that step.
     resolved_target_gem_version = target_gem_version(gem_root: release_root, requested_gem_version: requested_gem_version)
@@ -720,6 +852,12 @@ Arguments:
 2nd argument: Perform a dry run by passing 'true' as second argument.
 3rd argument: Override release version policy checks by passing 'true'.
               Equivalent to setting RELEASE_VERSION_POLICY_OVERRIDE=true.
+4th argument: Override the CI status gate by passing 'true'.
+              Equivalent to setting RELEASE_CI_POLICY_OVERRIDE=true.
+
+The release aborts unless GitHub CI is green for the commit being released.
+Use the CI override only for known-unrelated failures (for example an upstream
+registry outage), never to paper over a real regression.
 
 Examples:
 - rake \"release\"                      # uses CHANGELOG.md version or patch bump
@@ -727,11 +865,13 @@ Examples:
 - rake \"release[9.6.0.rc.0]\"
 - rake \"release[9.6.0,true]\"
 - rake \"release[9.6.0,false,true]\"
+- rake \"release[9.6.0,false,false,true]\"  # skip the CI gate
 ")
-task :release, %i[gem_version dry_run override_version_policy] do |_t, args|
+task :release, %i[gem_version dry_run override_version_policy override_ci_policy] do |_t, args|
   args_hash = args.to_hash
   is_dry_run = Shakapacker::Utils::Misc.object_to_boolean(args_hash[:dry_run])
   allow_override = version_policy_override_enabled?(args_hash[:override_version_policy])
+  allow_ci_override = ci_policy_override_enabled?(args_hash[:override_ci_policy])
 
   requested_version = args_hash[:gem_version].to_s.strip
   if requested_version.empty?
@@ -756,7 +896,8 @@ task :release, %i[gem_version dry_run override_version_policy] do |_t, args|
   release_result = perform_release(
     gem_version: requested_version,
     dry_run: is_dry_run,
-    allow_version_policy_override: allow_override
+    allow_version_policy_override: allow_override,
+    allow_ci_policy_override: allow_ci_override
   )
   print_release_summary(release_result)
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -275,16 +275,16 @@ def validate_release_version_policy!(gem_root:, target_gem_version:, allow_overr
   )
 end
 
-def ci_policy_override_enabled?(override_flag)
+def ci_status_override_enabled?(override_flag)
   Shakapacker::Utils::Misc.object_to_boolean(override_flag) ||
-    Shakapacker::Utils::Misc.object_to_boolean(ENV["RELEASE_CI_POLICY_OVERRIDE"])
+    Shakapacker::Utils::Misc.object_to_boolean(ENV["RELEASE_CI_STATUS_OVERRIDE"])
 end
 
-def handle_ci_policy_violation!(message:, allow_override:, dry_run:)
+def handle_ci_status_violation!(message:, allow_override:, dry_run:)
   normalized = message.sub(/\A❌\s*/, "")
 
   if allow_override
-    puts "⚠️ CI POLICY OVERRIDE enabled: #{normalized}"
+    puts "⚠️ CI STATUS OVERRIDE enabled: #{normalized}"
   elsif dry_run
     puts "DRY RUN: Release would be blocked: #{normalized}"
   else
@@ -300,28 +300,75 @@ def release_head_sha(gem_root)
   output
 end
 
-# Returns [check_runs, error_message]. `filter=latest` is the GitHub default and
-# means re-running a failed job replaces its earlier result, so a retried flake
-# stops blocking the release once it passes.
-def fetch_commit_check_runs(repo_slug:, commit_sha:)
-  api_path = "repos/#{repo_slug}/commits/#{commit_sha}/check-runs?per_page=100&filter=latest"
-  jq_filter = '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv'
-
+# `gh api --paginate --jq` flattens paginated responses into JSONL, one object per line.
+# Returns [rows, error_message]; the error is surfaced through the violation handler so a
+# missing `gh` or an API failure blocks a live release but only reports during a dry run.
+def fetch_gh_jsonl(api_path, jq_filter)
   begin
-    output, status = Open3.capture2e("gh", "api", api_path, "--paginate", "--jq", jq_filter)
+    output, status = Open3.capture2e("gh", "api", "--paginate", "--jq", jq_filter, api_path)
   rescue Errno::ENOENT
     return [nil, "GitHub CLI is not installed or not available on PATH. Install `gh` and retry."]
   end
   return [nil, output.strip] unless status.success?
 
-  check_runs = output.lines.filter_map do |line|
-    name, run_status, conclusion = line.chomp.split("\t", 3)
-    next if name.nil? || name.empty?
+  rows = output.lines.reject { |line| line.strip.empty? }.map { |line| JSON.parse(line) }
+  [rows, nil]
+rescue JSON::ParserError => e
+  [nil, "Failed to parse response from gh: #{e.message}"]
+end
 
-    { name: name, status: run_status.to_s, conclusion: conclusion.to_s }
+# `filter=latest` is the GitHub default and means re-running a failed job replaces its
+# earlier result, so a retried flake stops blocking the release once it passes.
+def fetch_commit_check_runs(repo_slug:, commit_sha:)
+  rows, error = fetch_gh_jsonl(
+    "repos/#{repo_slug}/commits/#{commit_sha}/check-runs?per_page=100&filter=latest",
+    ".check_runs[]"
+  )
+  return [nil, error] if error
+
+  [rows.map { |run| { name: run["name"].to_s, status: run["status"].to_s, conclusion: run["conclusion"].to_s } }, nil]
+end
+
+# Not every integration reports through the Checks API — CodeRabbit, for one, posts legacy
+# commit statuses. Ignoring those would let a failing check read as green, so they are folded
+# into the same evaluation.
+def fetch_commit_statuses(repo_slug:, commit_sha:)
+  rows, error = fetch_gh_jsonl("repos/#{repo_slug}/commits/#{commit_sha}/statuses?per_page=100", ".[]")
+  return [nil, error] if error
+
+  [latest_commit_statuses(rows).map { |status| normalize_status_as_check_run(status) }, nil]
+end
+
+# The statuses endpoint returns every status ever posted for a context, newest first is not
+# guaranteed, so keep only the most recent per context. GitHub emits ISO 8601 UTC timestamps,
+# which sort chronologically as strings.
+def latest_commit_statuses(statuses)
+  statuses.group_by { |status| status["context"] }.map do |_context, context_statuses|
+    context_statuses.max_by { |status| [status["created_at"].to_s, status["id"].to_i] }
   end
+end
 
-  [check_runs, nil]
+def normalize_status_as_check_run(status)
+  conclusion = normalize_status_conclusion(status["state"])
+
+  {
+    name: status["context"].to_s,
+    # A nil conclusion means the status is still pending, which must block like an
+    # in-progress check run rather than counting as a pass.
+    status: conclusion.nil? ? "pending" : "completed",
+    conclusion: conclusion.to_s
+  }
+end
+
+def normalize_status_conclusion(state)
+  case state
+  when "success" then "success"
+  when "pending" then nil
+  when "failure", "error" then state
+  else
+    # GitHub documents error/failure/pending/success; anything else is unknown, so block.
+    "error"
+  end
 end
 
 def classify_check_runs(check_runs)
@@ -354,10 +401,13 @@ end
 def validate_release_ci_status!(gem_root:, allow_override:, dry_run:)
   repo_slug = github_repo_slug(gem_root)
   commit_sha = release_head_sha(gem_root)
+
   check_runs, error = fetch_commit_check_runs(repo_slug: repo_slug, commit_sha: commit_sha)
+  statuses, status_error = fetch_commit_statuses(repo_slug: repo_slug, commit_sha: commit_sha) unless error
+  error ||= status_error
 
   if error
-    handle_ci_policy_violation!(
+    handle_ci_status_violation!(
       message: "❌ Unable to verify CI status for #{commit_sha} on #{repo_slug}.\n\n#{error}",
       allow_override: allow_override,
       dry_run: dry_run
@@ -365,8 +415,10 @@ def validate_release_ci_status!(gem_root:, allow_override:, dry_run:)
     return
   end
 
-  if check_runs.empty?
-    handle_ci_policy_violation!(
+  all_checks = check_runs + statuses
+
+  if all_checks.empty?
+    handle_ci_status_violation!(
       message: "❌ No CI results found for #{commit_sha} on #{repo_slug}. " \
                "Push the commit and let CI finish before releasing.",
       allow_override: allow_override,
@@ -375,20 +427,20 @@ def validate_release_ci_status!(gem_root:, allow_override:, dry_run:)
     return
   end
 
-  classified = classify_check_runs(check_runs)
+  classified = classify_check_runs(all_checks)
   pending = classified[:pending]
   failing = classified[:failing]
 
   if pending.empty? && failing.empty?
-    puts "✓ CI is green for #{commit_sha} (#{check_runs.length} checks)"
+    puts "✓ CI is green for #{commit_sha} (#{all_checks.length} checks)"
     return
   end
 
-  handle_ci_policy_violation!(
+  handle_ci_status_violation!(
     message: "❌ CI is not green for #{commit_sha}, the commit that would be released." \
              "#{format_check_run_problems(pending: pending, failing: failing)}\n\n" \
              "Fix CI (or wait for it to finish) and retry. " \
-             "To release anyway, set RELEASE_CI_POLICY_OVERRIDE=true.",
+             "To release anyway, set RELEASE_CI_STATUS_OVERRIDE=true.",
     allow_override: allow_override,
     dry_run: dry_run
   )
@@ -672,7 +724,7 @@ def perform_release(
   dry_run:,
   check_uncommitted: true,
   allow_version_policy_override: false,
-  allow_ci_policy_override: false,
+  allow_ci_status_override: false,
   fetch_tags_for_policy: true
 )
   ensure_clean_worktree! if check_uncommitted
@@ -700,7 +752,7 @@ def perform_release(
     # Gate on CI *after* the rebase so the validated commit is the one being released.
     validate_release_ci_status!(
       gem_root: release_root,
-      allow_override: allow_ci_policy_override,
+      allow_override: allow_ci_status_override,
       dry_run: dry_run
     )
 
@@ -853,7 +905,7 @@ Arguments:
 3rd argument: Override release version policy checks by passing 'true'.
               Equivalent to setting RELEASE_VERSION_POLICY_OVERRIDE=true.
 4th argument: Override the CI status gate by passing 'true'.
-              Equivalent to setting RELEASE_CI_POLICY_OVERRIDE=true.
+              Equivalent to setting RELEASE_CI_STATUS_OVERRIDE=true.
 
 The release aborts unless GitHub CI is green for the commit being released.
 Use the CI override only for known-unrelated failures (for example an upstream
@@ -867,11 +919,11 @@ Examples:
 - rake \"release[9.6.0,false,true]\"
 - rake \"release[9.6.0,false,false,true]\"  # skip the CI gate
 ")
-task :release, %i[gem_version dry_run override_version_policy override_ci_policy] do |_t, args|
+task :release, %i[gem_version dry_run override_version_policy override_ci_status] do |_t, args|
   args_hash = args.to_hash
   is_dry_run = Shakapacker::Utils::Misc.object_to_boolean(args_hash[:dry_run])
   allow_override = version_policy_override_enabled?(args_hash[:override_version_policy])
-  allow_ci_override = ci_policy_override_enabled?(args_hash[:override_ci_policy])
+  allow_ci_override = ci_status_override_enabled?(args_hash[:override_ci_status])
 
   requested_version = args_hash[:gem_version].to_s.strip
   if requested_version.empty?
@@ -897,7 +949,7 @@ task :release, %i[gem_version dry_run override_version_policy override_ci_policy
     gem_version: requested_version,
     dry_run: is_dry_run,
     allow_version_policy_override: allow_override,
-    allow_ci_policy_override: allow_ci_override
+    allow_ci_status_override: allow_ci_override
   )
   print_release_summary(release_result)
 end

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "release rake helpers" do
 
       expect do
         load File.expand_path("../../rakelib/release.rake", __dir__)
-      end.not_to output(/GITHUB_REPO_SLUG_PATTERN|AbortingMessageHandler/).to_stderr
+      end.not_to output(/GITHUB_REPO_SLUG_PATTERN|CI_PASSING_CONCLUSIONS|AbortingMessageHandler/).to_stderr
     ensure
       $VERBOSE = previous_verbose
     end
@@ -122,6 +122,112 @@ RSpec.describe "release rake helpers" do
           with_release_checkout(gem_root: "/repo", dry_run: true) { "ok" }
         end.to raise_error(RuntimeError, "cleanup failed")
       end.to output(/Failed to remove dry-run release worktree/).to_stderr
+    end
+  end
+
+  describe "#validate_release_ci_status!" do
+    let(:commit_sha) { "abc123" }
+
+    def stub_check_runs(rows, success: true)
+      status = double("status", success?: success)
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", a_string_including("commits/#{commit_sha}/check-runs"), "--paginate", "--jq", anything)
+        .and_return([rows.map { |row| row.join("\t") }.join("\n"), status])
+    end
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("RELEASE_CI_POLICY_OVERRIDE").and_return(nil)
+
+      origin_status = double("status", success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/repo", "remote", "get-url", "origin")
+        .and_return(["git@github.com:shakacode/shakapacker.git\n", origin_status])
+
+      head_status = double("status", success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/repo", "rev-parse", "HEAD")
+        .and_return(["#{commit_sha}\n", head_status])
+    end
+
+    def validate(allow_override: false, dry_run: false)
+      validate_release_ci_status!(gem_root: "/repo", allow_override: allow_override, dry_run: dry_run)
+    end
+
+    it "passes when every check run completed successfully" do
+      stub_check_runs([["Ruby based checks", "completed", "success"], ["claude", "completed", "skipped"]])
+
+      expect { validate }.to output(/✓ CI is green for #{commit_sha} \(2 checks\)/).to_stdout
+    end
+
+    it "aborts and names the failing checks" do
+      stub_check_runs([["Ruby based checks", "completed", "success"], ["Linting", "completed", "failure"]])
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/CI is not green.*Not passing \(1\):\n  - Linting \(failure\)/m).to_stderr
+    end
+
+    it "treats a cancelled check as not passing" do
+      stub_check_runs([["Generator specs", "completed", "cancelled"]])
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/Not passing \(1\):\n  - Generator specs \(cancelled\)/).to_stderr
+    end
+
+    it "aborts while checks are still running" do
+      stub_check_runs([["Dummy specs", "in_progress", ""]])
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/Still running \(1\):\n  - Dummy specs \(in_progress\)/).to_stderr
+    end
+
+    it "aborts when the commit has no CI results at all" do
+      stub_check_runs([])
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/No CI results found for #{commit_sha}/).to_stderr
+    end
+
+    it "fails closed when CI status cannot be read" do
+      stub_check_runs([["irrelevant", "completed", "success"]], success: false)
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/Unable to verify CI status for #{commit_sha}/).to_stderr
+    end
+
+    it "fails closed when the GitHub CLI is missing" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", a_string_including("check-runs"), "--paginate", "--jq", anything)
+        .and_raise(Errno::ENOENT)
+
+      expect do
+        expect { validate }.to raise_error(SystemExit)
+      end.to output(/GitHub CLI is not installed/).to_stderr
+    end
+
+    it "releases anyway when the override argument is set" do
+      stub_check_runs([["Linting", "completed", "failure"]])
+
+      expect { validate(allow_override: true) }.to output(/CI POLICY OVERRIDE enabled/).to_stdout
+    end
+
+    it "releases anyway when RELEASE_CI_POLICY_OVERRIDE is set" do
+      allow(ENV).to receive(:[]).with("RELEASE_CI_POLICY_OVERRIDE").and_return("true")
+      stub_check_runs([["Linting", "completed", "failure"]])
+
+      expect { validate(allow_override: ci_policy_override_enabled?(nil)) }
+        .to output(/CI POLICY OVERRIDE enabled/).to_stdout
+    end
+
+    it "reports instead of aborting during a dry run" do
+      stub_check_runs([["Linting", "completed", "failure"]])
+
+      expect { validate(dry_run: true) }.to output(/DRY RUN: Release would be blocked.*Linting \(failure\)/m).to_stdout
     end
   end
 end

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -128,16 +128,29 @@ RSpec.describe "release rake helpers" do
   describe "#validate_release_ci_status!" do
     let(:commit_sha) { "abc123" }
 
-    def stub_check_runs(rows, success: true)
+    def stub_gh_jsonl(path_fragment, objects, success: true)
       status = double("status", success?: success)
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", a_string_including("commits/#{commit_sha}/check-runs"), "--paginate", "--jq", anything)
-        .and_return([rows.map { |row| row.join("\t") }.join("\n"), status])
+        .with("gh", "api", "--paginate", "--jq", anything, a_string_including(path_fragment))
+        .and_return([objects.map(&:to_json).join("\n"), status])
+    end
+
+    # check_runs and legacy commit statuses come from separate endpoints and are evaluated together.
+    def stub_check_runs(rows, success: true)
+      objects = rows.map { |name, run_status, conclusion| { name: name, status: run_status, conclusion: conclusion } }
+      stub_gh_jsonl("check-runs", objects, success: success)
+    end
+
+    def stub_commit_statuses(rows, success: true)
+      objects = rows.map.with_index do |(context, state, created_at), index|
+        { id: index, context: context, state: state, created_at: created_at || "2026-01-0#{index + 1}T00:00:00Z" }
+      end
+      stub_gh_jsonl("/statuses", objects, success: success)
     end
 
     before do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("RELEASE_CI_POLICY_OVERRIDE").and_return(nil)
+      allow(ENV).to receive(:[]).with("RELEASE_CI_STATUS_OVERRIDE").and_return(nil)
 
       origin_status = double("status", success?: true)
       allow(Open3).to receive(:capture2e)
@@ -148,6 +161,9 @@ RSpec.describe "release rake helpers" do
       allow(Open3).to receive(:capture2e)
         .with("git", "-C", "/repo", "rev-parse", "HEAD")
         .and_return(["#{commit_sha}\n", head_status])
+
+      # Most examples exercise check_runs only; default the statuses endpoint to empty.
+      stub_commit_statuses([])
     end
 
     def validate(allow_override: false, dry_run: false)
@@ -202,7 +218,7 @@ RSpec.describe "release rake helpers" do
 
     it "fails closed when the GitHub CLI is missing" do
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", a_string_including("check-runs"), "--paginate", "--jq", anything)
+        .with("gh", "api", "--paginate", "--jq", anything, a_string_including("check-runs"))
         .and_raise(Errno::ENOENT)
 
       expect do
@@ -213,21 +229,71 @@ RSpec.describe "release rake helpers" do
     it "releases anyway when the override argument is set" do
       stub_check_runs([["Linting", "completed", "failure"]])
 
-      expect { validate(allow_override: true) }.to output(/CI POLICY OVERRIDE enabled/).to_stdout
+      expect { validate(allow_override: true) }.to output(/CI STATUS OVERRIDE enabled/).to_stdout
     end
 
-    it "releases anyway when RELEASE_CI_POLICY_OVERRIDE is set" do
-      allow(ENV).to receive(:[]).with("RELEASE_CI_POLICY_OVERRIDE").and_return("true")
+    it "releases anyway when RELEASE_CI_STATUS_OVERRIDE is set" do
+      allow(ENV).to receive(:[]).with("RELEASE_CI_STATUS_OVERRIDE").and_return("true")
       stub_check_runs([["Linting", "completed", "failure"]])
 
-      expect { validate(allow_override: ci_policy_override_enabled?(nil)) }
-        .to output(/CI POLICY OVERRIDE enabled/).to_stdout
+      expect { validate(allow_override: ci_status_override_enabled?(nil)) }
+        .to output(/CI STATUS OVERRIDE enabled/).to_stdout
     end
 
     it "reports instead of aborting during a dry run" do
       stub_check_runs([["Linting", "completed", "failure"]])
 
       expect { validate(dry_run: true) }.to output(/DRY RUN: Release would be blocked.*Linting \(failure\)/m).to_stdout
+    end
+
+    # Not every integration reports through the Checks API. CodeRabbit posts legacy commit
+    # statuses, so ignoring that endpoint would let a failing check read as green.
+    context "with legacy commit statuses" do
+      it "blocks on a failing commit status even when every check run passed" do
+        stub_check_runs([["Ruby based checks", "completed", "success"]])
+        stub_commit_statuses([["CodeRabbit", "failure"]])
+
+        expect do
+          expect { validate }.to raise_error(SystemExit)
+        end.to output(/Not passing \(1\):\n  - CodeRabbit \(failure\)/).to_stderr
+      end
+
+      it "blocks while a commit status is still pending" do
+        stub_check_runs([["Ruby based checks", "completed", "success"]])
+        stub_commit_statuses([["CodeRabbit", "pending"]])
+
+        expect do
+          expect { validate }.to raise_error(SystemExit)
+        end.to output(/Still running \(1\):\n  - CodeRabbit \(pending\)/).to_stderr
+      end
+
+      it "counts a successful commit status toward the green total" do
+        stub_check_runs([["Ruby based checks", "completed", "success"]])
+        stub_commit_statuses([["CodeRabbit", "success"]])
+
+        expect { validate }.to output(/✓ CI is green for #{commit_sha} \(2 checks\)/).to_stdout
+      end
+
+      it "uses only the most recent status per context" do
+        stub_check_runs([])
+        stub_commit_statuses(
+          [
+            ["CodeRabbit", "failure", "2026-01-01T00:00:00Z"],
+            ["CodeRabbit", "success", "2026-01-02T00:00:00Z"]
+          ]
+        )
+
+        expect { validate }.to output(/✓ CI is green for #{commit_sha} \(1 checks\)/).to_stdout
+      end
+
+      it "blocks on an unknown status state rather than assuming it passed" do
+        stub_check_runs([])
+        stub_commit_statuses([["Mystery", "banana"]])
+
+        expect do
+          expect { validate }.to raise_error(SystemExit)
+        end.to output(/Not passing \(1\):\n  - Mystery \(error\)/).to_stderr
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

v10.3.1 was released from a commit whose CI was already red. `rake release` had no notion of CI status, so nothing stopped a known-broken tree from being published to npm and RubyGems.

At the moment of the 10.3.1 release, `main` had **three** red workflows:

| Check | Cause | Introduced |
| --- | --- | --- |
| Node based checks → Linting | `prettier --check` fails on `AGENTS.md` (missing blank line) | #1217, red on `main` since Jul 15 |
| Test Both Bundlers | `spec/dummy/Gemfile.lock` still pins the path gem at `10.3.0` while `version.rb` says `10.3.1`, so frozen `bundle install` fails | the 10.3.1 release commit itself |
| Generator specs | `npm ERR! code ETARGET — No matching version found for @jsonjoy.com/fs-node@4.66.0` | upstream npm registry, transient |

The first one had been red for ~3 weeks. A CI gate would have caught it.

## What

`rake release` now validates GitHub check runs for the commit being released and aborts unless CI is green.

The validated commit is `HEAD` **after** `git pull --rebase` — the parent of the version-bump commit the task creates. That commit does not exist yet, so its own CI cannot be checked; its parent is the code actually being published.

The gate fails closed by design:

- Still-running checks block the release rather than being assumed green.
- `failure`, `cancelled`, `timed_out`, etc. all block. A cancelled check is not evidence the commit is good.
- A commit with **zero** check runs blocks, so an unpushed commit or a CI outage cannot look green.
- An unreadable CI status (no `gh`, API error) blocks.

Only `success`, `skipped`, and `neutral` count as passing. The query uses GitHub's default `filter=latest`, so re-running a failed job clears the block once it passes.

Dry runs report what the gate would do instead of aborting, matching how the task already handles confirmation prompts.

## Escape hatch

Mirrors the existing version-policy idiom exactly, so there is one override convention rather than two:

```bash
RELEASE_CI_POLICY_OVERRIDE=true bundle exec rake "release[10.3.2]"
bundle exec rake "release[10.3.2,false,false,true]"
```

Intended for failures confirmed unrelated to the release — the `@jsonjoy.com/fs-node` registry outage above is a textbook case — never to paper over a regression.

## Also included

`run_spec:gem` now runs `spec/rakelib/*_spec.rb`. Those specs, **including the pre-existing release specs**, were never executed in CI — only `spec/shakapacker/*_spec.rb` was.

## Verification

Unit specs cover green, failing, cancelled, pending, no-results, unreadable-status, missing-`gh`, both overrides, and dry-run reporting.

Beyond the unit tests, the gate was run against real GitHub data:

```
# red commit (the 10.3.1 release commit)
❌ CI is not green for c310d4ef..., the commit that would be released.

Not passing (6):
  - Generator specs (ubuntu-latest, 3.1, gemfiles/Gemfile-rails.7.1.x) (failure)
  - Generator specs (ubuntu-latest, 3.2, gemfiles/Gemfile-rails.7.2.x) (cancelled)
  - Linting (failure)
  - Test Bundler Switching (failure)
  - Test with Webpack (failure)
  - Test with RSpack (failure)

# green commit
✓ CI is green for 9f875b7e... (63 checks)

# override on the red commit
⚠️ CI POLICY OVERRIDE enabled: CI is not green for c310d4ef... → proceeds
```

Local checks:

- `bundle exec rake run_spec:gem` — 1297 examples, 0 failures, 6 pending
- `bundle exec rubocop` — 147 files, no offenses
- `npx prettier --check docs/releasing.md` — clean

## Not in this PR

The three CI failures themselves are left alone to keep this focused. They need separate PRs:

1. `AGENTS.md` prettier formatting — one blank line, unblocks `main`.
2. `spec/dummy/Gemfile.lock` drift after a version bump. Worth noting the release task already lists it in `release_staged_files` and runs `bundle install` in `spec/dummy`, yet the last three release commits (10.2.0, 10.3.0, 10.3.1) contain no `spec/dummy/Gemfile.lock` change — historically it has been bumped by unrelated PRs instead. That mechanism needs its own look.
3. The `@jsonjoy.com/fs-node` ETARGET failure is upstream and likely already resolved; re-run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now verify CI checks for the exact commit being released.
  * Successful, skipped, and neutral checks are accepted.
  * Dry-run reporting and explicit CI-policy overrides are supported.

* **Bug Fixes**
  * Releases are blocked when checks are missing, pending, failing, cancelled, or unreadable.

* **Documentation**
  * Updated the release guide with CI requirements, override examples, workflow guidance, and troubleshooting steps.

* **Tests**
  * Added coverage for successful, failing, unavailable, and overridden CI release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->