### PR TITLE
Make the Babel 8 smoke prove preset transformation

### DIFF
--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -4,6 +4,8 @@
 // Babel 7. Enable this smoke with RUN_BABEL8_SMOKE=1 after `yarn build`; it
 // installs Babel 8 packages into a temp app and runs Webpack through
 // babel-loader 10 with Shakapacker's built Babel preset.
+// Set BABEL8_SMOKE_BYPASS_PRESET=1 only for the manual negative-control replay
+// that proves the transform assertion fails when the preset is removed.
 //
 // Keep the pinned Babel 8 package versions below in sync during Babel
 // compatibility reviews. This smoke covers the published preset path; the
@@ -142,6 +144,7 @@ const compiler = webpack({
         test: /\\.js$/,
         include: srcDir,
         use: [
+          // Capture Babel's CommonJS output before webpack processes it.
           { loader: captureLoaderPath },
           {
             loader: appRequire.resolve("babel-loader"),
@@ -149,8 +152,7 @@ const compiler = webpack({
               cacheDirectory: false,
               cwd: workRoot,
               envName: "production",
-              // Make preset-env's modules: "auto" decision deterministic and
-              // capture Babel's CommonJS output before webpack processes it.
+              // Make preset-env's modules: "auto" decision deterministic.
               caller: { supportsStaticESM: false },
               presets
             }

--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -251,7 +251,10 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
     const distDir = path.join(workRoot, "dist")
     fs.mkdirSync(srcDir)
     const entryPath = path.join(srcDir, "index.js")
-    fs.writeFileSync(entryPath, "export const answer = 42\nconsole.log(answer)\n")
+    fs.writeFileSync(
+      entryPath,
+      "export const answer = 42\nconsole.log(answer)\n"
+    )
     const babelOutputPath = path.join(workRoot, "babel-output.js")
 
     const appRequire = createRequire(path.join(workRoot, "package.json"))

--- a/test/packages/babel8-smoke.test.js
+++ b/test/packages/babel8-smoke.test.js
@@ -30,6 +30,8 @@ const babel8SmokePackages = [
 ]
 const optedIn = process.env.RUN_BABEL8_SMOKE === "1"
 const coreIsBuilt = fs.existsSync(builtPresetPath)
+const bypassPreset = process.env.BABEL8_SMOKE_BYPASS_PRESET === "1"
+const smokePresets = (presetPath) => (bypassPreset ? [] : [presetPath])
 
 const toolVersion = (cmd) => {
   const r = spawnSync(cmd, ["--version"], {
@@ -89,7 +91,26 @@ const installBuiltShakapackerPackage = (workRoot) => {
   })
 }
 
-const writeWebpackSmokeRunner = ({ workRoot, srcDir, distDir, presetPath }) => {
+const writeWebpackSmokeRunner = ({
+  workRoot,
+  srcDir,
+  distDir,
+  babelOutputPath,
+  presets
+}) => {
+  const captureLoaderPath = path.join(workRoot, "capture-babel-output.cjs")
+  fs.writeFileSync(
+    captureLoaderPath,
+    `
+const fs = require("fs")
+
+module.exports = function captureBabelOutput(source) {
+  fs.writeFileSync(${JSON.stringify(babelOutputPath)}, source)
+  return source
+}
+`
+  )
+
   const runnerPath = path.join(workRoot, "run-webpack-smoke.cjs")
   fs.writeFileSync(
     runnerPath,
@@ -101,7 +122,8 @@ const webpack = require(${JSON.stringify(webpackPath)})
 const workRoot = ${JSON.stringify(workRoot)}
 const srcDir = ${JSON.stringify(srcDir)}
 const distDir = ${JSON.stringify(distDir)}
-const presetPath = ${JSON.stringify(presetPath)}
+const captureLoaderPath = ${JSON.stringify(captureLoaderPath)}
+const presets = ${JSON.stringify(presets)}
 const appRequire = createRequire(path.join(workRoot, "package.json"))
 
 const compiler = webpack({
@@ -120,13 +142,17 @@ const compiler = webpack({
         test: /\\.js$/,
         include: srcDir,
         use: [
+          { loader: captureLoaderPath },
           {
             loader: appRequire.resolve("babel-loader"),
             options: {
               cacheDirectory: false,
               cwd: workRoot,
               envName: "production",
-              presets: [presetPath]
+              // Make preset-env's modules: "auto" decision deterministic and
+              // capture Babel's CommonJS output before webpack processes it.
+              caller: { supportsStaticESM: false },
+              presets
             }
           }
         ]
@@ -188,7 +214,10 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
   beforeAll(() => {
     if (!shouldRun) return
 
-    workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shaka-babel8-smoke-"))
+    // Webpack canonicalizes resource paths before applying `include` rules.
+    workRoot = fs.mkdtempSync(
+      path.join(fs.realpathSync(os.tmpdir()), "shaka-babel8-smoke-")
+    )
     fs.writeFileSync(
       path.join(workRoot, "package.json"),
       JSON.stringify({ name: "shaka-babel8-smoke", private: true }, null, 2)
@@ -222,7 +251,8 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
     const distDir = path.join(workRoot, "dist")
     fs.mkdirSync(srcDir)
     const entryPath = path.join(srcDir, "index.js")
-    fs.writeFileSync(entryPath, "var answer = 42;\nconsole.log(answer);\n")
+    fs.writeFileSync(entryPath, "export const answer = 42\nconsole.log(answer)\n")
+    const babelOutputPath = path.join(workRoot, "babel-output.js")
 
     const appRequire = createRequire(path.join(workRoot, "package.json"))
     const presetPath = appRequire.resolve("shakapacker/package/babel/preset.js")
@@ -238,7 +268,8 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
       workRoot,
       srcDir,
       distDir,
-      presetPath
+      babelOutputPath,
+      presets: smokePresets(presetPath)
     })
 
     run(process.execPath, [runnerPath], {
@@ -246,7 +277,10 @@ describe("Babel 8 preset smoke (issue #1191)", () => {
       env: { ...process.env, BABEL_ENV: "production" }
     })
 
+    const babelOutput = fs.readFileSync(babelOutputPath, "utf8")
     const bundle = fs.readFileSync(path.join(distDir, "bundle.js"), "utf8")
+    expect(babelOutput).toContain("exports.answer")
+    expect(babelOutput).not.toContain("export const answer")
     expect(bundle).toContain("42")
   }, 180000)
 })


### PR DESCRIPTION
## Summary

- make the Babel 8 smoke inspect Babel's output before webpack processes it
- use a deterministic CommonJS transform signal independent of browser targets
- add an explicit preset-bypass path that demonstrates the assertion turns RED

## Why

The prior smoke only proved that webpack produced a runnable bundle; webpack could process the input even if Shakapacker's Babel preset was bypassed. The revised test captures Babel's output and requires the preset to convert an ES module export to CommonJS.

Closes #1235.

## Verification

- normal proof: `RUN_BABEL8_SMOKE=1 yarn jest test/packages/babel8-smoke.test.js --runInBand` — 1 suite / 1 test passed
- bypass proof: `BABEL8_SMOKE_BYPASS_PRESET=1 RUN_BABEL8_SMOKE=1 yarn jest test/packages/babel8-smoke.test.js --runInBand` — failed as required; expected `exports.answer`, received unchanged `export const answer = 42`
- `.agents/bin/validate` — passed
- focused ESLint — passed
- hosted-parity `yarn prettier --check test/packages/babel8-smoke.test.js` — passed after a formatting-only follow-up; the prior head reproduced the hosted Prettier failure locally
- review follow-up — source comments now identify the manual negative-control toggle and separate the Babel-output capture from the deterministic caller setting
- `git diff --check` — passed

## Decision log

- Captures the loader output immediately after Babel so webpack cannot satisfy the proof.
- Sets `supportsStaticESM: false` so preset-env's `modules: "auto"` decision is deterministic and not target-sensitive.
- Canonicalizes the temporary root because webpack canonicalizes resource paths on macOS; otherwise a `/var` versus `/private/var` mismatch can bypass the loader rule itself.
- Keeps the bypass as an independent mutation replay rather than a nested Jest invocation: the normal smoke remains a positive CI test, while exact-head batch QA separately proves preset removal turns it RED.
- Independent exact-head batch QA replayed both the normal GREEN and preset-bypass RED paths.

## QA Evidence

- Fresh Sol/xhigh QA passed Prettier and the normal smoke, observed the bypass fail with unchanged ESM/no CommonJS output, and passed the clean three-PR combined-tip validation.
- No P1/P2 findings; the exact-head priority-finding disposition is not applicable.
- Durable evidence: https://github.com/shakacode/shakapacker/pull/1241#issuecomment-5183922605

## Confidence

High. The focused transformation proof, full current-head checks, configured reviews, resolved-thread state, and independent exact-head batch QA are all green.
