### PR TITLE
Lint the extensionless merge-readiness helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,11 @@ AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true
+  inherit_mode:
+    merge:
+      - Include
+  Include:
+    - ".agents/bin/merge-readiness-check"
   Exclude:
     - "lib/install/templates/**"
     - "vendor/**/*"


### PR DESCRIPTION
## Why

Ruby CI is already triggered when `.agents/bin/merge-readiness-check` changes, but its bare `bundle exec rubocop` command did not discover this extensionless Ruby helper. That left both hosted Ruby lint and the local `.agents/bin/lint` / `.agents/bin/validate` gates unable to catch syntax or style regressions in the helper.

## What changed

- Merge one explicit helper path into RuboCop's default `AllCops/Include` list.
- Preserve the full existing default target set and every current exclusion.
- Keep the workflow command, helper implementation, dependencies, and fixtures unchanged.

## Verification

- Before: bare RuboCop discovered 147 files and omitted the helper.
- After: bare RuboCop discovers 148 files; the sole added target is `.agents/bin/merge-readiness-check`, with no removed targets.
- Negative replay: a temporary syntax defect in the helper made bare `bundle exec rubocop` exit 1 and report `Lint/Syntax` for that helper; the defect was immediately reversed and the helper has zero diff.
- `ruby -c .agents/bin/merge-readiness-check`
- `bundle exec rubocop .agents/bin/merge-readiness-check`
- `bundle exec rubocop`
- `.agents/bin/lint`
- `.agents/bin/validate`
- `git diff --check`

## Codex Decision Log

- **Non-blocking:** Configure RuboCop discovery instead of adding a workflow-only explicit target.
  - **Decision:** Merge the extensionless helper into `AllCops/Include`.
  - **Why:** The same bare RuboCop command is used by hosted Ruby CI and the repository's local lint/validate gates, so one narrow config change closes both blind spots without broad discovery expansion.
  - **Review later:** None.

## QA status

Independent QA passed on exact head `787042c385dd46b95975661aedc8658c1d20bf9e`. A fresh Sol/xhigh checker independently compared base/head discovery (147 → 148, with only the helper added), reproduced a helper-local `Lint/Syntax` failure through bare `bundle exec rubocop`, reversed the exact temporary hunk, and reconfirmed syntax, lint, clean worktree, and hosted Ruby lint success.

Confidence note: High — one configuration file changes, the target-set delta is exactly one intended helper, the negative control failed through the exact CI command, and full local validation passed.

Closes #1237

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 787042c385dd46b95975661aedc8658c1d20bf9e
tested_at: PR #1242 head 787042c385dd46b95975661aedc8658c1d20bf9e
scope: .rubocop.yml target-discovery change for .agents/bin/merge-readiness-check; trusted baseline 66bcf40bf67d7d6781fb6a039b60aba94f850796
automated_checks: base/head bundle exec rubocop --list-target-files => 147/148 targets, added only .agents/bin/merge-readiness-check, removed none; head bundle exec rubocop => pass; injected def 123 then bundle exec rubocop => exit 1 naming helper and Lint/Syntax; restored git diff --quiet, ruby -c, and bundle exec rubocop => pass
manual_checks: one-file diff and resolved AllCops Include/Exclude reviewed; live PR head/files and exact-head Ruby based checks / Linting success verified
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: lint configuration changes target discovery only; no user-visible UI surface
paint_check: not applicable: no rendered UI surface
interaction_change: no
interaction_evidence: not applicable: no interaction behavior changed
visual_fix: no
negative_control: not applicable: no visual fix; syntax-failure negative control covered lint detection
performance_impact: not_applicable
performance_evidence: not applicable: static lint target configuration does not affect rendered pages, delivered assets, bundles, or runtime performance
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->
<!-- priority-finding-dispositions v1
status: not_applicable
head_sha: 787042c385dd46b95975661aedc8658c1d20bf9e
-->
