### PR TITLE
Correct stale version and package ranges in upgrade docs

### DIFF
--- a/docs/common-upgrades.md
+++ b/docs/common-upgrades.md
@@ -107,7 +107,7 @@ Shakapacker 10.1 introduces two optional npm packages — `shakapacker-webpack` 
 
 **Rspack apps** on npm 7+ can replace `shakapacker` + `@rspack/core` + `@rspack/cli` + `@rspack/dev-server` + `rspack-manifest-plugin` with a single `shakapacker-rspack` dev dependency. npm <7, Yarn Classic, pnpm, and Yarn PnP apps should list `shakapacker-rspack`, `shakapacker`, and the required Rspack peers explicitly. If the app changes its config imports from `shakapacker/rspack` to `shakapacker-rspack`, it can drop only the direct `shakapacker` dependency; `@rspack/core`, `@rspack/cli`, `@rspack/dev-server`, and `rspack-manifest-plugin` still need to stay explicit.
 
-**Webpack apps** on npm 7+ can replace `shakapacker` + `webpack` + `webpack-cli` + `webpack-assets-manifest` with a single `shakapacker-webpack` dev dependency. npm <7, Yarn Classic, pnpm, and Yarn PnP apps should list direct imports explicitly. One caveat: `shakapacker-webpack` pins `webpack-assets-manifest` to `~6.5.1`, so apps still on `webpack-assets-manifest@5.x` need to upgrade to v6 when adopting it.
+**Webpack apps** on npm 7+ can replace `shakapacker` + `webpack` + `webpack-cli` + `webpack-assets-manifest` with a single `shakapacker-webpack` dev dependency. npm <7, Yarn Classic, pnpm, and Yarn PnP apps should list direct imports explicitly. One caveat: `shakapacker-webpack` requires `webpack-assets-manifest@^6.0.0`, so apps still on `webpack-assets-manifest@5.x` need to upgrade to v6 when adopting it.
 
 **Custom-build apps** (apps that ship their own webpack/rspack/Vite setup and only use Shakapacker to read `manifest.json`) should **not** install a supplemental package — continue using bare `shakapacker`.
 

--- a/docs/v10_upgrade.md
+++ b/docs/v10_upgrade.md
@@ -193,7 +193,7 @@ module.exports = {
 ```
 
 Issue [#1204](https://github.com/shakacode/shakapacker/issues/1204) tracks the
-10.2.1 doctor warning for old custom React Refresh config patterns. See also
+10.3.1 doctor warning for old custom React Refresh config patterns. See also
 [PR #1179](https://github.com/shakacode/shakapacker/pull/1179), the
 [Rspack guide](./rspack.md), and the
 [Rspack migration guide](./rspack_migration_guide.md).


### PR DESCRIPTION
## Summary

- correct the React Refresh doctor-warning release from the nonexistent 10.2.1 to 10.3.1
- describe the current webpack-assets-manifest peer requirement as ^6.0.0 instead of ~6.5.1

## Why

The upgrade guides currently point readers to a release that does not exist and overstate the supplemental webpack package constraint. This keeps the documentation aligned with the v10.3.1 tag and current package metadata without changing runtime or dependency behavior.

Closes #1238

## Verification

- `.agents/bin/validate`
- confirmed tag v10.3.1 contains the React Refresh warning change
- confirmed packages/shakapacker-webpack/package.json declares webpack-assets-manifest peer range ^6.0.0
- searched both assigned upgrade guides for stale 10.2.1 and ~6.5.1 values
- `git diff --check`

## Codex Decision Log

- Non-blocking decisions: none

## QA Evidence

- Fresh Sol/xhigh QA verified the exact head, authoritative version/range metadata, stale-value search, and the clean three-PR combined-tip validation.
- No P1/P2 findings; the exact-head priority-finding disposition is not applicable.
- Durable evidence: https://github.com/shakacode/shakapacker/pull/1239#issuecomment-5183922160

Confidence note: High. The documentation-only diff, full current-head checks, configured reviews, resolved-thread state, and independent exact-head batch QA are all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Webpack upgrade guidance to reflect the supported `webpack-assets-manifest` version range.
  * Corrected the documented Shakapacker doctor warning version for outdated React Refresh configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
