### PR TITLE
Fix release task never updating spec/dummy/Gemfile.lock

### DIFF
--- a/lib/shakapacker/utils/misc.rb
+++ b/lib/shakapacker/utils/misc.rb
@@ -33,7 +33,11 @@ module Shakapacker
         [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
       end
 
-      # Executes a string or an array of strings in a shell in the given directory in an unbundled environment
+      # Executes a string or an array of strings in a shell in the given directory.
+      # NOTE: this does NOT unbundle. The caller's Bundler environment (BUNDLE_GEMFILE,
+      # RUBYOPT, ...) is inherited, so a `bundle` command run here against a different
+      # directory's Gemfile still resolves the caller's Gemfile. Wrap the call in
+      # Bundler.with_unbundled_env when that matters.
       def self.sh_in_dir(dir, *shell_commands)
         shell_commands.flatten.each { |shell_command| sh %(cd '#{dir}' && #{shell_command.strip}) }
       end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,6 +1,7 @@
 require_relative File.join("..", "lib", "shakapacker", "utils", "version_syntax_converter")
 require_relative File.join("..", "lib", "shakapacker", "utils", "misc")
 require "English"
+require "bundler"
 require "rubygems/version"
 require "shellwords"
 require "open3"
@@ -498,6 +499,25 @@ def bump_supplemental_core_dep(full_pkg_dir, npm_version)
   File.write(pkg_json_path, "#{JSON.pretty_generate(pkg_json)}\n")
 end
 
+# spec/dummy is Yarn-managed, but package-lock.json is committed too for npm
+# compatibility/testing.
+#
+# The bundle install must run with the parent Bundler environment removed.
+# `bundle exec rake release` exports BUNDLE_GEMFILE pointing at the gem root, and a plain
+# `cd spec/dummy && bundle install` inherits it — so it re-resolves the ROOT Gemfile and
+# leaves spec/dummy/Gemfile.lock pinned to the pre-bump version. That drift then breaks CI
+# on the release commit, where spec/dummy installs in frozen mode. The Rakefile spec tasks
+# unbundle for the same reason.
+def refresh_spec_dummy_lockfiles(release_root)
+  spec_dummy_dir = File.join(release_root, "spec", "dummy")
+
+  Bundler.with_unbundled_env do
+    Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "bundle install")
+  end
+  Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "yarn install")
+  Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "npm install")
+end
+
 def print_release_summary(release_result)
   released_gem_version = release_result[:released_gem_version]
   released_npm_version = release_result[:released_npm_version]
@@ -604,11 +624,7 @@ def perform_release(
     Shakapacker::Utils::Misc.sh_in_dir(release_root, "bundle install")
 
     # Update spec/dummy lockfiles BEFORE release-it so they are included in the release commit.
-    # spec/dummy is Yarn-managed, but we also commit package-lock.json for npm compatibility/testing.
-    spec_dummy_dir = File.join(release_root, "spec", "dummy")
-    Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "bundle install")
-    Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "yarn install")
-    Shakapacker::Utils::Misc.sh_in_dir(spec_dummy_dir, "npm install")
+    refresh_spec_dummy_lockfiles(release_root)
 
     # Explicitly stage all release-related changes so release-it includes them in its commit.
     # release-it only reliably stages files it modifies (package.json); other working tree

--- a/spec/rakelib/release_spec.rb
+++ b/spec/rakelib/release_spec.rb
@@ -70,6 +70,45 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "#refresh_spec_dummy_lockfiles" do
+    # Tracks whether each command ran inside Bundler.with_unbundled_env. `bundle install`
+    # must, or it re-resolves the root Gemfile (BUNDLE_GEMFILE is inherited from
+    # `bundle exec rake release`) and leaves spec/dummy/Gemfile.lock at the pre-bump version.
+    let(:commands) { [] }
+
+    before do
+      unbundled = false
+
+      allow(Bundler).to receive(:with_unbundled_env) do |&block|
+        unbundled = true
+        begin
+          block.call
+        ensure
+          unbundled = false
+        end
+      end
+
+      allow(Shakapacker::Utils::Misc).to receive(:sh_in_dir) do |dir, command|
+        commands << { dir: dir, command: command, unbundled: unbundled }
+      end
+    end
+
+    it "runs the spec/dummy bundle install with the parent bundler env removed" do
+      refresh_spec_dummy_lockfiles("/repo")
+
+      expect(commands).to include(
+        { dir: "/repo/spec/dummy", command: "bundle install", unbundled: true }
+      )
+    end
+
+    it "refreshes the yarn and npm lockfiles in spec/dummy" do
+      refresh_spec_dummy_lockfiles("/repo")
+
+      expect(Shakapacker::Utils::Misc).to have_received(:sh_in_dir).with("/repo/spec/dummy", "yarn install")
+      expect(Shakapacker::Utils::Misc).to have_received(:sh_in_dir).with("/repo/spec/dummy", "npm install")
+    end
+  end
+
   describe "#with_release_checkout" do
     before do
       allow(Dir).to receive(:mktmpdir)


