### PR TITLE
Fail closed when PATH is unset

### DIFF
--- a/lib/install/bin/diff-bundler-config
+++ b/lib/install/bin/diff-bundler-config
@@ -24,7 +24,7 @@ def shakapacker_warn_missing_node
 end
 
 def shakapacker_exec_env(launch_dir)
-  return {} unless ENV.key?("PATH")
+  return unless ENV.key?("PATH")
 
   path_entries = ENV["PATH"].split(File::PATH_SEPARATOR, -1)
   path_entries = [""] if path_entries.empty?
@@ -38,12 +38,9 @@ end
 
 def shakapacker_exec_node(script_path, argv, launch_dir)
   exec_env = shakapacker_exec_env(launch_dir)
+  shakapacker_warn_missing_node unless exec_env
 
-  if exec_env.empty?
-    exec shakapacker_node_binary, script_path, *argv
-  else
-    exec exec_env, shakapacker_node_binary, script_path, *argv
-  end
+  exec exec_env, shakapacker_node_binary, script_path, *argv
 rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end

--- a/lib/install/bin/shakapacker-config
+++ b/lib/install/bin/shakapacker-config
@@ -24,7 +24,7 @@ def shakapacker_warn_missing_node
 end
 
 def shakapacker_exec_env(launch_dir)
-  return {} unless ENV.key?("PATH")
+  return unless ENV.key?("PATH")
 
   path_entries = ENV["PATH"].split(File::PATH_SEPARATOR, -1)
   path_entries = [""] if path_entries.empty?
@@ -38,12 +38,9 @@ end
 
 def shakapacker_exec_node(script_path, argv, launch_dir)
   exec_env = shakapacker_exec_env(launch_dir)
+  shakapacker_warn_missing_node unless exec_env
 
-  if exec_env.empty?
-    exec shakapacker_node_binary, script_path, *argv
-  else
-    exec exec_env, shakapacker_node_binary, script_path, *argv
-  end
+  exec exec_env, shakapacker_node_binary, script_path, *argv
 rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end

--- a/package/configExporter/cli.ts
+++ b/package/configExporter/cli.ts
@@ -558,7 +558,7 @@ def shakapacker_warn_missing_node
 end
 
 def shakapacker_exec_env(launch_dir)
-  return {} unless ENV.key?("PATH")
+  return unless ENV.key?("PATH")
 
   path_entries = ENV["PATH"].split(File::PATH_SEPARATOR, -1)
   path_entries = [""] if path_entries.empty?
@@ -572,12 +572,9 @@ end
 
 def shakapacker_exec_node(script_path, argv, launch_dir)
   exec_env = shakapacker_exec_env(launch_dir)
+  shakapacker_warn_missing_node unless exec_env
 
-  if exec_env.empty?
-    exec shakapacker_node_binary, script_path, *argv
-  else
-    exec exec_env, shakapacker_node_binary, script_path, *argv
-  end
+  exec exec_env, shakapacker_node_binary, script_path, *argv
 rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end

--- a/spec/dummy/bin/shakapacker-config
+++ b/spec/dummy/bin/shakapacker-config
@@ -24,7 +24,7 @@ def shakapacker_warn_missing_node
 end
 
 def shakapacker_exec_env(launch_dir)
-  return {} unless ENV.key?("PATH")
+  return unless ENV.key?("PATH")
 
   path_entries = ENV["PATH"].split(File::PATH_SEPARATOR, -1)
   path_entries = [""] if path_entries.empty?
@@ -38,12 +38,9 @@ end
 
 def shakapacker_exec_node(script_path, argv, launch_dir)
   exec_env = shakapacker_exec_env(launch_dir)
+  shakapacker_warn_missing_node unless exec_env
 
-  if exec_env.empty?
-    exec shakapacker_node_binary, script_path, *argv
-  else
-    exec exec_env, shakapacker_node_binary, script_path, *argv
-  end
+  exec exec_env, shakapacker_node_binary, script_path, *argv
 rescue Errno::ENOENT, Errno::EACCES
   shakapacker_warn_missing_node
 end

--- a/spec/shakapacker/helper_binstubs_spec.rb
+++ b/spec/shakapacker/helper_binstubs_spec.rb
@@ -442,52 +442,44 @@ RSpec.describe "helper binstubs" do
       end
     end
 
