### PR TITLE
Restore main to green

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Canonical agent instructions for Shakapacker.
 ## Agent Workflow Configuration
 
 Portable shared skills resolve this repo's commands and policy through:
+
 - **Commands** — run `.agents/bin/<name>` (`setup`, `validate`, `test`, ...); see `.agents/bin/README.md`. A missing script means that capability is n/a here.
 - **Policy / config** — `.agents/agent-workflow.yml`.
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    shakapacker (10.3.0)
+    shakapacker (10.3.1)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)


### PR DESCRIPTION
Fixes the two repo-side CI failures on `main`. Two lines total.

## 1. `spec/dummy/Gemfile.lock` drift — broke 3 jobs

The 10.3.1 release bumped `lib/shakapacker/version.rb` but `spec/dummy/Gemfile.lock` still pinned the path gem at `10.3.0`, so the frozen `bundle install` failed:

```
The gemspecs for path gems changed, but the lockfile can't be updated because
frozen mode is set
##[error]The process '.../bundle' failed with exit code 16
```

This took out **Test with Webpack**, **Test with RSpack**, and **Test Bundler Switching**. Regenerated with `bundle install` in `spec/dummy`; the only change is the version line.

## 2. `AGENTS.md` formatting — broke Linting

Missing blank line before a list, so `prettier --check .` failed in the **Node based checks → Linting** job.

That job has been red on `main` since [#1217](https://github.com/shakacode/shakapacker/pull/1217) on **Jul 15** — nearly three weeks. `node.yml` is path-filtered on `pull_request` but runs unconditionally on push to `main`, so a docs-only PR could land formatting drift without ever running prettier.

## Verification

```bash
cd spec/dummy && BUNDLE_FROZEN=true bundle install   # succeeds (was exit 16)
yarn prettier --check .                              # All matched files use Prettier code style!
```

## Context

This unblocks [#1230](https://github.com/shakacode/shakapacker/pull/1230), which adds a CI-status gate to `rake release`. That PR's CI inherits these same failures from `main`, so this should merge first.

The gate in #1230 is what would have prevented 10.3.1 from being published off an already-red tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved spacing in the agent workflow configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->