### PR DESCRIPTION
Root cause of the `spec/dummy/Gemfile.lock` drift that [#1231](https://github.com/shakacode/shakapacker/pull/1231) patches by hand.

## The bug

`perform_release` runs `cd spec/dummy && bundle install` to refresh the dummy lockfile before release-it commits. **That has never worked.**

`bundle exec rake release` exports `BUNDLE_GEMFILE` pointing at the gem root, and `sh_in_dir` does not unbundle, so the child shell inherits it. The install re-resolves the **root** Gemfile from inside `spec/dummy` and leaves `spec/dummy/Gemfile.lock` pinned to the pre-bump version.

Reproduced directly:

```console
$ bundle exec sh -c "cd spec/dummy && bundle install"
Bundle complete! 12 Gemfile dependencies, 84 gems now installed.   # <- root Gemfile
$ grep -m1 'shakapacker (' spec/dummy/Gemfile.lock
    shakapacker (10.3.0)                                           # <- unchanged

$ bundle exec ruby -e 'Bundler.with_unbundled_env { system("cd spec/dummy && bundle install") }'
Bundle complete! 19 Gemfile dependencies, 102 gems now installed.  # <- spec/dummy Gemfile
$ grep -m1 'shakapacker (' spec/dummy/Gemfile.lock
    shakapacker (10.3.1)                                           # <- correct
```

12 deps vs 19 deps is the tell — the first invocation is resolving the wrong Gemfile entirely.

## Why it matters

The drift ships in the release commit, and CI installs `spec/dummy` in frozen mode:

```
The gemspecs for path gems changed, but the lockfile can't be updated because
frozen mode is set
```

That is what took out **Test with Webpack**, **Test with RSpack**, and **Test Bundler Switching** immediately after 10.3.1.

It went unnoticed for a long time because the lockfile happened to get bumped by unrelated PRs before earlier releases — `dc1f658e` set it to `10.3.0` well before 10.3.0 shipped, so that release looked consistent by luck. `git log -- spec/dummy/Gemfile.lock` shows no release commit has touched it since 10.0.0.

## The fix

Wrap the `spec/dummy` bundle install in `Bundler.with_unbundled_env` — the same thing the Rakefile spec tasks already do at [Rakefile:26](../blob/main/Rakefile#L26), [:44](../blob/main/Rakefile#L44), [:69](../blob/main/Rakefile#L69).

Extracted `refresh_spec_dummy_lockfiles` so the behavior is unit-testable, and corrected the `sh_in_dir` doc comment, which claimed it ran commands *"in an unbundled environment"*. It does not — and that inaccurate claim is exactly what the release task relied on.

## Verification

The regression test was confirmed to have teeth: reverting the `with_unbundled_env` wrapper makes it fail, and only it.

```
10 examples, 1 failure
rspec ./spec/rakelib/release_spec.rb:96 # runs the spec/dummy bundle install with the parent bundler env removed
```

With the fix in place:

- `bundle exec rspec spec/shakapacker spec/rakelib` — 1289 examples, 0 failures, 6 pending
- `bundle exec rubocop` — no offenses

## Merge order

1. [#1231](https://github.com/shakacode/shakapacker/pull/1231) — restores `main` to green (all checks passing)
2. This PR — stops the drift recurring
3. [#1230](https://github.com/shakacode/shakapacker/pull/1230) — CI gate on `rake release`

Note: `spec/rakelib/` is not currently run by CI (`run_spec:gem` only globs `spec/shakapacker/*_spec.rb`), so this PR's regression test will not execute in CI until #1230 lands, which adds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