-    it "delegates unset PATH handling to Ruby's native exec for #{command}" do
+    it "does not execute an app-root node when PATH is unset for #{command}" do
       Dir.mktmpdir("shakapacker-binstub-") do |app_path|
         File.write(File.join(app_path, "Gemfile"), "")
         FileUtils.mkdir_p(File.join(app_path, "bin"))
         install_fake_node_script(app_path, command)
 
+        binstub_output_path = File.join(app_path, "binstub-output.json")
+        probe_output_path = File.join(app_path, "node-probe-output.txt")
+        fake_node_path = File.join(app_path, "node")
+        File.write(fake_node_path, <<~SH)
+          #!/bin/sh
+          echo executed > "$SHAKAPACKER_NODE_PROBE_OUTPUT"
+        SH
+        FileUtils.chmod(0o755, fake_node_path)
+
         binstub_path = File.join(app_path, "bin", command)
         FileUtils.cp(File.join(gem_root, "lib", "install", "bin", command), binstub_path)
         FileUtils.chmod(0o755, binstub_path)
 
-        wrapper_path = File.join(app_path, "capture_exec.rb")
-        File.write(wrapper_path, <<~RUBY)
-          require "json"
-
-          module Kernel
-            def exec(*args)
-              File.write(ENV.fetch("SHAKAPACKER_EXEC_ARGS_OUTPUT"), JSON.generate(args))
-              exit 0
-            end
-          end
-
-          binstub_path = ARGV.fetch(0)
-          ARGV.replace([])
-          load binstub_path
-        RUBY
-
-        exec_args_path = File.join(app_path, "exec-args.json")
         _stdout, stderr, status = Bundler.with_unbundled_env do
           Open3.capture3(
             {
               "BUNDLE_GEMFILE" => nil,
               "PATH" => nil,
               "RUBYOPT" => nil,
-              "SHAKAPACKER_EXEC_ARGS_OUTPUT" => exec_args_path
+              "SHAKAPACKER_BINSTUB_OUTPUT" => binstub_output_path,
+              "SHAKAPACKER_NODE_PROBE_OUTPUT" => probe_output_path
             },
             RbConfig.ruby,
-            wrapper_path,
             binstub_path,
             chdir: app_path
           )
         end
 
-        expect(status).to be_success, stderr
-        expect(JSON.parse(File.read(exec_args_path))).to eq(
-          ["node", File.realpath(File.join(app_path, "node_modules/shakapacker/package/bin/#{command}.cjs"))]
-        )
+        expect(status.exitstatus).to eq(1)
+        expect(File).not_to exist(binstub_output_path)
+        expect(File).not_to exist(probe_output_path)
+        expect(stderr).to include('[Shakapacker] Could not find Node.js executable "node"')
       end
     end
 


### PR DESCRIPTION
## Summary

- fail closed before executing Node when `PATH` is unset
- keep explicit, relative, empty, and empty-entry `PATH` behavior intact
- synchronize the generated binstub template, installed binstubs, dummy fixture, and regression coverage

## Why

Without `PATH`, the binstub previously fell through to Ruby's bare `exec "node"`, which could execute an app-root `node` file. The binstub now reports the existing contextual missing-Node error without attempting Node execution.

Closes #1234.

## Verification

- RED before fix: `bundle exec rspec spec/shakapacker/helper_binstubs_spec.rb --format progress` — 38 examples, 2 failures showing both commands launched system Node with `PATH` absent
- focused Ruby synchronization/regression suite — 42 examples, 0 failures
- template parity Jest test — 2 tests passed
- `.agents/bin/validate` — passed (RuboCop, ESLint, full Ruby specs, and full Jest suite)
- `git diff --check` — passed

## Decision log

- Preserved the existing explicit `PATH` normalization behavior.
- Avoided a broader binstub redesign; the change only closes the unset-`PATH` execution path.
- Did not add a changelog entry because this verified-audit lane is explicitly restricted to the five binstub/template/test paths above; release-note aggregation remains outside this PR's authorized scope.
- Independent exact-head batch QA replayed both unset-`PATH` commands and confirmed neither binstub output nor the fake app-root Node probe was created.

## QA Evidence

- Fresh Sol/xhigh QA passed the focused and full helper specs plus the clean three-PR combined-tip validation.
- No P1/P2 findings; the exact-head priority-finding disposition is not applicable.
- Durable evidence: https://github.com/shakacode/shakapacker/pull/1240#issuecomment-5183922368

## Confidence

High. The focused regression, synchronized generated surfaces, full current-head checks, configured reviews, resolved-thread state, and independent exact-head batch QA are all green.
