### PR TITLE
Configure direct merge submission

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -12,4 +12,6 @@ merge_ledger: n/a
 ci_parity_environment: "n/a — reproduce CI-only failures from the matching job in .github/workflows/**"
 hosted_ci_trigger: "n/a — CI runs on every PR"
 ci_change_detector: n/a
+merge_submission:
+  mode: direct
 repo_prefix: SP


### PR DESCRIPTION
## Summary

Explicitly set `merge_submission.mode: direct` so Shakapacker keeps the portable direct path after shared workflow upgrades.

## Validation

- Parsed `.agents/agent-workflow.yml` with Bundler Ruby.
- Ran the merged-source seam doctor. It reports the existing `AGENTS.md`/binstub-pointer mismatch unchanged from base `main`; this PR does not modify either file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured submissions to use direct merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->